### PR TITLE
Unify sign-in buttons.

### DIFF
--- a/client/lib/app/community/home/community_home.dart
+++ b/client/lib/app/community/home/community_home.dart
@@ -199,7 +199,7 @@ class _CommunityHomeState extends State<CommunityHome> {
             ThickOutlineButton(
               text: 'Donate',
               eventName: 'donate_pressed',
-              whiteBackground: false,
+              backgroundColor: Colors.white,
               onPressed: () => guardSignedIn(
                 () => DonateWidget(
                   community: CommunityProvider.read(context).community,

--- a/client/lib/app/home/sign_in_section.dart
+++ b/client/lib/app/home/sign_in_section.dart
@@ -1,3 +1,4 @@
+import 'package:client/common_widgets/sign_in_options_content.dart';
 import 'package:flutter/material.dart';
 import 'package:client/common_widgets/proxied_image.dart';
 import 'package:client/common_widgets/custom_ink_well.dart';
@@ -39,67 +40,16 @@ class _HomePageSignInSectionState extends State<HomePageSignInSection> {
                 'Sign up to get started.',
                 style: AppTextStyle.body.copyWith(color: AppColor.gray2),
               ),
-              SizedBox(height: 30),
-              _buildSignInButton(
-                text: 'Sign up with email',
-                image: 'media/social-email.png',
-                onTap: () =>
-                    SignInDialog.show(isInitializedOnEmailPassword: true),
-                iconSize: 40,
-                padding: 2,
+              SizedBox(
+                width: 300,
+                child: SignInOptionsContent(
+                  isNewUser: true,
+                  showHeader: false,
+                ),
               ),
-              SizedBox(height: 10),
-              _buildSignInButton(
-                text: 'Sign up with Google',
-                image: 'media/googleLogo.png',
-                onTap: () => userService.signInWithGoogle(),
-                leftPadding: 16,
-                padding: 12,
-              ),
-              SizedBox(height: 100),
             ],
           ),
         ],
-      ),
-    );
-  }
-
-  Widget _buildSignInButton({
-    String? image,
-    required String text,
-    required onTap,
-    double iconSize = 20,
-    double padding = 8.0,
-    double leftPadding = 0.0,
-  }) {
-    return CustomInkWell(
-      borderRadius: BorderRadius.circular(10),
-      onTap: onTap,
-      child: Container(
-        height: 48,
-        width: 311,
-        alignment: Alignment.center,
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(10),
-          color: AppColor.white,
-        ),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            SizedBox(width: leftPadding),
-            if (image != null)
-              ProxiedImage(
-                null,
-                asset: AppAsset(image),
-                width: iconSize,
-              ),
-            SizedBox(width: padding),
-            HeightConstrainedText(
-              text,
-              style: AppTextStyle.body.copyWith(color: AppColor.darkBlue),
-            ),
-          ],
-        ),
       ),
     );
   }

--- a/client/lib/common_widgets/community_membership_button.dart
+++ b/client/lib/common_widgets/community_membership_button.dart
@@ -82,7 +82,7 @@ class _CommunityMembershipButtonState extends State<CommunityMembershipButton> {
             ),
           ),
           text: _hovered ? 'Unfollow' : 'Followed',
-          whiteBackground: false,
+          backgroundColor: Colors.white,
           minWidth: widget.minWidth,
         ),
       );

--- a/client/lib/common_widgets/sign_in_options_content.dart
+++ b/client/lib/common_widgets/sign_in_options_content.dart
@@ -157,6 +157,7 @@ class _SignInOptionsContentState extends State<SignInOptionsContent> {
               height: 22,
             ),
           ),
+          backgroundColor: Colors.white,
           text: 'Sign ${widget.isNewUser ? 'up' : 'in'} with Google',
         ),
       ThickOutlineButton(
@@ -170,6 +171,7 @@ class _SignInOptionsContentState extends State<SignInOptionsContent> {
             size: 22,
           ),
         ),
+        backgroundColor: Colors.white,
         onPressed: () => setState(() => _emailSelected = true),
         text: 'Sign ${widget.isNewUser ? 'up' : 'in'} with Email',
       ),

--- a/client/lib/common_widgets/sign_in_options_content.dart
+++ b/client/lib/common_widgets/sign_in_options_content.dart
@@ -13,6 +13,15 @@ import 'package:client/utils/platform_utils.dart';
 import 'package:provider/provider.dart';
 
 class SignInOptionsContent extends StatefulWidget {
+  const SignInOptionsContent({
+    this.isNewUser = true,
+    this.isInitializedOnEmailPassword = false,
+    this.isPurchasingSubscription = false,
+    this.onComplete,
+    this.showHeader = true,
+    Key? key,
+  }) : super(key: key);
+
   static const emailSignInKey = Key('email-sign-in');
   static const newUserToggleKey = Key('new-user-toggle');
   static const nameTextFieldKey = Key('input-name');
@@ -24,14 +33,7 @@ class SignInOptionsContent extends StatefulWidget {
   final bool isInitializedOnEmailPassword;
   final bool isPurchasingSubscription;
   final void Function()? onComplete;
-
-  const SignInOptionsContent({
-    this.isNewUser = true,
-    this.isInitializedOnEmailPassword = false,
-    this.isPurchasingSubscription = false,
-    this.onComplete,
-    Key? key,
-  }) : super(key: key);
+  final bool showHeader;
 
   @override
   State<SignInOptionsContent> createState() => _SignInOptionsContentState();

--- a/client/lib/common_widgets/sign_in_options_content.dart
+++ b/client/lib/common_widgets/sign_in_options_content.dart
@@ -94,12 +94,13 @@ class _SignInOptionsContentState extends State<SignInOptionsContent> {
             ),
           ),
         Column(
+          mainAxisSize: MainAxisSize.min,
           children: [
             if (_emailSelected)
               ..._buildEmailWidgets()
             else
               ..._buildSignInProviderButtons(),
-            SizedBox(height: 8),
+            SizedBox(height: 12),
             _buildTermsOfService(),
           ],
         ),
@@ -130,22 +131,24 @@ class _SignInOptionsContentState extends State<SignInOptionsContent> {
   List<Widget> _buildSignInProviderButtons() {
     const minWidth = 260.0;
     return [
-      Align(
-        alignment: Alignment.centerLeft,
-        child: HeightConstrainedText(
-          _getTitleText(),
-          style: AppTextStyle.headline3,
-        ),
-      ),
-      SizedBox(height: 9),
-      if (_getMessageText().isNotEmpty)
+      if (widget.showHeader) ...[
         Align(
           alignment: Alignment.centerLeft,
           child: HeightConstrainedText(
-            _getMessageText(),
-            style: AppTextStyle.body.copyWith(color: AppColor.darkBlue),
+            _getTitleText(),
+            style: AppTextStyle.headline3,
           ),
         ),
+        SizedBox(height: 9),
+        if (_getMessageText().isNotEmpty)
+          Align(
+            alignment: Alignment.centerLeft,
+            child: HeightConstrainedText(
+              _getMessageText(),
+              style: AppTextStyle.body.copyWith(color: AppColor.darkBlue),
+            ),
+          ),
+      ],
       SizedBox(height: 9),
       if (!isWKWebView)
         ThickOutlineButton(

--- a/client/lib/common_widgets/thick_outline_button.dart
+++ b/client/lib/common_widgets/thick_outline_button.dart
@@ -6,10 +6,10 @@ class ThickOutlineButton extends StatelessWidget {
   final Function()? onPressed;
   final String? text;
   final Color? textColor;
+  final Color? backgroundColor;
   final Widget? icon;
   final double? minWidth;
   final double thickness;
-  final bool whiteBackground;
   final bool expand;
   final String? eventName;
 
@@ -18,33 +18,34 @@ class ThickOutlineButton extends StatelessWidget {
     this.onPressed,
     this.text,
     this.textColor,
+    this.backgroundColor,
     this.icon,
     this.expand = false,
     this.minWidth = 0,
     this.thickness = 1,
-    this.whiteBackground = true,
     this.eventName,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final color = textColor ??
+    final lineColor = textColor ??
         DefaultTextStyle.of(context).style.color ??
-        (whiteBackground ? Theme.of(context).primaryColor : AppColor.white);
+        Theme.of(context).primaryColor;
     return ActionButton(
       onPressed: onPressed,
       sendingIndicatorAlign: ActionButtonSendingIndicatorAlign.none,
       type: ActionButtonType.outline,
       borderSide: BorderSide(
-        color: color,
+        color: lineColor,
         width: thickness,
       ),
       minWidth: minWidth,
-      textColor: color,
+      textColor: lineColor,
       expand: expand,
       eventName: eventName,
       icon: icon,
       text: text,
+      color: backgroundColor,
     );
   }
 }


### PR DESCRIPTION
## What is in this PR?
<!-- What is the goal of this PR? What steps are involved in achieving that goal? -->
We currently have two instances of sign-in/sign-up buttons -- one that's used in dialogs, and one on the home page. They build essentially the same content, but we have 2 implementations, which is not helpful for making auth changes. This PR supports the subsequent bug fix for hidden Google auth on `WKWebviews`. 

## Changes in the codebase
<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

* Remove redundant sign-up section from home page and call existing sign-in content widget instead.
* Changes to support adapting the sign-in content to be shown on home page. 

## Changes outside the codebase
<!-- If you have made changes to external services, need to add additional values to the job settings, or need to add something new to the database, explain it here. This may include updates to third-party services, changes to infrastructure configuration, integration with external APIs, etc. -->

* None

## Testing this PR
<!-- Give your reviewer some context or recommendations on how to test your work. -->

Use staging link to observe minimal changes in the home page sign-up prompt. 

## Additional information
<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->

