### PR TITLE
Add community function tests

### DIFF
--- a/.github/workflows/deploy_firebase_staging.yaml
+++ b/.github/workflows/deploy_firebase_staging.yaml
@@ -38,7 +38,8 @@ jobs:
               - 'firebase/firestore/**'
             shared:
               - 'data_models/lib/**'
-              - 'firebase/functions/lib/utils/firestore_utils.dart'
+              - 'firebase/functions/lib/utils/infra/firestore_utils.dart'
+              - 'firebase/functions/lib/utils/infra/firebase_auth_utils.dart'
               - 'firebase/functions/lib/utils/utils.dart'
 
       - name: Setup Node

--- a/firebase/functions/lib/admin/payments/create_donation_checkout_session.dart
+++ b/firebase/functions/lib/admin/payments/create_donation_checkout_session.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 import '../../on_call_function.dart';
+import '../../utils/infra/firebase_auth_utils.dart';
 import '../../utils/infra/firestore_utils.dart';
 import 'stripe_util.dart';
 import '../../utils/subscription_plan_util.dart';
@@ -92,7 +93,7 @@ class CreateDonationCheckoutSession
         takeRate < 1;
 
     final user =
-        (await firestoreUtils.getUsers([context.authUid!].toList())).first;
+        (await firebaseAuthUtils.getUsers([context.authUid!].toList())).first;
 
     final Map<String, String> params = {
       'success_url': 'https://$domain/space/$communityId?donation=success',

--- a/firebase/functions/lib/admin/payments/stripe_util.dart
+++ b/firebase/functions/lib/admin/payments/stripe_util.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:firebase_admin_interop/firebase_admin_interop.dart';
 import 'package:firebase_functions_interop/firebase_functions_interop.dart';
+import '../../utils/infra/firebase_auth_utils.dart';
 import 'stripe_client.dart';
 import '../../utils/infra/firestore_utils.dart';
 import 'package:node_http/node_http.dart' as http;
@@ -16,7 +17,7 @@ class StripeUtil {
   StripeClient getClient() => _client ??= createStripeClient(_secretKey);
 
   Future<String> getOrCreateCustomerStripeId({required String uid}) async {
-    final users = await firestoreUtils.getUsers([uid]);
+    final users = await firebaseAuthUtils.getUsers([uid]);
     if (users.length != 1) {
       throw Exception('User not found');
     }

--- a/firebase/functions/lib/community/get_members_data.dart
+++ b/firebase/functions/lib/community/get_members_data.dart
@@ -1,13 +1,13 @@
 import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 import 'package:firebase_admin_interop/firebase_admin_interop.dart' as admin;
 import '../on_call_function.dart';
+import '../utils/infra/firebase_auth_utils.dart';
 import '../utils/infra/firestore_utils.dart';
 import '../utils/utils.dart';
 import 'package:data_models/cloud_functions/requests.dart';
 import 'package:data_models/events/event.dart';
 import 'package:data_models/community/member_details.dart';
 import 'package:data_models/community/membership.dart';
-import 'package:data_models/user/public_user_info.dart';
 import 'package:quiver/iterables.dart';
 
 class GetMembersData extends OnCallMethod<GetMembersDataRequest> {
@@ -92,7 +92,7 @@ class GetMembersData extends OnCallMethod<GetMembersDataRequest> {
     admin.UserRecord? memberInfo;
     try {
       // Get memberId user info
-      memberInfo = await firestoreUtils.getUser(memberId);
+      memberInfo = await firebaseAuthUtils.getUser(memberId);
     } catch (e) {
       print('Error getting user info for $memberId: $e');
     }

--- a/firebase/functions/lib/community/get_user_admin_details.dart
+++ b/firebase/functions/lib/community/get_user_admin_details.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 import '../on_call_function.dart';
+import '../utils/infra/firebase_auth_utils.dart';
 import '../utils/infra/firestore_utils.dart';
 import 'package:data_models/cloud_functions/requests.dart';
 import 'package:data_models/events/event.dart';
@@ -117,7 +118,7 @@ class GetUserAdminDetails extends OnCallMethod<GetUserAdminDetailsRequest> {
       throw HttpsError(HttpsError.failedPrecondition, 'unauthorized', null);
     }
 
-    final userRecords = await firestoreUtils.getUsers(request.userIds);
+    final userRecords = await firebaseAuthUtils.getUsers(request.userIds);
 
     return GetUserAdminDetailsResponse(
       userAdminDetails: userRecords

--- a/firebase/functions/lib/community/resolve_join_request.dart
+++ b/firebase/functions/lib/community/resolve_join_request.dart
@@ -4,6 +4,7 @@ import 'package:firebase_admin_interop/firebase_admin_interop.dart';
 import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 import '../on_call_function.dart';
 import '../utils/email_templates.dart';
+import '../utils/infra/firebase_auth_utils.dart';
 import '../utils/infra/firestore_utils.dart';
 import '../utils/send_email_client.dart';
 import 'package:data_models/cloud_functions/requests.dart';
@@ -158,7 +159,7 @@ class ResolveJoinRequest extends OnCallMethod<ResolveJoinRequestRequest> {
     required String userId,
     required String communityId,
   }) async {
-    final users = await firestoreUtils.getUsers([userId]);
+    final users = await firebaseAuthUtils.getUsers([userId]);
     final community = await firestoreUtils.getFirestoreObject(
       path: 'community/$communityId',
       constructor: (map) => Community.fromJson(map),

--- a/firebase/functions/lib/community/trigger_email_digests.dart
+++ b/firebase/functions/lib/community/trigger_email_digests.dart
@@ -36,7 +36,7 @@ class TriggerEmailDigests extends CloudFunction {
   TriggerEmailDigests({NotificationsUtils? notificationsUtils})
       : notificationsUtils = notificationsUtils ?? NotificationsUtils();
 
-  FutureOr<void> _action(EventContext context) async {
+  FutureOr<void> action(EventContext context) async {
     // events are included that fall between 'now' and 'endTime'
     // digest is discarded if one was already sent after 'prevCutoffTime'
     final now = DateTime.now();
@@ -280,6 +280,6 @@ class TriggerEmailDigests extends CloudFunction {
         )
         .pubsub
         .schedule('every tuesday 17:00') // Tuesday 8pm EST, converted to PST
-        .onRun((_, context) => _action(context));
+        .onRun((_, context) => action(context));
   }
 }

--- a/firebase/functions/lib/community/trigger_email_digests.dart
+++ b/firebase/functions/lib/community/trigger_email_digests.dart
@@ -7,6 +7,7 @@ import 'package:firebase_functions_interop/firebase_functions_interop.dart'
     hide CloudFunction;
 import '../cloud_function.dart';
 import '../utils/email_templates.dart';
+import '../utils/infra/firebase_auth_utils.dart';
 import '../utils/infra/firestore_utils.dart';
 import '../utils/notifications_utils.dart';
 import '../utils/send_email_client.dart';
@@ -143,7 +144,7 @@ class TriggerEmailDigests extends CloudFunction {
             try {
               final List<admin.UserRecord> user =
                   await (userLookups[membership.userId] ??=
-                      firestoreUtils.getUsers([membership.userId]));
+                      firebaseAuthUtils.getUsers([membership.userId]));
               if (user.isEmpty || isNullOrEmpty(user[0].email)) {
                 print('Email not found for user: ${membership.userId}');
                 return;

--- a/firebase/functions/lib/events/calendar/get_calendar_link.dart
+++ b/firebase/functions/lib/events/calendar/get_calendar_link.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 import '../../on_call_function.dart';
 import '../../utils/calendar_link_util.dart';
+import '../../utils/infra/firebase_auth_utils.dart';
 import '../../utils/infra/firestore_utils.dart';
 import '../../utils/utils.dart';
 import 'package:data_models/cloud_functions/requests.dart';
@@ -33,7 +34,7 @@ class GetCommunityCalendarLink
       path: request.eventPath,
       constructor: (map) => Event.fromJson(map),
     );
-    final users = await firestoreUtils.getUsers([event.creatorId]);
+    final users = await firebaseAuthUtils.getUsers([event.creatorId]);
     if (users.length != 1) {
       throw Exception('Organizer not found');
     }

--- a/firebase/functions/lib/events/live_meetings/get_meeting_chat_suggestion_data.dart
+++ b/firebase/functions/lib/events/live_meetings/get_meeting_chat_suggestion_data.dart
@@ -4,6 +4,7 @@ import 'package:firebase_functions_interop/firebase_functions_interop.dart'
     as functions_interop;
 import 'package:firebase_admin_interop/firebase_admin_interop.dart';
 import '../../on_call_function.dart';
+import '../../utils/infra/firebase_auth_utils.dart';
 import '../../utils/infra/firestore_utils.dart';
 import '../../utils/utils.dart';
 import 'package:data_models/cloud_functions/requests.dart';
@@ -115,7 +116,7 @@ class GetMeetingChatSuggestionData
       var doc = ChatMessage.fromJson(
         firestoreUtils.fromFirestoreJson(document.data.toMap()),
       );
-      final memberInfo = await firestoreUtils.getUser(doc.creatorId!);
+      final memberInfo = await firebaseAuthUtils.getUser(doc.creatorId!);
 
       String memberName;
       if (isNullOrEmpty(memberInfo.displayName)) {
@@ -160,7 +161,7 @@ class GetMeetingChatSuggestionData
       var doc = SuggestedAgendaItem.fromJson(
         firestoreUtils.fromFirestoreJson(document.data.toMap()),
       );
-      final memberInfo = await firestoreUtils.getUser(doc.creatorId!);
+      final memberInfo = await firebaseAuthUtils.getUser(doc.creatorId!);
 
       String memberName;
       if (isNullOrEmpty(memberInfo.displayName)) {
@@ -245,7 +246,7 @@ class GetMeetingChatSuggestionData
     DocumentSnapshot document,
     ParticipantAgendaItemDetails details,
   ) async {
-    final memberInfo = await firestoreUtils.getUser(details.userId!);
+    final memberInfo = await firebaseAuthUtils.getUser(details.userId!);
 
     String memberName;
     if (isNullOrEmpty(memberInfo.displayName)) {

--- a/firebase/functions/lib/events/live_meetings/get_meeting_join_info.dart
+++ b/firebase/functions/lib/events/live_meetings/get_meeting_join_info.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:collection/collection.dart';
 import 'package:firebase_functions_interop/firebase_functions_interop.dart';
+import '../../utils/infra/firebase_auth_utils.dart';
 import 'live_meeting_utils.dart';
 import '../../on_call_function.dart';
 import '../../utils/infra/firestore_utils.dart';
@@ -49,7 +50,7 @@ class GetMeetingJoinInfo extends OnCallMethod<GetMeetingJoinInfoRequest> {
       print('Public user display name: $displayName');
 
       if (displayName == null || displayName.trim().isEmpty) {
-        final userLookup = await firestoreUtils.getUsers([context.authUid!]);
+        final userLookup = await firebaseAuthUtils.getUsers([context.authUid!]);
         displayName =
             firstAndLastInitial(userLookup.firstOrNull?.displayName) ??
                 'User-${context.authUid!.substring(0, 4)}';

--- a/firebase/functions/lib/events/notifications/event_emails.dart
+++ b/firebase/functions/lib/events/notifications/event_emails.dart
@@ -2,6 +2,7 @@ import 'package:firebase_admin_interop/firebase_admin_interop.dart'
     as admin_interop;
 import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 import 'package:intl/intl.dart';
+import '../../utils/infra/firebase_auth_utils.dart';
 import 'email_event_reminder.dart';
 import '../../utils/calendar_link_util.dart';
 import '../../utils/email_templates.dart';
@@ -165,7 +166,7 @@ class EventEmails {
       idsToEmail.remove(log.userId);
     }
 
-    var lookedUpUsers = await firestoreUtils.getUsers(idsToEmail.toList());
+    var lookedUpUsers = await firebaseAuthUtils.getUsers(idsToEmail.toList());
     print('Looked up users: ${lookedUpUsers.map((e) => e.uid).toList()}');
     if (lookedUpUsers.isEmpty) {
       print('No looked up users found.');
@@ -174,7 +175,7 @@ class EventEmails {
 
     admin_interop.UserRecord? organizer;
     final organizerLookup =
-        await firestoreUtils.getUsers([eventLocal.creatorId]);
+        await firebaseAuthUtils.getUsers([eventLocal.creatorId]);
     if (organizerLookup.isNotEmpty) {
       organizer = organizerLookup[0];
     }

--- a/firebase/functions/lib/utils/email_templates.dart
+++ b/firebase/functions/lib/utils/email_templates.dart
@@ -357,6 +357,7 @@ String makeNewAnnouncementBody({
   Announcement? announcement,
 }) {
   const htmlEscape = HtmlEscape();
+  print('Got mock instance: ${community.hashCode}');
   final communityName = htmlEscape.convert(community.name ?? community.id);
   final title = htmlEscape.convert(announcement?.title ?? '');
   final message = htmlEscape.convert(announcement?.message ?? '');

--- a/firebase/functions/lib/utils/infra/firebase_auth_utils.dart
+++ b/firebase/functions/lib/utils/infra/firebase_auth_utils.dart
@@ -1,0 +1,21 @@
+import './firestore_utils.dart';
+import 'package:firebase_admin_interop/firebase_admin_interop.dart';
+
+/// Use a global singleton to allow mocking in tests
+FirebaseAuthUtils firebaseAuthUtils = FirebaseAuthUtils();
+
+class FirebaseAuthUtils {
+  Future<UserRecord> getUser(String uid) async {
+    // Get user record
+    var user = await firebaseApp.auth().getUser(uid);
+
+    return user;
+  }
+
+  Future<List<UserRecord>> getUsers(List<String> uids) async {
+    // Get emails of every user we want to email
+    final getUserFutures = uids.map((id) => firebaseApp.auth().getUser(id));
+
+    return Future.wait(getUserFutures);
+  }
+}

--- a/firebase/functions/lib/utils/infra/firestore_utils.dart
+++ b/firebase/functions/lib/utils/infra/firestore_utils.dart
@@ -18,20 +18,6 @@ Firestore get firestore => firebaseApp.firestore();
 FirestoreUtils firestoreUtils = FirestoreUtils();
 
 class FirestoreUtils {
-  Future<UserRecord> getUser(String uid) async {
-    // Get user record
-    var user = await firebaseApp.auth().getUser(uid);
-
-    return user;
-  }
-
-  Future<List<UserRecord>> getUsers(List<String> uids) async {
-    // Get emails of every user we want to email
-    final getUserFutures = uids.map((id) => firebaseApp.auth().getUser(id));
-
-    return Future.wait(getUserFutures);
-  }
-
   Future<T> getFirestoreObject<T>({
     required String path,
     required T Function(Map<String, dynamic>) constructor,

--- a/firebase/functions/lib/utils/notifications_utils.dart
+++ b/firebase/functions/lib/utils/notifications_utils.dart
@@ -5,6 +5,7 @@ import 'package:firebase_admin_interop/firebase_admin_interop.dart'
     as admin_interop;
 import 'package:firebase_admin_interop/firebase_admin_interop.dart';
 import 'package:firebase_functions_interop/firebase_functions_interop.dart';
+import 'infra/firebase_auth_utils.dart';
 import 'infra/firestore_utils.dart';
 import 'send_email_client.dart';
 import 'utils.dart';
@@ -92,7 +93,7 @@ class NotificationsUtils {
 
     print('user IDs filtered');
     // Get email addresses from auth and queue emails
-    final users = await firestoreUtils.getUsers(usersIdsFiltered);
+    final users = await firebaseAuthUtils.getUsers(usersIdsFiltered);
 
     print('Got users');
     final usersWithoutEmail =
@@ -161,7 +162,7 @@ class NotificationsUtils {
 
     // Get email addresses from these participants. Some of them might not have an email
     // therefore ignore them.
-    final users = await firestoreUtils.getUsers(eventParticipantIds);
+    final users = await firebaseAuthUtils.getUsers(eventParticipantIds);
     final usersWithoutEmail =
         users.where((u) => isNullOrEmpty(u.email)).toList();
     if (usersWithoutEmail.isNotEmpty) {
@@ -225,7 +226,7 @@ class NotificationsUtils {
     }
 
     if (userIds.isEmpty) return;
-    final lookedUpUsers = await firestoreUtils.getUsers(userIds.toList());
+    final lookedUpUsers = await firebaseAuthUtils.getUsers(userIds.toList());
     print('Looked up users: ${lookedUpUsers.map((e) => e.uid).toList()}');
     if (lookedUpUsers.isEmpty) {
       print('No looked up users found.');

--- a/firebase/functions/lib/utils/send_email_client.dart
+++ b/firebase/functions/lib/utils/send_email_client.dart
@@ -3,7 +3,7 @@ import 'infra/firestore_utils.dart';
 import 'package:data_models/cloud_functions/requests.dart';
 import 'package:quiver/iterables.dart';
 
-final sendEmailClient = SendEmailClient();
+SendEmailClient sendEmailClient = SendEmailClient();
 
 class SendEmailClient {
   Future<void> sendEmail(

--- a/firebase/functions/lib/utils/subscription_plan_util.dart
+++ b/firebase/functions/lib/utils/subscription_plan_util.dart
@@ -151,6 +151,7 @@ class SubscriptionPlanUtil {
         ),
       );
     } else {
+      print('Using default capabilities');
       return getDefaultCapabilities();
     }
   }

--- a/firebase/functions/package.json
+++ b/firebase/functions/package.json
@@ -2,7 +2,7 @@
   "name": "functions",
   "description": "Cloud Functions for Firebase",
   "scripts": {
-    "test": "dart test",
+    "test": "dart test --concurrency=1",
     "postinstall": "patch-package"
   },
   "engines": {

--- a/firebase/functions/test/community/create_announcement_test.dart
+++ b/firebase/functions/test/community/create_announcement_test.dart
@@ -12,23 +12,14 @@ import '../util/email_test_utils.dart';
 import '../util/function_test_fixture.dart';
 
 void main() {
-  const adminUserId = 'adminUser';
   const nonAdminUserId = 'nonAdminUser';
-  String communityId = 'testCommunityId';
+  late String communityId;
   final communityTestUtils = CommunityTestUtils();
   setupTestFixture();
 
   setUp(() async {
     // Create test community
-    final communityResult = await communityTestUtils.createCommunity(
-      community: Community(
-        id: '199212322222911',
-        name: 'Testing Community',
-        isPublic: true,
-      ),
-      userId: adminUserId,
-    );
-    communityId = communityResult['communityId'];
+    communityId = await communityTestUtils.createTestCommunity();
     await communityTestUtils.addCommunityMember(
       communityId: communityId,
       userId: nonAdminUserId,

--- a/firebase/functions/test/community/create_announcement_test.dart
+++ b/firebase/functions/test/community/create_announcement_test.dart
@@ -1,0 +1,124 @@
+import 'package:data_models/announcements/announcement.dart';
+import 'package:data_models/cloud_functions/requests.dart';
+import 'package:data_models/community/community.dart';
+import 'package:data_models/community/membership.dart';
+import 'package:firebase_admin_interop/firebase_admin_interop.dart';
+import 'package:firebase_functions_interop/firebase_functions_interop.dart';
+import 'package:functions/community/create_announcement.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+import 'package:functions/utils/infra/firestore_utils.dart';
+import '../util/community_test_utils.dart';
+import '../util/email_test_utils.dart';
+
+void main() {
+  const adminUserId = 'adminUser';
+  const nonAdminUserId = 'nonAdminUser';
+  String communityId = 'testCommunityId';
+  final communityTestUtils = CommunityTestUtils();
+
+  setUp(() async {
+    setFirebaseAppFactory(() => FirebaseAdmin.instance.initializeApp()!);
+    // Create test community
+    final communityResult = await communityTestUtils.createCommunity(
+      community: Community(
+        id: '199212322222911',
+        name: 'Testing Community',
+        isPublic: true,
+      ),
+      userId: adminUserId,
+    );
+    communityId = communityResult['communityId'];
+    await communityTestUtils.addCommunityMember(
+      communityId: communityId,
+      userId: nonAdminUserId,
+      status: MembershipStatus.member,
+    );
+  });
+
+  tearDown(() async {
+    resetMocktailState();
+  });
+
+  test('Should allow admin to create an announcement', () async {
+    final notificationsUtils = MockNotificationsUtils();
+    registerFallbackValue(
+      ({
+        required community,
+        required user,
+        required unsubscribeUrl,
+      }) =>
+          SendGridEmailMessage(
+        subject: 'Dummy Subject',
+        html: 'Dummy HTML',
+      ),
+    );
+    when(
+      () => notificationsUtils.sendCommunityNotifications(
+        filterUsersBy: any(named: 'filterUsersBy'),
+        communityId: communityId,
+        generateMessage: any(named: 'generateMessage'),
+      ),
+    ).thenAnswer((_) async {
+      return;
+    });
+
+    final createAnnouncement =
+        CreateAnnouncement(notificationsUtils: notificationsUtils);
+    final announcement = Announcement(
+      title: 'Test Announcement',
+      message: 'This is a test announcement.',
+    );
+    final req = CreateAnnouncementRequest(
+      communityId: communityId,
+      announcement: announcement,
+    );
+
+    await createAnnouncement.action(
+      req,
+      CallableContext(adminUserId, null, 'fakeInstanceId'),
+    );
+
+    final announcementRef = await firestore
+        .collection('/community/$communityId/announcements')
+        .where('title', isEqualTo: 'Test Announcement')
+        .get();
+    final createdAnnouncement = Announcement.fromJson(
+      firestoreUtils
+          .fromFirestoreJson(announcementRef.documents[0].data.toMap()),
+    );
+    final expectedAnnouncement =
+        announcement.copyWith(createdDate: createdAnnouncement.createdDate);
+    expect(createdAnnouncement, equals(expectedAnnouncement));
+
+    verify(
+      () => notificationsUtils.sendCommunityNotifications(
+        filterUsersBy: any(named: 'filterUsersBy'),
+        communityId: communityId,
+        generateMessage: any(named: 'generateMessage'),
+      ),
+    );
+  });
+
+  test('Should prevent non-admin user from creating an announcement', () async {
+    final createAnnouncement = CreateAnnouncement();
+    final announcement = Announcement(
+      title: 'Unauthorized Announcement',
+      message: 'This should not be allowed.',
+    );
+    final req = CreateAnnouncementRequest(
+      communityId: communityId,
+      announcement: announcement,
+    );
+
+    expect(
+      () async => await createAnnouncement.action(
+        req,
+        CallableContext(nonAdminUserId, null, 'fakeInstanceId'),
+      ),
+      throwsA(isA<HttpsError>()),
+    );
+  });
+}
+
+class MockCommunity extends Mock implements Community {}

--- a/firebase/functions/test/community/create_announcement_test.dart
+++ b/firebase/functions/test/community/create_announcement_test.dart
@@ -2,7 +2,6 @@ import 'package:data_models/announcements/announcement.dart';
 import 'package:data_models/cloud_functions/requests.dart';
 import 'package:data_models/community/community.dart';
 import 'package:data_models/community/membership.dart';
-import 'package:firebase_admin_interop/firebase_admin_interop.dart';
 import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 import 'package:functions/community/create_announcement.dart';
 import 'package:mocktail/mocktail.dart';
@@ -10,15 +9,16 @@ import 'package:test/test.dart';
 import 'package:functions/utils/infra/firestore_utils.dart';
 import '../util/community_test_utils.dart';
 import '../util/email_test_utils.dart';
+import '../util/function_test_fixture.dart';
 
 void main() {
   const adminUserId = 'adminUser';
   const nonAdminUserId = 'nonAdminUser';
   String communityId = 'testCommunityId';
   final communityTestUtils = CommunityTestUtils();
+  setupTestFixture();
 
   setUp(() async {
-    setFirebaseAppFactory(() => FirebaseAdmin.instance.initializeApp()!);
     // Create test community
     final communityResult = await communityTestUtils.createCommunity(
       community: Community(
@@ -34,10 +34,6 @@ void main() {
       userId: nonAdminUserId,
       status: MembershipStatus.member,
     );
-  });
-
-  tearDown(() async {
-    resetMocktailState();
   });
 
   test('Should allow admin to create an announcement', () async {

--- a/firebase/functions/test/community/create_community_test.dart
+++ b/firebase/functions/test/community/create_community_test.dart
@@ -6,12 +6,11 @@ import 'package:test/test.dart';
 import 'package:functions/community/create_community.dart';
 import 'package:data_models/cloud_functions/requests.dart';
 import 'package:functions/utils/infra/firestore_utils.dart';
-import 'package:firebase_admin_interop/firebase_admin_interop.dart';
+
+import '../util/function_test_fixture.dart';
 
 void main() {
-  setUp(() async {
-    setFirebaseAppFactory(() => FirebaseAdmin.instance.initializeApp()!);
-  });
+  setupTestFixture();
 
   test('Community should be created without partner agreement', () async {
     const userId = 'fakeAuthId';

--- a/firebase/functions/test/community/get_community_capabilities_test.dart
+++ b/firebase/functions/test/community/get_community_capabilities_test.dart
@@ -1,5 +1,4 @@
 import 'package:data_models/admin/plan_capability_list.dart';
-import 'package:data_models/community/community.dart';
 import 'package:data_models/community/membership.dart';
 import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 import 'package:test/test.dart';
@@ -12,22 +11,13 @@ import '../util/function_test_fixture.dart';
 import '../util/subscription_test_utils.dart';
 
 void main() {
-  const userId = 'fakeAuthId';
   const memberId = 'memberFooId';
-  String communityId = '';
+  late String communityId;
   final communityTestUtils = CommunityTestUtils();
   setupTestFixture();
 
   setUp(() async {
-    final communityResult = await communityTestUtils.createCommunity(
-      community: Community(
-        id: '1999',
-        name: 'Testing Community',
-        isPublic: true,
-      ),
-      userId: userId,
-    );
-    communityId = communityResult['communityId'];
+    communityId = await communityTestUtils.createTestCommunity();
     await communityTestUtils.addCommunityMember(
       communityId: communityId,
       userId: memberId,
@@ -44,7 +34,7 @@ void main() {
 
     final result = await capabilitiesGetter.action(
       req,
-      CallableContext(userId, null, 'fakeInstanceId'),
+      CallableContext(adminUserId, null, 'fakeInstanceId'),
     );
 
     final capabilitiesResult = PlanCapabilityList.fromJson(

--- a/firebase/functions/test/community/get_community_capabilities_test.dart
+++ b/firebase/functions/test/community/get_community_capabilities_test.dart
@@ -5,10 +5,10 @@ import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 import 'package:test/test.dart';
 import 'package:data_models/cloud_functions/requests.dart';
 import 'package:functions/community/get_community_capabilities.dart';
-import 'package:firebase_admin_interop/firebase_admin_interop.dart';
 import 'package:functions/utils/infra/firestore_utils.dart';
 
 import '../util/community_test_utils.dart';
+import '../util/function_test_fixture.dart';
 import '../util/subscription_test_utils.dart';
 
 void main() {
@@ -16,13 +16,9 @@ void main() {
   const memberId = 'memberFooId';
   String communityId = '';
   final communityTestUtils = CommunityTestUtils();
-  final subscriptionTestUtils = SubscriptionTestUtils();
+  setupTestFixture();
 
   setUp(() async {
-    setFirebaseAppFactory(() => FirebaseAdmin.instance.initializeApp()!);
-    await subscriptionTestUtils.addUnrestrictedPlanCapabilities(
-      planCapabilities: SubscriptionTestUtils.unrestrictedPlan,
-    );
     final communityResult = await communityTestUtils.createCommunity(
       community: Community(
         id: '1999',
@@ -37,10 +33,6 @@ void main() {
       userId: memberId,
       status: MembershipStatus.member,
     );
-  });
-
-  tearDown(() async {
-    await subscriptionTestUtils.removeUnrestrictedPlanCapabilities();
   });
 
   test('Should return unrestricted capabilities since Stripe is disabled',

--- a/firebase/functions/test/community/get_community_capabilities_test.dart
+++ b/firebase/functions/test/community/get_community_capabilities_test.dart
@@ -1,0 +1,112 @@
+import 'package:data_models/admin/plan_capability_list.dart';
+import 'package:data_models/community/community.dart';
+import 'package:data_models/community/membership.dart';
+import 'package:firebase_functions_interop/firebase_functions_interop.dart';
+import 'package:test/test.dart';
+import 'package:data_models/cloud_functions/requests.dart';
+import 'package:functions/community/get_community_capabilities.dart';
+import 'package:firebase_admin_interop/firebase_admin_interop.dart';
+import 'package:functions/utils/infra/firestore_utils.dart';
+
+import '../util/community_test_utils.dart';
+import '../util/subscription_test_utils.dart';
+
+void main() {
+  const userId = 'fakeAuthId';
+  const memberId = 'memberFooId';
+  String communityId = '';
+  final communityTestUtils = CommunityTestUtils();
+  final subscriptionTestUtils = SubscriptionTestUtils();
+
+  setUp(() async {
+    setFirebaseAppFactory(() => FirebaseAdmin.instance.initializeApp()!);
+    await subscriptionTestUtils.addUnrestrictedPlanCapabilities(
+      planCapabilities: SubscriptionTestUtils.unrestrictedPlan,
+    );
+    final communityResult = await communityTestUtils.createCommunity(
+      community: Community(
+        id: '1999',
+        name: 'Testing Community',
+        isPublic: true,
+      ),
+      userId: userId,
+    );
+    communityId = communityResult['communityId'];
+    await communityTestUtils.addCommunityMember(
+      communityId: communityId,
+      userId: memberId,
+      status: MembershipStatus.member,
+    );
+  });
+
+  tearDown(() async {
+    await subscriptionTestUtils.removeUnrestrictedPlanCapabilities();
+  });
+
+  test('Should return unrestricted capabilities since Stripe is disabled',
+      () async {
+    final capabilitiesGetter = GetCommunityCapabilities();
+    final req = GetCommunityCapabilitiesRequest(
+      communityId: communityId,
+    );
+
+    final result = await capabilitiesGetter.action(
+      req,
+      CallableContext(userId, null, 'fakeInstanceId'),
+    );
+
+    final capabilitiesResult = PlanCapabilityList.fromJson(
+      firestoreUtils.fromFirestoreJson(result),
+    );
+    expect(capabilitiesResult, equals(SubscriptionTestUtils.unrestrictedPlan));
+  });
+
+  test('Error thrown when user is not authenticated', () async {
+    final capabilitiesGetter = GetCommunityCapabilities();
+    final req = GetCommunityCapabilitiesRequest(
+      communityId: communityId,
+    );
+
+    expect(
+      () async {
+        await capabilitiesGetter.action(
+          req,
+          CallableContext(null, null, 'fakeInstanceId'),
+        );
+      },
+      throwsA(
+        predicate(
+          (e) =>
+              e is HttpsError &&
+              e.code == HttpsError.failedPrecondition &&
+              e.message == 'unauthorized',
+        ),
+      ),
+    );
+  });
+  test(
+      'Error thrown when requester does not have moderator or above permission',
+      () async {
+    final capabilitiesGetter = GetCommunityCapabilities();
+    final req = GetCommunityCapabilitiesRequest(
+      communityId: communityId,
+    );
+
+    expect(
+      () async {
+        await capabilitiesGetter.action(
+          req,
+          CallableContext(memberId, null, 'fakeInstanceId'),
+        );
+      },
+      throwsA(
+        predicate(
+          (e) =>
+              e is HttpsError &&
+              e.code == HttpsError.failedPrecondition &&
+              e.message == 'unauthorized',
+        ),
+      ),
+    );
+  });
+}

--- a/firebase/functions/test/community/get_community_pre_post_enabled_test.dart
+++ b/firebase/functions/test/community/get_community_pre_post_enabled_test.dart
@@ -1,0 +1,57 @@
+import 'package:data_models/community/community.dart';
+import 'package:firebase_functions_interop/firebase_functions_interop.dart';
+import 'package:functions/community/get_community_pre_post_enabled.dart';
+import 'package:test/test.dart';
+import 'package:data_models/cloud_functions/requests.dart';
+import 'package:firebase_admin_interop/firebase_admin_interop.dart';
+import 'package:functions/utils/infra/firestore_utils.dart';
+
+import '../util/community_test_utils.dart';
+import '../util/subscription_test_utils.dart';
+
+void main() {
+  const userId = 'fakeAuthId';
+  String communityId = '';
+  final communityTestUtils = CommunityTestUtils();
+  final subscriptionTestUtils = SubscriptionTestUtils();
+
+  setUp(() async {
+    setFirebaseAppFactory(() => FirebaseAdmin.instance.initializeApp()!);
+    await subscriptionTestUtils.addUnrestrictedPlanCapabilities(
+      planCapabilities: SubscriptionTestUtils.unrestrictedPlan,
+    );
+    final communityResult = await communityTestUtils.createCommunity(
+      community: Community(
+        id: '19954439',
+        name: 'Testing Community',
+        isPublic: true,
+      ),
+      userId: userId,
+    );
+    communityId = communityResult['communityId'];
+  });
+
+  tearDown(() async {
+    await subscriptionTestUtils.removeUnrestrictedPlanCapabilities();
+  });
+
+  test('Should return true since Stripe is disabled', () async {
+    final enabledGetter = GetCommunityPrePostEnabled();
+    final req = GetCommunityPrePostEnabledRequest(
+      communityId: communityId,
+    );
+
+    final result = await enabledGetter.action(
+      req,
+      CallableContext(userId, null, 'fakeInstanceId'),
+    );
+
+    final prePostResult = GetCommunityPrePostEnabledResponse.fromJson(
+      firestoreUtils.fromFirestoreJson(result),
+    );
+    expect(
+      prePostResult,
+      equals(GetCommunityPrePostEnabledResponse(prePostEnabled: true)),
+    );
+  });
+}

--- a/firebase/functions/test/community/get_community_pre_post_enabled_test.dart
+++ b/firebase/functions/test/community/get_community_pre_post_enabled_test.dart
@@ -1,4 +1,3 @@
-import 'package:data_models/community/community.dart';
 import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 import 'package:functions/community/get_community_pre_post_enabled.dart';
 import 'package:test/test.dart';
@@ -9,21 +8,12 @@ import '../util/community_test_utils.dart';
 import '../util/function_test_fixture.dart';
 
 void main() {
-  const userId = 'fakeAuthId';
-  String communityId = '';
+  late String communityId;
   final communityTestUtils = CommunityTestUtils();
   setupTestFixture();
 
   setUp(() async {
-    final communityResult = await communityTestUtils.createCommunity(
-      community: Community(
-        id: '19954439',
-        name: 'Testing Community',
-        isPublic: true,
-      ),
-      userId: userId,
-    );
-    communityId = communityResult['communityId'];
+    communityId = await communityTestUtils.createTestCommunity();
   });
 
   test('Should return true since Stripe is disabled', () async {
@@ -34,7 +24,7 @@ void main() {
 
     final result = await enabledGetter.action(
       req,
-      CallableContext(userId, null, 'fakeInstanceId'),
+      CallableContext(adminUserId, null, 'fakeInstanceId'),
     );
 
     final prePostResult = GetCommunityPrePostEnabledResponse.fromJson(

--- a/firebase/functions/test/community/get_community_pre_post_enabled_test.dart
+++ b/firebase/functions/test/community/get_community_pre_post_enabled_test.dart
@@ -3,23 +3,18 @@ import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 import 'package:functions/community/get_community_pre_post_enabled.dart';
 import 'package:test/test.dart';
 import 'package:data_models/cloud_functions/requests.dart';
-import 'package:firebase_admin_interop/firebase_admin_interop.dart';
 import 'package:functions/utils/infra/firestore_utils.dart';
 
 import '../util/community_test_utils.dart';
-import '../util/subscription_test_utils.dart';
+import '../util/function_test_fixture.dart';
 
 void main() {
   const userId = 'fakeAuthId';
   String communityId = '';
   final communityTestUtils = CommunityTestUtils();
-  final subscriptionTestUtils = SubscriptionTestUtils();
+  setupTestFixture();
 
   setUp(() async {
-    setFirebaseAppFactory(() => FirebaseAdmin.instance.initializeApp()!);
-    await subscriptionTestUtils.addUnrestrictedPlanCapabilities(
-      planCapabilities: SubscriptionTestUtils.unrestrictedPlan,
-    );
     final communityResult = await communityTestUtils.createCommunity(
       community: Community(
         id: '19954439',
@@ -29,10 +24,6 @@ void main() {
       userId: userId,
     );
     communityId = communityResult['communityId'];
-  });
-
-  tearDown(() async {
-    await subscriptionTestUtils.removeUnrestrictedPlanCapabilities();
   });
 
   test('Should return true since Stripe is disabled', () async {

--- a/firebase/functions/test/community/get_members_data_test.dart
+++ b/firebase/functions/test/community/get_members_data_test.dart
@@ -7,12 +7,9 @@ import 'package:data_models/cloud_functions/requests.dart';
 import 'package:data_models/community/membership.dart';
 import 'package:data_models/events/event.dart';
 import 'package:functions/community/get_members_data.dart';
-import 'package:firebase_admin_interop/firebase_admin_interop.dart'
-    as admin_interop hide EventType;
-import 'package:functions/utils/infra/firestore_utils.dart';
-
 import '../util/community_test_utils.dart';
 import '../util/event_test_utils.dart';
+import '../util/function_test_fixture.dart';
 
 void main() {
   const adminUserId = 'adminUser';
@@ -22,12 +19,9 @@ void main() {
   firebaseAuthUtils = mockFirebaseAuthUtils;
   final communityTestUtils = CommunityTestUtils();
   final eventTestUtils = EventTestUtils();
+  setupTestFixture();
 
   setUp(() async {
-    setFirebaseAppFactory(
-      () => admin_interop.FirebaseAdmin.instance.initializeApp()!,
-    );
-
     // Create test community
     final communityResult = await communityTestUtils.createCommunity(
       community: Community(

--- a/firebase/functions/test/community/get_members_data_test.dart
+++ b/firebase/functions/test/community/get_members_data_test.dart
@@ -1,0 +1,224 @@
+import 'package:data_models/community/community.dart';
+import 'package:firebase_functions_interop/firebase_functions_interop.dart';
+import 'package:functions/utils/infra/firebase_auth_utils.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+import 'package:data_models/cloud_functions/requests.dart';
+import 'package:data_models/community/membership.dart';
+import 'package:data_models/events/event.dart';
+import 'package:functions/community/get_members_data.dart';
+import 'package:firebase_admin_interop/firebase_admin_interop.dart'
+    as admin_interop hide EventType;
+import 'package:functions/utils/infra/firestore_utils.dart';
+
+import '../util/community_test_utils.dart';
+import '../util/event_test_utils.dart';
+
+void main() {
+  const adminUserId = 'adminUser';
+  const regularUserId = 'regularUser';
+  String communityId = '';
+  final mockFirebaseAuthUtils = MockFirebaseAuthUtils();
+  firebaseAuthUtils = mockFirebaseAuthUtils;
+  final communityTestUtils = CommunityTestUtils();
+  final eventTestUtils = EventTestUtils();
+
+  setUp(() async {
+    setFirebaseAppFactory(
+      () => admin_interop.FirebaseAdmin.instance.initializeApp()!,
+    );
+
+    // Create test community
+    final communityResult = await communityTestUtils.createCommunity(
+      community: Community(
+        id: '19921239',
+        name: 'Testing Community',
+        isPublic: true,
+      ),
+      userId: adminUserId,
+    );
+    communityId = communityResult['communityId'];
+
+    // Add regular member
+    await communityTestUtils.addCommunityMember(
+      communityId: communityId,
+      userId: regularUserId,
+      status: MembershipStatus.member,
+    );
+  });
+
+  test('Should return member details for admin request', () async {
+    final membersDataGetter = GetMembersData();
+    final req = GetMembersDataRequest(
+      communityId: communityId,
+      userIds: [adminUserId, regularUserId],
+    );
+
+    final adminUserRecord = MockUserRecord();
+    final regularUserRecord = MockUserRecord();
+
+    when(
+      () => mockFirebaseAuthUtils.getUser(adminUserId),
+    ).thenAnswer((_) async {
+      return adminUserRecord;
+    });
+
+    when(() => adminUserRecord.displayName).thenReturn('Admin');
+    when(() => adminUserRecord.email).thenReturn('admin@admin.com');
+    when(() => regularUserRecord.displayName).thenReturn('Joe User');
+    when(() => regularUserRecord.email).thenReturn('user@joe.com');
+
+    when(
+      () => mockFirebaseAuthUtils.getUser(regularUserId),
+    ).thenAnswer((_) async {
+      return regularUserRecord;
+    });
+
+    final result = await membersDataGetter.action(
+      req,
+      CallableContext(adminUserId, null, 'fakeInstanceId'),
+    );
+
+    /** Have to deal with returned Map instead of using GetMembersDataResponse.fromJson because SERVER_TIMESTAMP
+    placeholder used for Membership.firstJoined does not resolve to an actual date. */
+    expect(result['membersDetailsList'], hasLength(2));
+
+    // Verify admin member details
+    final adminMember = result['membersDetailsList']
+        .firstWhere((member) => member['id'] == adminUserId);
+
+    expect(
+      adminMember,
+      equals(
+        {
+          'id': adminUserId,
+          'email': 'admin@admin.com',
+          'displayName': 'Admin',
+          'membership': {
+            'userId': adminUserId,
+            'communityId': communityId,
+            'status': 'owner',
+            'firstJoined': 'SERVER_TIMESTAMP',
+            'invisible': false,
+          },
+          'memberEvent': null,
+        },
+      ),
+    );
+
+    // Verify regular member details
+    final regularMember = result['membersDetailsList']
+        .firstWhere((member) => member['id'] == regularUserId);
+    expect(
+      regularMember,
+      equals(
+        {
+          'id': regularUserId,
+          'email': 'user@joe.com',
+          'displayName': 'Joe User',
+          'membership': {
+            'userId': regularUserId,
+            'communityId': communityId,
+            'status': 'member',
+            'firstJoined': 'SERVER_TIMESTAMP',
+            'invisible': false,
+          },
+          'memberEvent': null,
+        },
+      ),
+    );
+  });
+
+  test('Error thrown when non-admin requests member data', () async {
+    final membersDataGetter = GetMembersData();
+    final req = GetMembersDataRequest(
+      communityId: communityId,
+      userIds: [adminUserId, regularUserId],
+    );
+
+    expect(
+      () async {
+        await membersDataGetter.action(
+          req,
+          CallableContext(regularUserId, null, 'fakeInstanceId'),
+        );
+      },
+      throwsA(
+        predicate(
+          (e) =>
+              e is HttpsError &&
+              e.code == HttpsError.failedPrecondition &&
+              e.message == 'Unauthorized',
+        ),
+      ),
+    );
+  });
+
+  test('Should include event participation data when event path provided',
+      () async {
+    // Add event participation data
+    final event = Event(
+      id: '12341daaaåff2ddd837',
+      status: EventStatus.active,
+      communityId: communityId,
+      templateId: '902342',
+      creatorId: adminUserId,
+      nullableEventType: EventType.hosted,
+      collectionPath: '',
+      agendaItems: [
+        AgendaItem(
+          id: '55005',
+          title: "Role call",
+          content: "Shout out if you're here",
+        ),
+      ],
+    );
+
+    Event createdEvent = await eventTestUtils.createEvent(
+      event: event,
+      userId: adminUserId,
+    );
+
+    final membersDataGetter = GetMembersData();
+    final req = GetMembersDataRequest(
+      communityId: communityId,
+      userIds: [adminUserId],
+      eventPath: createdEvent.fullPath,
+    );
+
+    final result = await membersDataGetter.action(
+      req,
+      CallableContext(adminUserId, null, 'fakeInstanceId'),
+    );
+
+    final memberDetails = result['membersDetailsList'].first;
+
+    expect(memberDetails['memberEvent'], isNotNull);
+    expect(memberDetails['memberEvent']['eventId'], equals(createdEvent.id));
+    expect(
+      memberDetails['memberEvent']['participant']['status'],
+      equals('active'),
+    );
+  });
+
+  test('Should handle non-existent users gracefully', () async {
+    final membersDataGetter = GetMembersData();
+    final req = GetMembersDataRequest(
+      communityId: communityId,
+      userIds: ['non-existent-user'],
+    );
+
+    final result = await membersDataGetter.action(
+      req,
+      CallableContext(adminUserId, null, 'fakeInstanceId'),
+    );
+
+    final memberDetails = result['membersDetailsList'].first;
+
+    expect(memberDetails['email'], equals('Unknown'));
+    expect(
+      memberDetails['membership']['status'],
+      equals('nonmember'),
+    );
+  });
+}

--- a/firebase/functions/test/community/get_members_data_test.dart
+++ b/firebase/functions/test/community/get_members_data_test.dart
@@ -1,4 +1,3 @@
-import 'package:data_models/community/community.dart';
 import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 import 'package:functions/utils/infra/firebase_auth_utils.dart';
 import 'package:mocktail/mocktail.dart';
@@ -12,9 +11,8 @@ import '../util/event_test_utils.dart';
 import '../util/function_test_fixture.dart';
 
 void main() {
-  const adminUserId = 'adminUser';
   const regularUserId = 'regularUser';
-  String communityId = '';
+  late String communityId;
   final mockFirebaseAuthUtils = MockFirebaseAuthUtils();
   firebaseAuthUtils = mockFirebaseAuthUtils;
   final communityTestUtils = CommunityTestUtils();
@@ -23,15 +21,7 @@ void main() {
 
   setUp(() async {
     // Create test community
-    final communityResult = await communityTestUtils.createCommunity(
-      community: Community(
-        id: '19921239',
-        name: 'Testing Community',
-        isPublic: true,
-      ),
-      userId: adminUserId,
-    );
-    communityId = communityResult['communityId'];
+    communityId = await communityTestUtils.createTestCommunity();
 
     // Add regular member
     await communityTestUtils.addCommunityMember(

--- a/firebase/functions/test/community/get_user_admin_details_test.dart
+++ b/firebase/functions/test/community/get_user_admin_details_test.dart
@@ -8,12 +8,11 @@ import 'package:data_models/cloud_functions/requests.dart';
 import 'package:data_models/community/membership.dart';
 import 'package:data_models/events/event.dart';
 import 'package:functions/community/get_user_admin_details.dart';
-import 'package:firebase_admin_interop/firebase_admin_interop.dart'
-    as admin_interop hide EventType;
 import 'package:functions/utils/infra/firestore_utils.dart';
 
 import '../util/community_test_utils.dart';
 import '../util/event_test_utils.dart';
+import '../util/function_test_fixture.dart';
 
 void main() {
   const adminUserId = 'adminUser';
@@ -25,12 +24,9 @@ void main() {
   firebaseAuthUtils = mockFirebaseAuthUtils;
   final communityTestUtils = CommunityTestUtils();
   final eventTestUtils = EventTestUtils();
+  setupTestFixture();
 
   setUp(() async {
-    setFirebaseAppFactory(
-      () => admin_interop.FirebaseAdmin.instance.initializeApp()!,
-    );
-
     // Create test community
     final communityResult = await communityTestUtils.createCommunity(
       community: Community(
@@ -48,10 +44,6 @@ void main() {
       userId: regularUserId,
       status: MembershipStatus.member,
     );
-  });
-
-  tearDown(() async {
-    resetMocktailState();
   });
 
   test('Should allow user to request their own admin details', () async {

--- a/firebase/functions/test/community/get_user_admin_details_test.dart
+++ b/firebase/functions/test/community/get_user_admin_details_test.dart
@@ -1,4 +1,3 @@
-import 'package:data_models/community/community.dart';
 import 'package:data_models/community/membership_request.dart';
 import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 import 'package:functions/utils/infra/firebase_auth_utils.dart';
@@ -15,11 +14,10 @@ import '../util/event_test_utils.dart';
 import '../util/function_test_fixture.dart';
 
 void main() {
-  const adminUserId = 'adminUser';
   const regularUserId = 'regularUser';
   const requesterUserId = 'requesterUser';
   const nonMemberUserId = 'nonMemberUser';
-  String communityId = '';
+  late String communityId;
   final mockFirebaseAuthUtils = MockFirebaseAuthUtils();
   firebaseAuthUtils = mockFirebaseAuthUtils;
   final communityTestUtils = CommunityTestUtils();
@@ -28,15 +26,7 @@ void main() {
 
   setUp(() async {
     // Create test community
-    final communityResult = await communityTestUtils.createCommunity(
-      community: Community(
-        id: '1992123911',
-        name: 'Testing Community',
-        isPublic: true,
-      ),
-      userId: adminUserId,
-    );
-    communityId = communityResult['communityId'];
+    communityId = await communityTestUtils.createTestCommunity();
 
     // Add regular member
     await communityTestUtils.addCommunityMember(

--- a/firebase/functions/test/community/get_user_admin_details_test.dart
+++ b/firebase/functions/test/community/get_user_admin_details_test.dart
@@ -1,0 +1,258 @@
+import 'package:data_models/community/community.dart';
+import 'package:data_models/community/membership_request.dart';
+import 'package:firebase_functions_interop/firebase_functions_interop.dart';
+import 'package:functions/utils/infra/firebase_auth_utils.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+import 'package:data_models/cloud_functions/requests.dart';
+import 'package:data_models/community/membership.dart';
+import 'package:data_models/events/event.dart';
+import 'package:functions/community/get_user_admin_details.dart';
+import 'package:firebase_admin_interop/firebase_admin_interop.dart'
+    as admin_interop hide EventType;
+import 'package:functions/utils/infra/firestore_utils.dart';
+
+import '../util/community_test_utils.dart';
+import '../util/event_test_utils.dart';
+
+void main() {
+  const adminUserId = 'adminUser';
+  const regularUserId = 'regularUser';
+  const requesterUserId = 'requesterUser';
+  const nonMemberUserId = 'nonMemberUser';
+  String communityId = '';
+  final mockFirebaseAuthUtils = MockFirebaseAuthUtils();
+  firebaseAuthUtils = mockFirebaseAuthUtils;
+  final communityTestUtils = CommunityTestUtils();
+  final eventTestUtils = EventTestUtils();
+
+  setUp(() async {
+    setFirebaseAppFactory(
+      () => admin_interop.FirebaseAdmin.instance.initializeApp()!,
+    );
+
+    // Create test community
+    final communityResult = await communityTestUtils.createCommunity(
+      community: Community(
+        id: '1992123911',
+        name: 'Testing Community',
+        isPublic: true,
+      ),
+      userId: adminUserId,
+    );
+    communityId = communityResult['communityId'];
+
+    // Add regular member
+    await communityTestUtils.addCommunityMember(
+      communityId: communityId,
+      userId: regularUserId,
+      status: MembershipStatus.member,
+    );
+  });
+
+  tearDown(() async {
+    resetMocktailState();
+  });
+
+  test('Should allow user to request their own admin details', () async {
+    final getUserAdminDetails = GetUserAdminDetails();
+    final req = GetUserAdminDetailsRequest(
+      userIds: [regularUserId],
+    );
+
+    final userRecord = MockUserRecord();
+    when(() => userRecord.uid).thenReturn(regularUserId);
+    when(() => userRecord.email).thenReturn('user@example.com');
+
+    when(
+      () => mockFirebaseAuthUtils.getUsers([regularUserId]),
+    ).thenAnswer((_) async => [userRecord]);
+
+    final result = await getUserAdminDetails.action(
+      req,
+      CallableContext(regularUserId, null, 'fakeInstanceId'),
+    );
+
+    expect(result['userAdminDetails'], hasLength(1));
+    final response = UserAdminDetails.fromJson(
+      firestoreUtils.fromFirestoreJson(result['userAdminDetails'].first),
+    );
+    expect(
+      response,
+      equals(
+        UserAdminDetails(
+          userId: regularUserId,
+          email: 'user@example.com',
+        ),
+      ),
+    );
+  });
+
+  test('Should allow admin to request member admin details', () async {
+    final getUserAdminDetails = GetUserAdminDetails();
+    final req = GetUserAdminDetailsRequest(
+      userIds: [regularUserId],
+      communityId: communityId,
+    );
+
+    final userRecord = MockUserRecord();
+    when(() => userRecord.uid).thenReturn(regularUserId);
+    when(() => userRecord.email).thenReturn('user@example.com');
+
+    when(
+      () => mockFirebaseAuthUtils.getUsers([regularUserId]),
+    ).thenAnswer((_) async => [userRecord]);
+
+    final result = await getUserAdminDetails.action(
+      req,
+      CallableContext(adminUserId, null, 'fakeInstanceId'),
+    );
+
+    expect(result['userAdminDetails'], hasLength(1));
+    final response = UserAdminDetails.fromJson(
+      firestoreUtils.fromFirestoreJson(result['userAdminDetails'].first),
+    );
+    expect(
+      response,
+      equals(
+        UserAdminDetails(
+          userId: regularUserId,
+          email: 'user@example.com',
+        ),
+      ),
+    );
+  });
+
+  test('Should allow admin to request details for event participants',
+      () async {
+    const templateId = '902342';
+    // Create test event
+    final event = Event(
+      id: '12341234',
+      status: EventStatus.active,
+      communityId: communityId,
+      templateId: templateId,
+      creatorId: adminUserId,
+      nullableEventType: EventType.hosted,
+      collectionPath: '',
+      agendaItems: [],
+    );
+
+    Event createdEvent = await eventTestUtils.createEvent(
+      event: event,
+      userId: adminUserId,
+    );
+
+    // Add participant to event
+    await eventTestUtils.joinEvent(
+      communityId: communityId,
+      eventId: createdEvent.id,
+      templateId: '902342',
+      uid: nonMemberUserId,
+    );
+
+    final getUserAdminDetails = GetUserAdminDetails();
+    final req = GetUserAdminDetailsRequest(
+      userIds: [nonMemberUserId],
+      communityId: communityId,
+      eventPath: createdEvent.fullPath,
+    );
+
+    final userRecord = MockUserRecord();
+    when(() => userRecord.uid).thenReturn(nonMemberUserId);
+    when(() => userRecord.email).thenReturn('user@example2.com');
+
+    when(
+      () => mockFirebaseAuthUtils.getUsers([nonMemberUserId]),
+    ).thenAnswer((_) async => [userRecord]);
+
+    final result = await getUserAdminDetails.action(
+      req,
+      CallableContext(adminUserId, null, 'fakeInstanceId'),
+    );
+
+    expect(result['userAdminDetails'], hasLength(1));
+    final response = UserAdminDetails.fromJson(
+      firestoreUtils.fromFirestoreJson(result['userAdminDetails'].first),
+    );
+    expect(
+      response,
+      equals(
+        UserAdminDetails(
+          userId: nonMemberUserId,
+          email: 'user@example2.com',
+        ),
+      ),
+    );
+  });
+
+  test('Should throw error when non-admin requests other user details',
+      () async {
+    final getUserAdminDetails = GetUserAdminDetails();
+    final req = GetUserAdminDetailsRequest(
+      userIds: [adminUserId],
+      communityId: communityId,
+    );
+
+    expect(
+      () async {
+        await getUserAdminDetails.action(
+          req,
+          CallableContext(regularUserId, null, 'fakeInstanceId'),
+        );
+      },
+      throwsA(
+        predicate(
+          (e) =>
+              e is HttpsError &&
+              e.code == HttpsError.failedPrecondition &&
+              e.message == 'unauthorized',
+        ),
+      ),
+    );
+  });
+
+  test('Should allow admin to request details for membership requesters',
+      () async {
+    // Add membership request
+    await communityTestUtils.addJoinRequest(
+      request: MembershipRequest(
+        communityId: communityId,
+        userId: requesterUserId,
+      ),
+    );
+
+    final getUserAdminDetails = GetUserAdminDetails();
+    final req = GetUserAdminDetailsRequest(
+      userIds: [requesterUserId],
+      communityId: communityId,
+    );
+
+    final userRecord = MockUserRecord();
+    when(() => userRecord.uid).thenReturn(requesterUserId);
+    when(() => userRecord.email).thenReturn('requester@example.com');
+
+    when(
+      () => mockFirebaseAuthUtils.getUsers([requesterUserId]),
+    ).thenAnswer((_) async => [userRecord]);
+
+    final result = await getUserAdminDetails.action(
+      req,
+      CallableContext(adminUserId, null, 'fakeInstanceId'),
+    );
+
+    expect(result['userAdminDetails'], hasLength(1));
+    final response = UserAdminDetails.fromJson(
+      firestoreUtils.fromFirestoreJson(result['userAdminDetails'].first),
+    );
+    expect(
+      response,
+      equals(
+        UserAdminDetails(
+          userId: requesterUserId,
+          email: 'requester@example.com',
+        ),
+      ),
+    );
+  });
+}

--- a/firebase/functions/test/community/on_community_membership_test.dart
+++ b/firebase/functions/test/community/on_community_membership_test.dart
@@ -1,0 +1,244 @@
+import 'package:data_models/community/community.dart';
+import 'package:data_models/community/membership.dart';
+import 'package:firebase_functions_interop/firebase_functions_interop.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+import 'package:firebase_admin_interop/firebase_admin_interop.dart'
+    as admin_interop;
+import 'package:functions/utils/infra/firestore_utils.dart';
+import 'package:functions/community/on_community_membership.dart';
+import 'package:enum_to_string/enum_to_string.dart';
+
+import '../util/community_test_utils.dart';
+
+void main() {
+  const creatorId = 'creatorUser';
+  const newMemberId = 'newMember';
+  String communityId = '';
+  final communityTestUtils = CommunityTestUtils();
+  late OnCommunityMembership onCommunityMembership;
+
+  setUp(() async {
+    setFirebaseAppFactory(
+      () => admin_interop.FirebaseAdmin.instance.initializeApp()!,
+    );
+
+    onCommunityMembership = OnCommunityMembership();
+
+    // Create test community with initial onboarding step
+    final communityResult = await communityTestUtils.createCommunity(
+      community: Community(
+        id: '1992123911',
+        name: 'Testing Community',
+        isPublic: true,
+        creatorId: creatorId,
+        onboardingSteps: [
+          OnboardingStep.brandSpace,
+        ],
+      ),
+      userId: creatorId,
+    );
+    communityId = communityResult['communityId'];
+  });
+
+  test('Should not add inviteSomeone step when creator joins', () async {
+    // Get the document snapshot
+    final docSnapshot = await firestore
+        .document('memberships/$creatorId/community-membership/$communityId')
+        .get();
+
+    // Explicitly call onCreate
+    await onCommunityMembership.onCreate(
+      docSnapshot,
+      Membership(communityId: communityId, userId: creatorId),
+      DateTime.now(),
+      MockEventContext(),
+    );
+
+    // Verify community document
+    final communityDoc =
+        await firestore.document('community/$communityId').get();
+
+    final onboardingSteps = communityDoc.data
+        .toMap()[Community.kFieldOnboardingSteps] as List<dynamic>;
+
+    // Should only have the initial brandSpace step
+    expect(onboardingSteps, hasLength(1));
+    expect(
+      onboardingSteps.first,
+      equals(EnumToString.convertToString(OnboardingStep.brandSpace)),
+    );
+  });
+
+  test('Should add inviteSomeone step when first non-creator member joins',
+      () async {
+    // Create membership document
+    await communityTestUtils.addCommunityMember(
+      communityId: communityId,
+      userId: newMemberId,
+      status: MembershipStatus.member,
+    );
+
+    // Get the document snapshot
+    final docSnapshot = await firestore
+        .document('memberships/$newMemberId/community-membership/$communityId')
+        .get();
+
+    // Explicitly call onCreate
+    await onCommunityMembership.onCreate(
+      docSnapshot,
+      Membership(communityId: communityId, userId: newMemberId),
+      DateTime.now(),
+      MockEventContext(),
+    );
+
+    // Verify community document
+    final communityDoc =
+        await firestore.document('community/$communityId').get();
+
+    final onboardingSteps = communityDoc.data
+        .toMap()[Community.kFieldOnboardingSteps] as List<dynamic>;
+
+    // Should have both brandSpace and inviteSomeone steps
+    expect(onboardingSteps, hasLength(2));
+    expect(
+      onboardingSteps,
+      contains(EnumToString.convertToString(OnboardingStep.brandSpace)),
+    );
+    expect(
+      onboardingSteps,
+      contains(EnumToString.convertToString(OnboardingStep.inviteSomeone)),
+    );
+  });
+
+  test('Should not add duplicate inviteSomeone step when second member joins',
+      () async {
+    // Add first new member and call onCreate
+    await communityTestUtils.addCommunityMember(
+      communityId: communityId,
+      userId: newMemberId,
+      status: MembershipStatus.member,
+    );
+
+    final firstDocSnapshot = await firestore
+        .document('memberships/$newMemberId/community-membership/$communityId')
+        .get();
+
+    await onCommunityMembership.onCreate(
+      firstDocSnapshot,
+      Membership(communityId: communityId, userId: newMemberId),
+      DateTime.now(),
+      MockEventContext(),
+    );
+
+    // Add second member and call onCreate
+    await communityTestUtils.addCommunityMember(
+      communityId: communityId,
+      userId: 'anotherMember',
+      status: MembershipStatus.member,
+    );
+
+    final secondDocSnapshot = await firestore
+        .document('memberships/anotherMember/community-membership/$communityId')
+        .get();
+
+    await onCommunityMembership.onCreate(
+      secondDocSnapshot,
+      Membership(communityId: communityId, userId: 'anotherMember'),
+      DateTime.now(),
+      MockEventContext(),
+    );
+
+    // Verify community document
+    final communityDoc =
+        await firestore.document('community/$communityId').get();
+
+    final onboardingSteps = communityDoc.data
+        .toMap()[Community.kFieldOnboardingSteps] as List<dynamic>;
+
+    // Should still only have two steps
+    expect(onboardingSteps, hasLength(2));
+    expect(
+      onboardingSteps,
+      contains(EnumToString.convertToString(OnboardingStep.brandSpace)),
+    );
+    expect(
+      onboardingSteps,
+      contains(EnumToString.convertToString(OnboardingStep.inviteSomeone)),
+    );
+  });
+
+  test('Should handle missing onboardingSteps field gracefully', () async {
+    // Create community without onboardingSteps
+    final communityWithoutSteps = await communityTestUtils.createCommunity(
+      community: Community(
+        id: '99999',
+        name: 'No Steps Community',
+        isPublic: true,
+        creatorId: creatorId,
+      ),
+      userId: creatorId,
+    );
+
+    // Create membership and call onCreate
+    await communityTestUtils.addCommunityMember(
+      communityId: communityWithoutSteps['communityId'],
+      userId: newMemberId,
+      status: MembershipStatus.member,
+    );
+
+    final docSnapshot = await firestore
+        .document(
+          'memberships/$newMemberId/community-membership/${communityWithoutSteps['communityId']}',
+        )
+        .get();
+
+    await onCommunityMembership.onCreate(
+      docSnapshot,
+      Membership(communityId: communityId, userId: newMemberId),
+      DateTime.now(),
+      MockEventContext(),
+    );
+
+    // Verify no error was thrown and community still exists
+    final communityDoc = await firestore
+        .document('community/${communityWithoutSteps['communityId']}')
+        .get();
+
+    expect(communityDoc.exists, isTrue);
+  });
+
+  test('Should handle non-existent community gracefully', () async {
+    // Create membership for non-existent community
+    await communityTestUtils.addCommunityMember(
+      communityId: 'nonexistent-community',
+      userId: newMemberId,
+      status: MembershipStatus.member,
+    );
+
+    final docSnapshot = await firestore
+        .document(
+          'memberships/$newMemberId/community-membership/nonexistent-community',
+        )
+        .get();
+
+    // Call onCreate and verify it doesn't throw exception
+    await onCommunityMembership.onCreate(
+      docSnapshot,
+      Membership(communityId: 'nonexistent-community', userId: newMemberId),
+      DateTime.now(),
+      MockEventContext(),
+    );
+
+    // Verify membership was created despite community not existing
+    final membershipVerifyDoc = await firestore
+        .document(
+          'memberships/$newMemberId/community-membership/nonexistent-community',
+        )
+        .get();
+
+    expect(membershipVerifyDoc.exists, isTrue);
+  });
+}
+
+class MockEventContext extends Mock implements EventContext {}

--- a/firebase/functions/test/community/on_community_membership_test.dart
+++ b/firebase/functions/test/community/on_community_membership_test.dart
@@ -229,15 +229,6 @@ void main() {
       DateTime.now(),
       MockEventContext(),
     );
-
-    // Verify membership was created despite community not existing
-    final membershipVerifyDoc = await firestore
-        .document(
-          'memberships/$newMemberId/community-membership/nonexistent-community',
-        )
-        .get();
-
-    expect(membershipVerifyDoc.exists, isTrue);
   });
 }
 

--- a/firebase/functions/test/community/resolve_join_request_test.dart
+++ b/firebase/functions/test/community/resolve_join_request_test.dart
@@ -6,14 +6,13 @@ import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 import 'package:data_models/cloud_functions/requests.dart';
 import 'package:data_models/community/membership.dart';
-import 'package:firebase_admin_interop/firebase_admin_interop.dart'
-    as admin_interop;
 import 'package:functions/utils/infra/firestore_utils.dart';
 import 'package:functions/utils/send_email_client.dart';
 import 'package:functions/community/resolve_join_request.dart';
 
 import '../util/community_test_utils.dart';
 import '../util/email_test_utils.dart';
+import '../util/function_test_fixture.dart';
 
 void main() {
   const adminUserId = 'adminUser';
@@ -25,6 +24,7 @@ void main() {
   firebaseAuthUtils = mockFirebaseAuthUtils;
   sendEmailClient = mockSendEmailClient;
   final communityTestUtils = CommunityTestUtils();
+  setupTestFixture();
 
   setUpAll(() {
     // Register fallback values for SendGridEmail and its dependencies
@@ -33,10 +33,6 @@ void main() {
   });
 
   setUp(() async {
-    setFirebaseAppFactory(
-      () => admin_interop.FirebaseAdmin.instance.initializeApp()!,
-    );
-
     // Create test community
     final communityResult = await communityTestUtils.createCommunity(
       community: Community(
@@ -54,10 +50,6 @@ void main() {
       userId: regularUserId,
       status: MembershipStatus.member,
     );
-  });
-
-  tearDown(() async {
-    resetMocktailState();
   });
 
   test('Should allow admin to approve join request', () async {

--- a/firebase/functions/test/community/resolve_join_request_test.dart
+++ b/firebase/functions/test/community/resolve_join_request_test.dart
@@ -1,4 +1,3 @@
-import 'package:data_models/community/community.dart';
 import 'package:data_models/community/membership_request.dart';
 import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 import 'package:functions/utils/infra/firebase_auth_utils.dart';
@@ -15,10 +14,9 @@ import '../util/email_test_utils.dart';
 import '../util/function_test_fixture.dart';
 
 void main() {
-  const adminUserId = 'adminUser';
   const regularUserId = 'regularUser';
   const requesterUserId = 'requesterUser';
-  String communityId = '';
+  late String communityId;
   final mockFirebaseAuthUtils = MockFirebaseAuthUtils();
   final mockSendEmailClient = MockSendEmailClient();
   firebaseAuthUtils = mockFirebaseAuthUtils;
@@ -34,15 +32,7 @@ void main() {
 
   setUp(() async {
     // Create test community
-    final communityResult = await communityTestUtils.createCommunity(
-      community: Community(
-        id: '1992123911',
-        name: 'Testing Community',
-        isPublic: true,
-      ),
-      userId: adminUserId,
-    );
-    communityId = communityResult['communityId'];
+    communityId = await communityTestUtils.createTestCommunity();
 
     // Add regular member
     await communityTestUtils.addCommunityMember(

--- a/firebase/functions/test/community/resolve_join_request_test.dart
+++ b/firebase/functions/test/community/resolve_join_request_test.dart
@@ -1,0 +1,246 @@
+import 'package:data_models/community/community.dart';
+import 'package:data_models/community/membership_request.dart';
+import 'package:firebase_functions_interop/firebase_functions_interop.dart';
+import 'package:functions/utils/infra/firebase_auth_utils.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+import 'package:data_models/cloud_functions/requests.dart';
+import 'package:data_models/community/membership.dart';
+import 'package:firebase_admin_interop/firebase_admin_interop.dart'
+    as admin_interop;
+import 'package:functions/utils/infra/firestore_utils.dart';
+import 'package:functions/utils/send_email_client.dart';
+import 'package:functions/community/resolve_join_request.dart';
+
+import '../util/community_test_utils.dart';
+import '../util/email_test_utils.dart';
+
+void main() {
+  const adminUserId = 'adminUser';
+  const regularUserId = 'regularUser';
+  const requesterUserId = 'requesterUser';
+  String communityId = '';
+  final mockFirebaseAuthUtils = MockFirebaseAuthUtils();
+  final mockSendEmailClient = MockSendEmailClient();
+  firebaseAuthUtils = mockFirebaseAuthUtils;
+  sendEmailClient = mockSendEmailClient;
+  final communityTestUtils = CommunityTestUtils();
+
+  setUpAll(() {
+    // Register fallback values for SendGridEmail and its dependencies
+    registerFallbackValue(MockSendGridEmail());
+    registerFallbackValue(MockSendGridEmailMessage());
+  });
+
+  setUp(() async {
+    setFirebaseAppFactory(
+      () => admin_interop.FirebaseAdmin.instance.initializeApp()!,
+    );
+
+    // Create test community
+    final communityResult = await communityTestUtils.createCommunity(
+      community: Community(
+        id: '1992123911',
+        name: 'Testing Community',
+        isPublic: true,
+      ),
+      userId: adminUserId,
+    );
+    communityId = communityResult['communityId'];
+
+    // Add regular member
+    await communityTestUtils.addCommunityMember(
+      communityId: communityId,
+      userId: regularUserId,
+      status: MembershipStatus.member,
+    );
+  });
+
+  tearDown(() async {
+    resetMocktailState();
+  });
+
+  test('Should allow admin to approve join request', () async {
+    // Add join request
+    await communityTestUtils.addJoinRequest(
+      request: MembershipRequest(
+        communityId: communityId,
+        userId: requesterUserId,
+        status: MembershipRequestStatus.requested,
+      ),
+    );
+
+    final resolveJoinRequest = ResolveJoinRequest();
+    final req = ResolveJoinRequestRequest(
+      communityId: communityId,
+      userId: requesterUserId,
+      approve: true,
+    );
+
+    final userRecord = MockUserRecord();
+    when(() => userRecord.uid).thenReturn(requesterUserId);
+    when(() => userRecord.email).thenReturn('requester@example.com');
+
+    when(
+      () => mockFirebaseAuthUtils.getUsers([requesterUserId]),
+    ).thenAnswer((_) async => [userRecord]);
+
+    when(
+      () => mockSendEmailClient.sendEmail(
+        any(),
+        transaction: any(named: 'transaction'),
+      ),
+    ).thenAnswer((_) async => {});
+
+    await resolveJoinRequest.action(
+      req,
+      CallableContext(adminUserId, null, 'fakeInstanceId'),
+    );
+
+    // Verify membership was updated
+    final membershipDoc = await firestore
+        .document(
+          'memberships/$requesterUserId/community-membership/$communityId',
+        )
+        .get();
+
+    final membership = Membership.fromJson(
+      firestoreUtils.fromFirestoreJson(membershipDoc.data.toMap()),
+    );
+    expect(membership.status, equals(MembershipStatus.member));
+
+    // Verify request was marked as approved
+    final requestDoc = await firestore
+        .document(
+          'community/$communityId/join-requests/$requesterUserId',
+        )
+        .get();
+
+    final request = MembershipRequest.fromJson(
+      firestoreUtils.fromFirestoreJson(requestDoc.data.toMap()),
+    );
+    expect(request.status, equals(MembershipRequestStatus.approved));
+
+    // Verify email was sent
+    verify(
+      () => mockSendEmailClient.sendEmail(
+        any(),
+        transaction: any(named: 'transaction'),
+      ),
+    ).called(1);
+  });
+
+  test('Should allow admin to deny join request', () async {
+    // Add join request
+    await communityTestUtils.addJoinRequest(
+      request: MembershipRequest(
+        communityId: communityId,
+        userId: requesterUserId,
+        status: MembershipRequestStatus.requested,
+      ),
+    );
+
+    final resolveJoinRequest = ResolveJoinRequest();
+    final req = ResolveJoinRequestRequest(
+      communityId: communityId,
+      userId: requesterUserId,
+      approve: false,
+    );
+
+    await resolveJoinRequest.action(
+      req,
+      CallableContext(adminUserId, null, 'fakeInstanceId'),
+    );
+
+    // Verify request was marked as denied
+    final requestDoc = await firestore
+        .document(
+          'community/$communityId/join-requests/$requesterUserId',
+        )
+        .get();
+
+    final request = MembershipRequest.fromJson(
+      firestoreUtils.fromFirestoreJson(requestDoc.data.toMap()),
+    );
+    expect(request.status, equals(MembershipRequestStatus.denied));
+
+    // Verify no email was sent for denial
+    verifyNever(
+      () => mockSendEmailClient.sendEmail(
+        any(),
+        transaction: any(named: 'transaction'),
+      ),
+    );
+  });
+
+  test('Should throw error when trying to approve already approved request',
+      () async {
+    // Add already approved request
+    await communityTestUtils.addJoinRequest(
+      request: MembershipRequest(
+        communityId: communityId,
+        userId: requesterUserId,
+        status: MembershipRequestStatus.approved,
+      ),
+    );
+
+    final resolveJoinRequest = ResolveJoinRequest();
+    final req = ResolveJoinRequestRequest(
+      communityId: communityId,
+      userId: requesterUserId,
+      approve: true,
+    );
+
+    expect(
+      () async {
+        await resolveJoinRequest.action(
+          req,
+          CallableContext(adminUserId, null, 'fakeInstanceId'),
+        );
+      },
+      throwsA(
+        predicate(
+          (e) =>
+              e is HttpsError &&
+              e.code == HttpsError.failedPrecondition &&
+              e.message == 'unauthorized',
+        ),
+      ),
+    );
+  });
+
+  test('Should throw error when non-admin tries to resolve request', () async {
+    // Add join request
+    await communityTestUtils.addJoinRequest(
+      request: MembershipRequest(
+        communityId: communityId,
+        userId: requesterUserId,
+        status: MembershipRequestStatus.requested,
+      ),
+    );
+
+    final resolveJoinRequest = ResolveJoinRequest();
+    final req = ResolveJoinRequestRequest(
+      communityId: communityId,
+      userId: requesterUserId,
+      approve: true,
+    );
+
+    expect(
+      () async {
+        await resolveJoinRequest.action(
+          req,
+          CallableContext(regularUserId, null, 'fakeInstanceId'),
+        );
+      },
+      throwsA(
+        predicate(
+          (e) =>
+              e is HttpsError &&
+              e.code == HttpsError.failedPrecondition &&
+              e.message == 'unauthorized',
+        ),
+      ),
+    );
+  });
+}

--- a/firebase/functions/test/community/trigger_email_digests_test.dart
+++ b/firebase/functions/test/community/trigger_email_digests_test.dart
@@ -1,0 +1,383 @@
+import 'package:data_models/community/community.dart';
+import 'package:data_models/community/email_digest_record.dart';
+import 'package:data_models/community/membership.dart';
+import 'package:data_models/community/community_user_settings.dart';
+import 'package:data_models/events/event.dart';
+import 'package:data_models/templates/template.dart';
+import 'package:firebase_functions_interop/firebase_functions_interop.dart';
+import 'package:functions/utils/infra/firebase_auth_utils.dart';
+import 'package:functions/utils/send_email_client.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+import 'package:functions/community/trigger_email_digests.dart';
+import 'package:firebase_admin_interop/firebase_admin_interop.dart'
+    as admin_interop hide EventType;
+import 'package:functions/utils/infra/firestore_utils.dart';
+
+import '../util/community_test_utils.dart';
+import '../util/email_test_utils.dart';
+import '../util/event_test_utils.dart';
+
+void main() {
+  const memberId = 'memberUser';
+  const adminUserId = 'adminUser';
+  const templateId = '123777';
+  String communityId = '';
+  final mockFirebaseAuthUtils = MockFirebaseAuthUtils();
+  final mockNotificationsUtils = MockNotificationsUtils();
+  final mockSendEmailClient = MockSendEmailClient();
+  firebaseAuthUtils = mockFirebaseAuthUtils;
+  sendEmailClient = mockSendEmailClient;
+  final communityTestUtils = CommunityTestUtils();
+  final eventTestUtils = EventTestUtils();
+
+  setUp(() async {
+    setFirebaseAppFactory(
+      () => admin_interop.FirebaseAdmin.instance.initializeApp()!,
+    );
+    await communityTestUtils.deleteAllCommunities();
+    // Create test community
+    final communityResult = await communityTestUtils.createCommunity(
+      community: Community(
+        id: '1992123911',
+        name: 'Testing Community',
+        isPublic: true,
+        communitySettings: const CommunitySettings(
+          disableEmailDigests: false,
+        ),
+      ),
+      userId: adminUserId,
+    );
+    communityId = communityResult['communityId'];
+
+    // Add regular member
+    await communityTestUtils.addCommunityMember(
+      communityId: communityId,
+      userId: memberId,
+      status: MembershipStatus.member,
+    );
+
+    // Reset mocks
+    reset(mockSendEmailClient);
+    reset(mockNotificationsUtils);
+    reset(mockFirebaseAuthUtils);
+  });
+
+  tearDown(() async {
+    resetMocktailState();
+  });
+
+  test('Should send digest emails for upcoming events to subscribed members',
+      () async {
+    final triggerEmailDigests = TriggerEmailDigests(
+      notificationsUtils: mockNotificationsUtils,
+    );
+
+    var template =
+        const Template(id: templateId, title: 'All the things to discuss');
+
+    template = await eventTestUtils.createTemplate(
+      communityId: communityId,
+      template: template,
+      creatorId: adminUserId,
+    );
+
+    // Create test event
+    final now = DateTime.now();
+    final event = Event(
+      id: '12341234',
+      status: EventStatus.active,
+      communityId: communityId,
+      templateId: templateId,
+      creatorId: adminUserId,
+      nullableEventType: EventType.hosted,
+      collectionPath: '',
+      agendaItems: [],
+      scheduledTime: now.add(const Duration(days: 7)),
+      isPublic: true,
+    );
+
+    await eventTestUtils.createEvent(
+      event: event,
+      userId: adminUserId,
+    );
+
+    when(
+      () => mockSendEmailClient.sendEmails(any()),
+    ).thenAnswer((_) async => {});
+
+    // Mock user record
+    final userRecord = MockUserRecord();
+    when(() => userRecord.uid).thenReturn(memberId);
+    when(() => userRecord.email).thenReturn('member@example.com');
+
+    final adminRecord = MockUserRecord();
+    when(() => adminRecord.uid).thenReturn(adminUserId);
+    when(() => adminRecord.email).thenReturn('admin@example.com');
+
+    when(() => mockFirebaseAuthUtils.getUsers([memberId]))
+        .thenAnswer((_) async => [userRecord]);
+
+    when(() => mockFirebaseAuthUtils.getUsers([adminUserId]))
+        .thenAnswer((_) async => [adminRecord]);
+
+    // Mock notifications utils
+    when(() => mockNotificationsUtils.getUnsubscribeUrl(userId: memberId))
+        .thenReturn('https://example.com/unsubscribe');
+    when(() => mockNotificationsUtils.getUnsubscribeUrl(userId: adminUserId))
+        .thenReturn('https://example.com/unsubscribe');
+
+    // Set user notification preferences
+    await firestore
+        .document(
+          '/privateUserData/$memberId/communityUserSettings/$communityId',
+        )
+        .setData(
+          admin_interop.DocumentData.fromMap(
+            firestoreUtils.toFirestoreJson(
+              CommunityUserSettings(
+                notifyEvents: NotificationEmailType.immediate,
+              ).toJson(),
+            ),
+          ),
+        );
+
+    await firestore
+        .document(
+          '/privateUserData/$adminUserId/communityUserSettings/$communityId',
+        )
+        .setData(
+          admin_interop.DocumentData.fromMap(
+            firestoreUtils.toFirestoreJson(
+              CommunityUserSettings(
+                notifyEvents: NotificationEmailType.immediate,
+              ).toJson(),
+            ),
+          ),
+        );
+
+    // Trigger the function
+    await triggerEmailDigests.action(MockEventContext());
+
+    // Verify email was sent
+    verify(() => sendEmailClient.sendEmails(any())).called(1);
+  });
+
+  test('Should not send digest if community has disabled email digests',
+      () async {
+    // Update community settings to disable digests
+    await firestore.document('community/$communityId').setData(
+          admin_interop.DocumentData.fromMap(
+            firestoreUtils.toFirestoreJson(
+              Community(
+                id: communityId,
+                name: 'Testing Community',
+                isPublic: true,
+                communitySettings: const CommunitySettings(
+                  disableEmailDigests: true,
+                ),
+              ).toJson(),
+            ),
+          ),
+        );
+
+    when(
+      () => mockSendEmailClient.sendEmails(any()),
+    ).thenAnswer((_) async => {});
+    final triggerEmailDigests = TriggerEmailDigests(
+      notificationsUtils: mockNotificationsUtils,
+    );
+
+    // Trigger the function
+    await triggerEmailDigests.action(MockEventContext());
+
+    // Verify no emails were sent
+    verify(() => sendEmailClient.sendEmails([])).called(1);
+  });
+
+  test('Should not send digest if user has disabled event notifications',
+      () async {
+    final triggerEmailDigests = TriggerEmailDigests(
+      notificationsUtils: mockNotificationsUtils,
+    );
+
+    var template =
+        const Template(id: templateId, title: 'All the things to discuss');
+
+    template = await eventTestUtils.createTemplate(
+      communityId: communityId,
+      template: template,
+      creatorId: adminUserId,
+    );
+
+    // Create test event
+    final now = DateTime.now();
+    final event = Event(
+      id: '12341234',
+      status: EventStatus.active,
+      communityId: communityId,
+      templateId: templateId,
+      creatorId: adminUserId,
+      nullableEventType: EventType.hosted,
+      collectionPath: '',
+      agendaItems: [],
+      scheduledTime: now.add(const Duration(days: 7)),
+      isPublic: true,
+    );
+
+    await eventTestUtils.createEvent(
+      event: event,
+      userId: adminUserId,
+    );
+
+    // Set user notification preferences to none
+    await firestore
+        .document(
+          '/privateUserData/$memberId/communityUserSettings/$communityId',
+        )
+        .setData(
+          admin_interop.DocumentData.fromMap(
+            firestoreUtils.toFirestoreJson(
+              CommunityUserSettings(
+                notifyEvents: NotificationEmailType.none,
+              ).toJson(),
+            ),
+          ),
+        );
+    await firestore
+        .document(
+          '/privateUserData/$adminUserId/communityUserSettings/$communityId',
+        )
+        .setData(
+          admin_interop.DocumentData.fromMap(
+            firestoreUtils.toFirestoreJson(
+              CommunityUserSettings(
+                notifyEvents: NotificationEmailType.immediate,
+              ).toJson(),
+            ),
+          ),
+        );
+
+    when(
+      () => mockSendEmailClient.sendEmails(any()),
+    ).thenAnswer((_) async => {});
+    when(() => mockNotificationsUtils.getUnsubscribeUrl(userId: adminUserId))
+        .thenReturn('https://example.com/unsubscribe');
+
+    // Mock user record
+    final userRecord = MockUserRecord();
+    when(() => userRecord.uid).thenReturn(memberId);
+    when(() => userRecord.email).thenReturn('member@example.com');
+
+    when(() => mockFirebaseAuthUtils.getUsers([memberId]))
+        .thenAnswer((_) async => [userRecord]);
+
+    final adminRecord = MockUserRecord();
+    when(() => adminRecord.uid).thenReturn(adminUserId);
+    when(() => adminRecord.email).thenReturn('admin@example.com');
+
+    when(() => mockFirebaseAuthUtils.getUsers([adminUserId]))
+        .thenAnswer((_) async => [adminRecord]);
+
+    // Trigger the function
+    await triggerEmailDigests.action(MockEventContext());
+
+    // Verify only one email sent (to admin user)
+    verify(() => sendEmailClient.sendEmails(any(that: hasLength(1)))).called(1);
+  });
+
+  test('Should not send digest if one was recently sent', () async {
+    final triggerEmailDigests = TriggerEmailDigests(
+      notificationsUtils: mockNotificationsUtils,
+    );
+
+    final now = DateTime.now();
+
+    // Create recent digest record
+    await firestore
+        .collection('/privateUserData/$memberId/emailDigests')
+        .document()
+        .setData(
+          admin_interop.DocumentData.fromMap(
+            firestoreUtils.toFirestoreJson(
+              EmailDigestRecord(
+                userId: memberId,
+                communityId: communityId,
+                type: DigestType.weekly,
+                sentAt: now.subtract(const Duration(days: 2)),
+              ).toJson(),
+            ),
+          ),
+        );
+    await firestore
+        .collection('/privateUserData/$adminUserId/emailDigests')
+        .document()
+        .setData(
+          admin_interop.DocumentData.fromMap(
+            firestoreUtils.toFirestoreJson(
+              EmailDigestRecord(
+                userId: memberId,
+                communityId: communityId,
+                type: DigestType.weekly,
+                sentAt: now.subtract(const Duration(days: 2)),
+              ).toJson(),
+            ),
+          ),
+        );
+    var template =
+        const Template(id: templateId, title: 'All the things to discuss');
+
+    template = await eventTestUtils.createTemplate(
+      communityId: communityId,
+      template: template,
+      creatorId: adminUserId,
+    );
+    // Create test event
+    final event = Event(
+      id: '12341234',
+      status: EventStatus.active,
+      communityId: communityId,
+      templateId: templateId,
+      creatorId: adminUserId,
+      nullableEventType: EventType.hosted,
+      collectionPath: '',
+      agendaItems: [],
+      scheduledTime: now.add(const Duration(days: 7)),
+      isPublic: true,
+    );
+
+    await eventTestUtils.createEvent(
+      event: event,
+      userId: adminUserId,
+    );
+    when(
+      () => mockSendEmailClient.sendEmails(any()),
+    ).thenAnswer((_) async => {});
+    when(() => mockNotificationsUtils.getUnsubscribeUrl(userId: adminUserId))
+        .thenReturn('https://example.com/unsubscribe');
+    when(() => mockNotificationsUtils.getUnsubscribeUrl(userId: memberId))
+        .thenReturn('https://example.com/unsubscribe');
+    // Mock user record
+    final userRecord = MockUserRecord();
+    when(() => userRecord.uid).thenReturn(memberId);
+    when(() => userRecord.email).thenReturn('member@example.com');
+
+    when(() => mockFirebaseAuthUtils.getUsers([memberId]))
+        .thenAnswer((_) async => [userRecord]);
+
+    final adminRecord = MockUserRecord();
+    when(() => adminRecord.uid).thenReturn(adminUserId);
+    when(() => adminRecord.email).thenReturn('admin@example.com');
+
+    when(() => mockFirebaseAuthUtils.getUsers([adminUserId]))
+        .thenAnswer((_) async => [adminRecord]);
+
+    // Trigger the function
+    await triggerEmailDigests.action(MockEventContext());
+
+    // Verify no emails were sent
+    verify(() => sendEmailClient.sendEmails([])).called(1);
+  });
+}
+
+class MockEventContext extends Mock implements EventContext {}

--- a/firebase/functions/test/community/trigger_email_digests_test.dart
+++ b/firebase/functions/test/community/trigger_email_digests_test.dart
@@ -17,6 +17,7 @@ import 'package:functions/utils/infra/firestore_utils.dart';
 import '../util/community_test_utils.dart';
 import '../util/email_test_utils.dart';
 import '../util/event_test_utils.dart';
+import '../util/function_test_fixture.dart';
 
 void main() {
   const memberId = 'memberUser';
@@ -30,12 +31,9 @@ void main() {
   sendEmailClient = mockSendEmailClient;
   final communityTestUtils = CommunityTestUtils();
   final eventTestUtils = EventTestUtils();
+  setupTestFixture();
 
   setUp(() async {
-    setFirebaseAppFactory(
-      () => admin_interop.FirebaseAdmin.instance.initializeApp()!,
-    );
-    await communityTestUtils.deleteAllCommunities();
     // Create test community
     final communityResult = await communityTestUtils.createCommunity(
       community: Community(
@@ -56,15 +54,6 @@ void main() {
       userId: memberId,
       status: MembershipStatus.member,
     );
-
-    // Reset mocks
-    reset(mockSendEmailClient);
-    reset(mockNotificationsUtils);
-    reset(mockFirebaseAuthUtils);
-  });
-
-  tearDown(() async {
-    resetMocktailState();
   });
 
   test('Should send digest emails for upcoming events to subscribed members',

--- a/firebase/functions/test/community/trigger_email_digests_test.dart
+++ b/firebase/functions/test/community/trigger_email_digests_test.dart
@@ -21,7 +21,6 @@ import '../util/function_test_fixture.dart';
 
 void main() {
   const memberId = 'memberUser';
-  const adminUserId = 'adminUser';
   const templateId = '123777';
   String communityId = '';
   final mockFirebaseAuthUtils = MockFirebaseAuthUtils();

--- a/firebase/functions/test/community/unsubscribe_from_community_notifications_test.dart
+++ b/firebase/functions/test/community/unsubscribe_from_community_notifications_test.dart
@@ -15,24 +15,13 @@ import '../util/function_test_fixture.dart';
 
 void main() {
   const testUserId = 'testUser123';
-  const adminUserId = 'admin1';
-  String testCommunityId1 = 'community1';
-  String testCommunityId2 = 'community2';
   final mockNotificationsUtils = MockNotificationsUtils();
   final communityTestUtils = CommunityTestUtils();
   setupTestFixture();
 
   test('Should unsubscribe user from all community notifications', () async {
     // Create test community
-    final communityResult = await communityTestUtils.createCommunity(
-      community: Community(
-        id: '19921239',
-        name: 'Testing Community',
-        isPublic: true,
-      ),
-      userId: adminUserId,
-    );
-    testCommunityId1 = communityResult['communityId'];
+    final testCommunityId1 = await communityTestUtils.createTestCommunity();
 
     // Add regular member
     await communityTestUtils.addCommunityMember(
@@ -48,7 +37,7 @@ void main() {
       ),
       userId: adminUserId,
     );
-    testCommunityId2 = community2Result['communityId'];
+    final testCommunityId2 = community2Result['communityId'];
     // Add regular member
     await communityTestUtils.addCommunityMember(
       communityId: testCommunityId2,

--- a/firebase/functions/test/community/unsubscribe_from_community_notifications_test.dart
+++ b/firebase/functions/test/community/unsubscribe_from_community_notifications_test.dart
@@ -1,0 +1,160 @@
+import 'package:data_models/community/community.dart';
+import 'package:data_models/community/community_user_settings.dart';
+import 'package:data_models/community/membership.dart';
+import 'package:firebase_functions_interop/firebase_functions_interop.dart';
+import 'package:functions/utils/infra/firestore_utils.dart';
+import 'package:functions/utils/notifications_utils.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+import 'package:data_models/cloud_functions/requests.dart';
+import 'package:functions/community/unsubscribe_from_community_notifications.dart';
+import 'package:firebase_admin_interop/firebase_admin_interop.dart'
+    as admin_interop;
+
+import '../util/community_test_utils.dart';
+import '../util/email_test_utils.dart';
+
+void main() {
+  const testUserId = 'testUser123';
+  const adminUserId = 'admin1';
+  String testCommunityId1 = 'community1';
+  String testCommunityId2 = 'community2';
+  final mockNotificationsUtils = MockNotificationsUtils();
+  final communityTestUtils = CommunityTestUtils();
+
+  setUp(() async {
+    setFirebaseAppFactory(
+      () => admin_interop.FirebaseAdmin.instance.initializeApp()!,
+    );
+  });
+
+  tearDown(() {
+    resetMocktailState();
+  });
+
+  test('Should unsubscribe user from all community notifications', () async {
+    // Create test community
+    final communityResult = await communityTestUtils.createCommunity(
+      community: Community(
+        id: '19921239',
+        name: 'Testing Community',
+        isPublic: true,
+      ),
+      userId: adminUserId,
+    );
+    testCommunityId1 = communityResult['communityId'];
+
+    // Add regular member
+    await communityTestUtils.addCommunityMember(
+      communityId: testCommunityId1,
+      userId: testUserId,
+      status: MembershipStatus.member,
+    );
+    final community2Result = await communityTestUtils.createCommunity(
+      community: Community(
+        id: '199212393333',
+        name: 'Another Testing Community',
+        isPublic: true,
+      ),
+      userId: adminUserId,
+    );
+    testCommunityId2 = community2Result['communityId'];
+    // Add regular member
+    await communityTestUtils.addCommunityMember(
+      communityId: testCommunityId2,
+      userId: testUserId,
+      status: MembershipStatus.member,
+    );
+
+    final mockUnsubscribeData = UnsubscribeData(testUserId);
+
+    // Setup mock response for encrypted data
+    when(
+      () => mockNotificationsUtils.decryptUnsubscribeData('encrypted_data'),
+    ).thenReturn(mockUnsubscribeData);
+
+    // Execute the function
+    final unsubscribe = UnsubscribeFromCommunityNotifications(
+      notificationsUtils: mockNotificationsUtils,
+    );
+
+    final req = UnsubscribeFromCommunityNotificationsRequest(
+      data: 'encrypted_data',
+    );
+
+    await unsubscribe.action(
+      req,
+      CallableContext(adminUserId, null, 'fakeInstanceId'),
+    );
+
+    // Verify results
+    for (final communityId in [testCommunityId1, testCommunityId2]) {
+      final settingsDoc = await firestore
+          .document(
+            'privateUserData/$testUserId/communityUserSettings/$communityId',
+          )
+          .get();
+
+      final settings = CommunityUserSettings.fromJson(
+        firestoreUtils.fromFirestoreJson(settingsDoc.data.toMap()),
+      );
+
+      expect(settings.notifyAnnouncements, equals(NotificationEmailType.none));
+      expect(settings.notifyEvents, equals(NotificationEmailType.none));
+      expect(settings.userId, equals(testUserId));
+      expect(settings.communityId, equals(communityId));
+    }
+
+    // Verify notifications utils was called correctly
+    verify(
+      () => mockNotificationsUtils.decryptUnsubscribeData('encrypted_data'),
+    ).called(1);
+  });
+
+  test('Should handle user with no community memberships', () async {
+    final mockUnsubscribeData = UnsubscribeData('nonMemberUser');
+
+    when(
+      () => mockNotificationsUtils.decryptUnsubscribeData('encrypted_data'),
+    ).thenReturn(mockUnsubscribeData);
+
+    final unsubscribe = UnsubscribeFromCommunityNotifications(
+      notificationsUtils: mockNotificationsUtils,
+    );
+
+    final req = UnsubscribeFromCommunityNotificationsRequest(
+      data: 'encrypted_data',
+    );
+
+    // Should complete without error
+    await expectLater(
+      unsubscribe.action(
+        req,
+        CallableContext('nonMemberUser', null, 'fakeInstanceId'),
+      ),
+      completes,
+    );
+  });
+
+  test('Should handle invalid encrypted data', () async {
+    when(
+      () => mockNotificationsUtils.decryptUnsubscribeData('invalid_data'),
+    ).thenThrow(Exception('Invalid encrypted data'));
+
+    final unsubscribe = UnsubscribeFromCommunityNotifications(
+      notificationsUtils: mockNotificationsUtils,
+    );
+
+    final req = UnsubscribeFromCommunityNotificationsRequest(
+      data: 'invalid_data',
+    );
+
+    expect(
+      () async => await unsubscribe.action(
+        req,
+        CallableContext(testUserId, null, 'fakeInstanceId'),
+      ),
+      throwsException,
+    );
+  });
+}

--- a/firebase/functions/test/community/unsubscribe_from_community_notifications_test.dart
+++ b/firebase/functions/test/community/unsubscribe_from_community_notifications_test.dart
@@ -8,11 +8,10 @@ import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 import 'package:data_models/cloud_functions/requests.dart';
 import 'package:functions/community/unsubscribe_from_community_notifications.dart';
-import 'package:firebase_admin_interop/firebase_admin_interop.dart'
-    as admin_interop;
 
 import '../util/community_test_utils.dart';
 import '../util/email_test_utils.dart';
+import '../util/function_test_fixture.dart';
 
 void main() {
   const testUserId = 'testUser123';
@@ -21,16 +20,7 @@ void main() {
   String testCommunityId2 = 'community2';
   final mockNotificationsUtils = MockNotificationsUtils();
   final communityTestUtils = CommunityTestUtils();
-
-  setUp(() async {
-    setFirebaseAppFactory(
-      () => admin_interop.FirebaseAdmin.instance.initializeApp()!,
-    );
-  });
-
-  tearDown(() {
-    resetMocktailState();
-  });
+  setupTestFixture();
 
   test('Should unsubscribe user from all community notifications', () async {
     // Create test community

--- a/firebase/functions/test/community/update_community_test.dart
+++ b/firebase/functions/test/community/update_community_test.dart
@@ -1,140 +1,112 @@
+import 'package:data_models/community/membership.dart';
 import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 import 'package:data_models/events/event.dart';
 import 'package:data_models/community/community.dart';
-import 'package:data_models/community/membership.dart';
+import 'package:functions/community/update_community.dart';
 import 'package:test/test.dart';
-import 'package:functions/community/create_community.dart';
 import 'package:data_models/cloud_functions/requests.dart';
 import 'package:functions/utils/infra/firestore_utils.dart';
 import 'package:firebase_admin_interop/firebase_admin_interop.dart';
 
+import '../util/community_test_utils.dart';
+import '../util/subscription_test_utils.dart';
+
 void main() {
+  const userId = 'fakeAuthId';
+  String communityId = '';
+  final communityTestUtils = CommunityTestUtils();
+  final subscriptionTestUtils = SubscriptionTestUtils();
+
   setUp(() async {
     setFirebaseAppFactory(() => FirebaseAdmin.instance.initializeApp()!);
-  });
-
-  test('Community should be created without partner agreement', () async {
-    const userId = 'fakeAuthId';
-    final communityCreator = CreateCommunity();
-    final testCommunity = Community(
-      id: '1234',
+    Community testCommunity = Community(
+      id: '1999',
       name: 'Testing Community',
       isPublic: true,
       profileImageUrl: 'http://someimage.com',
       bannerImageUrl: 'http://mybanner.com',
     );
-    final req = CreateCommunityRequest(community: testCommunity);
-    final result = await communityCreator.action(
-      req,
-      CallableContext(userId, null, 'fakeInstanceId'),
-    );
-    expect(result, contains('communityId'));
-    final communityId = result['communityId'];
-    final communitySnapshot =
-        await firestore.document('community/$communityId').get();
-    final createdCommunity = Community.fromJson(
-      firestoreUtils.fromFirestoreJson(communitySnapshot.data.toMap()),
-    );
 
-    final expectedCommunity = testCommunity.copyWith(
-      id: communityId,
-      creatorId: userId,
-      communitySettings: const CommunitySettings(),
-      eventSettings: EventSettings.defaultSettings,
-      createdDate: createdCommunity.createdDate,
-      displayIds: [communityId],
-    );
-
-    expect(createdCommunity, equals(expectedCommunity));
-    final membershipSnapshot = await firestore
-        .document('memberships/fakeAuthId/community-membership/$communityId')
-        .get();
-    final createdMembership = Membership.fromJson(
-      firestoreUtils.fromFirestoreJson(membershipSnapshot.data.toMap()),
-    );
-    expect(
-      createdMembership,
-      equals(
-        Membership(
-          communityId: communityId,
-          userId: userId,
-          status: MembershipStatus.owner,
-          firstJoined: createdMembership.firstJoined,
-        ),
-      ),
-    );
-    // add verification of partner agreement when default partner agreement info added to firestore
-  });
-
-  test('Community should be created under existing partner agreement',
-      () async {
-    // Implement this when default partner agreement info added to firestore
-  });
-
-  test('Community should be created with default image URLs', () async {
-    const userId = 'fakeAuthId';
-    final communityCreator = CreateCommunity();
-    final testCommunity =
-        Community(id: '1234', name: 'Testing Community', isPublic: true);
-    final req = CreateCommunityRequest(community: testCommunity);
-    final result = await communityCreator.action(
-      req,
-      CallableContext(userId, null, 'fakeInstanceId'),
-    );
-    expect(result, contains('communityId'));
-    final communityId = result['communityId'];
-    final communitySnapshot =
-        await firestore.document('community/$communityId').get();
-    final createdCommunity = Community.fromJson(
-      firestoreUtils.fromFirestoreJson(communitySnapshot.data.toMap()),
-    );
-
-    final expectedCommunity = testCommunity.copyWith(
-      id: communityId,
-      creatorId: userId,
-      communitySettings: const CommunitySettings(),
-      eventSettings: EventSettings.defaultSettings,
-      createdDate: createdCommunity.createdDate,
-      profileImageUrl: 'https://picsum.photos/seed/$communityId-profile/512',
-      bannerImageUrl: '',
-      displayIds: [communityId],
-    );
-
-    expect(createdCommunity, equals(expectedCommunity));
-    final membershipSnapshot = await firestore
-        .document('memberships/fakeAuthId/community-membership/$communityId')
-        .get();
-    final createdMembership = Membership.fromJson(
-      firestoreUtils.fromFirestoreJson(membershipSnapshot.data.toMap()),
-    );
-    expect(
-      createdMembership,
-      equals(
-        Membership(
-          communityId: communityId,
-          userId: userId,
-          status: MembershipStatus.owner,
-          firstJoined: createdMembership.firstJoined,
-        ),
-      ),
-    );
-  });
-
-  test('Exception should be thrown if specified partner agreement not found',
-      () async {
-    const userId = 'fakeAuthId';
-    final communityCreator = CreateCommunity();
-    final testCommunity =
-        Community(id: '1234', name: 'Testing Community', isPublic: true);
-    final req = CreateCommunityRequest(
+    final communityResult = await communityTestUtils.createCommunity(
       community: testCommunity,
-      agreementId: 'fakeagreement',
+      userId: userId,
     );
+    communityId = communityResult['communityId'];
+  });
+
+  test('Community should be updated', () async {
+    final communityUpdater = UpdateCommunity();
+    final testCommunity = Community(
+      id: communityId,
+      name: 'Testing Community Too',
+      isPublic: false,
+      description: 'A community of testers',
+      tagLine: 'Test It!',
+    );
+    final req = UpdateCommunityRequest(
+      community: testCommunity,
+      keys: [
+        Community.kFieldName,
+        Community.kFieldTagLine,
+        Community.kFieldDescription,
+      ],
+    );
+    final result = await communityUpdater.action(
+      req,
+      CallableContext(userId, null, 'fakeInstanceId'),
+    );
+    expect(result, equals(''));
+
+    final communitySnapshot =
+        await firestore.document('community/$communityId').get();
+    final updatedCommunity = Community.fromJson(
+      firestoreUtils.fromFirestoreJson(communitySnapshot.data.toMap()),
+    );
+
+    final expectedCommunity = testCommunity.copyWith(
+      id: communityId,
+      creatorId: userId,
+      isPublic: true,
+      communitySettings: const CommunitySettings(),
+      eventSettings: EventSettings.defaultSettings,
+      createdDate: updatedCommunity.createdDate,
+      displayIds: [communityId],
+      profileImageUrl: 'http://someimage.com',
+      bannerImageUrl: 'http://mybanner.com',
+    );
+
+    expect(updatedCommunity, equals(expectedCommunity));
+  });
+
+  test('Error thrown when request made by non-admin', () async {
+    final communityUpdater = UpdateCommunity();
+    final testCommunity = Community(
+      id: communityId,
+      name: 'Testing Community Too',
+      isPublic: false,
+      description: 'A community of testers',
+      tagLine: 'Test It!',
+    );
+    final req = UpdateCommunityRequest(
+      community: testCommunity,
+      keys: [
+        Community.kFieldName,
+        Community.kFieldTagLine,
+        Community.kFieldDescription,
+      ],
+    );
+    const memberId = '932';
+    await communityTestUtils.addCommunityMember(
+      communityId: communityId,
+      userId: memberId,
+      status: MembershipStatus.member,
+    );
+
     expect(
       () async {
-        await communityCreator.action(
+        await communityUpdater.action(
           req,
-          CallableContext(userId, null, 'fakeInstanceId'),
+          CallableContext(memberId, null, 'fakeInstanceId'),
         );
       },
       throwsA(
@@ -148,36 +120,23 @@ void main() {
     );
   });
 
-  test('Exception should be thrown if no community specified', () async {
-    const userId = 'fakeAuthId';
-    final communityCreator = CreateCommunity();
-    final req = CreateCommunityRequest(community: null);
-    expect(
-      () async {
-        await communityCreator.action(
-          req,
-          CallableContext(userId, null, 'fakeInstanceId'),
-        );
-      },
-      throwsA(
-        predicate(
-          (e) =>
-              e is HttpsError &&
-              e.code == HttpsError.failedPrecondition &&
-              e.message == 'Must provide community information.',
-        ),
-      ),
+  test('Error thrown when community name is not specified', () async {
+    final communityUpdater = UpdateCommunity();
+    final testCommunity = Community(
+      id: communityId,
+      isPublic: false,
+      name: '',
+      description: 'A community of testers',
+      tagLine: 'Test It!',
     );
-  });
+    final req = UpdateCommunityRequest(
+      community: testCommunity,
+      keys: [Community.kFieldTagLine, Community.kFieldDescription],
+    );
 
-  test('Exception should be thrown if community name not specified', () async {
-    const userId = 'fakeAuthId';
-    final communityCreator = CreateCommunity();
-    final testCommunity = Community(id: '1234', isPublic: true);
-    final req = CreateCommunityRequest(community: testCommunity);
     expect(
       () async {
-        await communityCreator.action(
+        await communityUpdater.action(
           req,
           CallableContext(userId, null, 'fakeInstanceId'),
         );
@@ -193,15 +152,135 @@ void main() {
     );
   });
 
-  test('Exception should be thrown if request unauthorized', () async {
-    final communityCreator = CreateCommunity();
-    final testCommunity = Community(id: '1234', isPublic: true);
-    final req = CreateCommunityRequest(community: testCommunity);
+  group("Unrestricted plan capabilities tests", () {
+    setUp(() async {
+      await subscriptionTestUtils.addUnrestrictedPlanCapabilities(
+        planCapabilities: SubscriptionTestUtils.unrestrictedPlan,
+      );
+    });
+
+    tearDown(() async {
+      await subscriptionTestUtils.removeUnrestrictedPlanCapabilities();
+    });
+
+    test('Error thrown when display name already in use', () async {
+      Community testCommunity2 = Community(
+        id: '1939',
+        name: 'Testing Community Number Two',
+        isPublic: true,
+        profileImageUrl: 'http://someimage.com',
+        bannerImageUrl: 'http://mybanner.com',
+      );
+
+      final secondCommResult = await communityTestUtils.createCommunity(
+        community: testCommunity2,
+        userId: userId,
+      );
+      final secondCommunityId = secondCommResult['communityId'];
+      final communityUpdater = UpdateCommunity();
+      testCommunity2 = Community(
+        id: secondCommunityId,
+        name: 'Testing Community Number Two',
+        isPublic: true,
+        profileImageUrl: 'http://someimage.com',
+        bannerImageUrl: 'http://mybanner.com',
+        displayIds: ['testing', 'tester', 'testy'],
+      );
+      final req = UpdateCommunityRequest(
+        community: testCommunity2,
+        keys: [Community.kFieldDisplayIds],
+      );
+      await communityUpdater.action(
+        req,
+        CallableContext(userId, null, 'fakeInstanceId'),
+      );
+      final testCommunity = Community(
+        id: communityId,
+        name: 'Testing Community',
+        isPublic: false,
+        displayIds: ['tested', 'testy'],
+        description: 'A community of testers',
+        tagLine: 'Test It!',
+      );
+      final req2 = UpdateCommunityRequest(
+        community: testCommunity,
+        keys: [Community.kFieldDisplayIds],
+      );
+
+      expect(
+        () async {
+          await communityUpdater.action(
+            req2,
+            CallableContext(userId, null, 'fakeInstanceId'),
+          );
+        },
+        throwsA(
+          predicate(
+            (e) =>
+                e is HttpsError &&
+                e.code == HttpsError.failedPrecondition &&
+                e.message == 'The URL display name testy is already taken.',
+          ),
+        ),
+      );
+    });
+    test('Display IDs updated when custom URLs allowed', () async {
+      final communityUpdater = UpdateCommunity();
+      final Community testCommunity = Community(
+        id: communityId,
+        name: 'Testing Community',
+        isPublic: true,
+        profileImageUrl: 'http://someimage.com',
+        bannerImageUrl: 'http://mybanner.com',
+        displayIds: ['testing-community'],
+      );
+      final req = UpdateCommunityRequest(
+        community: testCommunity,
+        keys: [
+          Community.kFieldDisplayIds,
+        ],
+      );
+      final result = await communityUpdater.action(
+        req,
+        CallableContext(userId, null, 'fakeInstanceId'),
+      );
+      expect(result, equals(''));
+
+      final communitySnapshot =
+          await firestore.document('community/$communityId').get();
+      final updatedCommunity = Community.fromJson(
+        firestoreUtils.fromFirestoreJson(communitySnapshot.data.toMap()),
+      );
+
+      expect(
+        updatedCommunity.displayIds,
+        unorderedEquals(
+          [communityId, communityId.toLowerCase(), 'testing-community'],
+        ),
+      );
+    });
+  });
+
+  test('Error thrown when no allowed update fields specified', () async {
+    final communityUpdater = UpdateCommunity();
+    final testCommunity = Community(
+      id: communityId,
+      isPublic: false,
+      name: 'Testing Community Too',
+      description: 'A community of testers',
+      createdDate: DateTime.now(),
+      tagLine: 'Test It!',
+    );
+    final req = UpdateCommunityRequest(
+      community: testCommunity,
+      keys: [Community.kFieldCreatedDate],
+    );
+
     expect(
       () async {
-        await communityCreator.action(
+        await communityUpdater.action(
           req,
-          CallableContext(null, null, 'fakeInstanceId'),
+          CallableContext(userId, null, 'fakeInstanceId'),
         );
       },
       throwsA(
@@ -209,7 +288,7 @@ void main() {
           (e) =>
               e is HttpsError &&
               e.code == HttpsError.failedPrecondition &&
-              e.message == 'unauthorized',
+              e.message == 'No fields to update',
         ),
       ),
     );

--- a/firebase/functions/test/community/update_membership_test.dart
+++ b/firebase/functions/test/community/update_membership_test.dart
@@ -1,6 +1,5 @@
 import 'package:data_models/community/membership.dart';
 import 'package:firebase_functions_interop/firebase_functions_interop.dart';
-import 'package:data_models/community/community.dart';
 import 'package:functions/community/update_membership.dart';
 import 'package:functions/utils/subscription_plan_util.dart';
 import 'package:mocktail/mocktail.dart';
@@ -13,28 +12,15 @@ import '../util/function_test_fixture.dart';
 import '../util/subscription_test_utils.dart';
 
 void main() {
-  const ownerId = 'ownerUserId';
   const adminId = 'adminUserId';
   const memberId = 'memberUserId';
   const member2Id = 'memberUser2Id';
   String communityId = '';
   final communityTestUtils = CommunityTestUtils();
-  final subscriptionTestUtils = SubscriptionTestUtils();
   setupTestFixture();
 
   setUp(() async {
-    Community testCommunity = Community(
-      id: '19999999',
-      name: 'Testing Community',
-      isPublic: true,
-      creatorId: ownerId,
-    );
-
-    final communityResult = await communityTestUtils.createCommunity(
-      community: testCommunity,
-      userId: ownerId,
-    );
-    communityId = communityResult['communityId'];
+    communityId = await communityTestUtils.createTestCommunity();
 
     // Set up initial memberships
     await communityTestUtils.addCommunityMember(
@@ -64,7 +50,7 @@ void main() {
 
     await membershipUpdater.action(
       req,
-      CallableContext(ownerId, null, 'fakeInstanceId'),
+      CallableContext(adminUserId, null, 'fakeInstanceId'),
     );
 
     final membershipSnapshot = await firestore
@@ -103,7 +89,7 @@ void main() {
     final membershipUpdater = UpdateMembership();
     final req = UpdateMembershipRequest(
       communityId: communityId,
-      userId: ownerId,
+      userId: adminUserId,
       status: MembershipStatus.admin,
     );
 
@@ -186,7 +172,7 @@ void main() {
         () async {
           await membershipUpdater.action(
             req,
-            CallableContext(ownerId, null, 'fakeInstanceId'),
+            CallableContext(adminUserId, null, 'fakeInstanceId'),
           );
         },
         throwsA(
@@ -209,7 +195,7 @@ void main() {
       );
       await membershipUpdater.action(
         req,
-        CallableContext(ownerId, null, 'fakeInstanceId'),
+        CallableContext(adminUserId, null, 'fakeInstanceId'),
       );
 
       final req2 = UpdateMembershipRequest(
@@ -222,7 +208,7 @@ void main() {
         () async {
           await membershipUpdater.action(
             req2,
-            CallableContext(ownerId, null, 'fakeInstanceId'),
+            CallableContext(adminUserId, null, 'fakeInstanceId'),
           );
         },
         throwsA(

--- a/firebase/functions/test/community/update_membership_test.dart
+++ b/firebase/functions/test/community/update_membership_test.dart
@@ -1,0 +1,270 @@
+import 'package:data_models/community/membership.dart';
+import 'package:firebase_functions_interop/firebase_functions_interop.dart';
+import 'package:data_models/community/community.dart';
+import 'package:functions/community/update_membership.dart';
+import 'package:test/test.dart';
+import 'package:data_models/cloud_functions/requests.dart';
+import 'package:functions/utils/infra/firestore_utils.dart';
+import 'package:firebase_admin_interop/firebase_admin_interop.dart';
+
+import '../util/community_test_utils.dart';
+import '../util/subscription_test_utils.dart';
+
+void main() {
+  const ownerId = 'ownerUserId';
+  const adminId = 'adminUserId';
+  const memberId = 'memberUserId';
+  const member2Id = 'memberUser2Id';
+  String communityId = '';
+  final communityTestUtils = CommunityTestUtils();
+  final subscriptionTestUtils = SubscriptionTestUtils();
+
+  setUp(() async {
+    setFirebaseAppFactory(() => FirebaseAdmin.instance.initializeApp()!);
+    Community testCommunity = Community(
+      id: '19999999',
+      name: 'Testing Community',
+      isPublic: true,
+      creatorId: ownerId,
+    );
+
+    final communityResult = await communityTestUtils.createCommunity(
+      community: testCommunity,
+      userId: ownerId,
+    );
+    communityId = communityResult['communityId'];
+
+    // Set up initial memberships
+    await communityTestUtils.addCommunityMember(
+      communityId: communityId,
+      userId: adminId,
+      status: MembershipStatus.admin,
+    );
+    await communityTestUtils.addCommunityMember(
+      communityId: communityId,
+      userId: memberId,
+      status: MembershipStatus.member,
+    );
+    await communityTestUtils.addCommunityMember(
+      communityId: communityId,
+      userId: member2Id,
+      status: MembershipStatus.member,
+    );
+  });
+
+  group('Default quota tests', () {
+    setUp(() async {
+      // Set up subscription plan with limited admin quota
+      await subscriptionTestUtils.addUnrestrictedPlanCapabilities(
+        planCapabilities: SubscriptionTestUtils.unrestrictedPlan,
+      );
+    });
+
+    tearDown(() async {
+      await subscriptionTestUtils.removeUnrestrictedPlanCapabilities();
+    });
+
+    test('Owner should be able to promote member to admin', () async {
+      final membershipUpdater = UpdateMembership();
+      final req = UpdateMembershipRequest(
+        communityId: communityId,
+        userId: memberId,
+        status: MembershipStatus.admin,
+      );
+
+      await membershipUpdater.action(
+        req,
+        CallableContext(ownerId, null, 'fakeInstanceId'),
+      );
+
+      final membershipSnapshot = await firestore
+          .document('memberships/$memberId/community-membership/$communityId')
+          .get();
+      final updatedMembership = Membership.fromJson(
+        firestoreUtils.fromFirestoreJson(membershipSnapshot.data.toMap()),
+      );
+
+      expect(updatedMembership.status, equals(MembershipStatus.admin));
+    });
+    test('Admin should be able to promote member to mod', () async {
+      final membershipUpdater = UpdateMembership();
+      final req = UpdateMembershipRequest(
+        communityId: communityId,
+        userId: memberId,
+        status: MembershipStatus.mod,
+      );
+
+      await membershipUpdater.action(
+        req,
+        CallableContext(adminId, null, 'fakeInstanceId'),
+      );
+
+      final membershipSnapshot = await firestore
+          .document('memberships/$memberId/community-membership/$communityId')
+          .get();
+      final updatedMembership = Membership.fromJson(
+        firestoreUtils.fromFirestoreJson(membershipSnapshot.data.toMap()),
+      );
+
+      expect(updatedMembership.status, equals(MembershipStatus.mod));
+    });
+  });
+
+  test('Admin should not be able to modify owner status', () async {
+    final membershipUpdater = UpdateMembership();
+    final req = UpdateMembershipRequest(
+      communityId: communityId,
+      userId: ownerId,
+      status: MembershipStatus.admin,
+    );
+
+    expect(
+      () async {
+        await membershipUpdater.action(
+          req,
+          CallableContext(adminId, null, 'fakeInstanceId'),
+        );
+      },
+      throwsA(
+        predicate(
+          (e) =>
+              e is HttpsError &&
+              e.code == HttpsError.failedPrecondition &&
+              e.message == 'unauthorized',
+        ),
+      ),
+    );
+  });
+
+  test('Regular member should not be able to promote others', () async {
+    final membershipUpdater = UpdateMembership();
+    const newMemberId = 'newMemberId';
+    await communityTestUtils.addCommunityMember(
+      communityId: communityId,
+      userId: newMemberId,
+      status: MembershipStatus.member,
+    );
+
+    final req = UpdateMembershipRequest(
+      communityId: communityId,
+      userId: newMemberId,
+      status: MembershipStatus.admin,
+    );
+
+    expect(
+      () async {
+        await membershipUpdater.action(
+          req,
+          CallableContext(memberId, null, 'fakeInstanceId'),
+        );
+      },
+      throwsA(
+        predicate(
+          (e) =>
+              e is HttpsError &&
+              e.code == HttpsError.failedPrecondition &&
+              e.message == 'unauthorized',
+        ),
+      ),
+    );
+  });
+
+  group('Quota tests', () {
+    setUp(() async {
+      // Set up subscription plan with limited admin and facilitator quotas
+      await subscriptionTestUtils.addUnrestrictedPlanCapabilities(
+        planCapabilities: SubscriptionTestUtils.unrestrictedPlanWithQuotas,
+      );
+    });
+
+    tearDown(() async {
+      await subscriptionTestUtils.removeUnrestrictedPlanCapabilities();
+    });
+
+    test('Should fail when exceeding admin quota', () async {
+      // Already have owner and one admin, try to add another
+      final membershipUpdater = UpdateMembership();
+      final req = UpdateMembershipRequest(
+        communityId: communityId,
+        userId: memberId,
+        status: MembershipStatus.admin,
+      );
+
+      expect(
+        () async {
+          await membershipUpdater.action(
+            req,
+            CallableContext(ownerId, null, 'fakeInstanceId'),
+          );
+        },
+        throwsA(
+          predicate(
+            (e) =>
+                e is HttpsError &&
+                e.code == HttpsError.resourceExhausted &&
+                e.message == 'Insufficient admin count quota.',
+          ),
+        ),
+      );
+    });
+    test('Should fail when exceeding faciliator quota', () async {
+      // Make one member a facilitator
+      final membershipUpdater = UpdateMembership();
+      final req = UpdateMembershipRequest(
+        communityId: communityId,
+        userId: memberId,
+        status: MembershipStatus.facilitator,
+      );
+      await membershipUpdater.action(
+        req,
+        CallableContext(ownerId, null, 'fakeInstanceId'),
+      );
+
+      final req2 = UpdateMembershipRequest(
+        communityId: communityId,
+        userId: member2Id,
+        status: MembershipStatus.facilitator,
+      );
+
+      expect(
+        () async {
+          await membershipUpdater.action(
+            req2,
+            CallableContext(ownerId, null, 'fakeInstanceId'),
+          );
+        },
+        throwsA(
+          predicate(
+            (e) =>
+                e is HttpsError &&
+                e.code == HttpsError.resourceExhausted &&
+                e.message == 'Insufficient facilitator count quota.',
+          ),
+        ),
+      );
+    });
+  });
+
+  test('Member should be able to leave community', () async {
+    final membershipUpdater = UpdateMembership();
+    final req = UpdateMembershipRequest(
+      communityId: communityId,
+      userId: memberId,
+      status: MembershipStatus.nonmember,
+    );
+
+    await membershipUpdater.action(
+      req,
+      CallableContext(memberId, null, 'fakeInstanceId'),
+    );
+
+    final membershipSnapshot = await firestore
+        .document('memberships/$memberId/community-membership/$communityId')
+        .get();
+    final updatedMembership = Membership.fromJson(
+      firestoreUtils.fromFirestoreJson(membershipSnapshot.data.toMap()),
+    );
+
+    expect(updatedMembership.status, equals(MembershipStatus.nonmember));
+  });
+}

--- a/firebase/functions/test/events/calendar/calendar_feed_ics_test.dart
+++ b/firebase/functions/test/events/calendar/calendar_feed_ics_test.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 import 'package:data_models/events/event.dart';
-import 'package:data_models/community/community.dart';
 import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 import 'package:functions/events/calendar/calendar_feed_ics.dart';
 import 'package:mocktail/mocktail.dart';
@@ -10,27 +9,14 @@ import '../../util/event_test_utils.dart';
 import '../../util/function_test_fixture.dart';
 
 void main() {
-  String communityId = '';
-  const userId = 'fakeAuthId';
+  late String communityId;
   const templateId = '9654988';
   final communityTestUtils = CommunityTestUtils();
   final eventTestUtils = EventTestUtils();
   setupTestFixture();
 
   setUp(() async {
-    final testCommunity = Community(
-      id: '2921159966669',
-      name: 'Testing Community',
-      isPublic: true,
-      profileImageUrl: 'http://someimage.com',
-      bannerImageUrl: 'http://mybanner.com',
-    );
-
-    final communityResult = await communityTestUtils.createCommunity(
-      community: testCommunity,
-      userId: userId,
-    );
-    communityId = communityResult['communityId'];
+    communityId = await communityTestUtils.createTestCommunity();
   });
 
   test('ICS calendar feed generated', () async {
@@ -40,7 +26,7 @@ void main() {
       status: EventStatus.active,
       communityId: communityId,
       templateId: templateId,
-      creatorId: userId,
+      creatorId: adminUserId,
       nullableEventType: EventType.hosted,
       collectionPath: '',
       isPublic: true,
@@ -55,7 +41,7 @@ void main() {
     );
     event = await eventTestUtils.createEvent(
       event: event,
-      userId: userId,
+      userId: adminUserId,
     );
 
     registerFallbackValue(event);

--- a/firebase/functions/test/events/calendar/calendar_feed_ics_test.dart
+++ b/firebase/functions/test/events/calendar/calendar_feed_ics_test.dart
@@ -5,11 +5,9 @@ import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 import 'package:functions/events/calendar/calendar_feed_ics.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
-import 'package:functions/utils/infra/firestore_utils.dart';
-import 'package:firebase_admin_interop/firebase_admin_interop.dart'
-    hide EventType;
 import '../../util/community_test_utils.dart';
 import '../../util/event_test_utils.dart';
+import '../../util/function_test_fixture.dart';
 
 void main() {
   String communityId = '';
@@ -17,10 +15,9 @@ void main() {
   const templateId = '9654988';
   final communityTestUtils = CommunityTestUtils();
   final eventTestUtils = EventTestUtils();
+  setupTestFixture();
 
   setUp(() async {
-    setFirebaseAppFactory(() => FirebaseAdmin.instance.initializeApp()!);
-
     final testCommunity = Community(
       id: '2921159966669',
       name: 'Testing Community',

--- a/firebase/functions/test/events/calendar/calendar_feed_rss_test.dart
+++ b/firebase/functions/test/events/calendar/calendar_feed_rss_test.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 import 'package:data_models/events/event.dart';
-import 'package:data_models/community/community.dart';
 import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 import 'package:functions/events/calendar/calendar_feed_rss.dart';
 import 'package:mocktail/mocktail.dart';
@@ -10,27 +9,14 @@ import '../../util/event_test_utils.dart';
 import '../../util/function_test_fixture.dart';
 
 void main() {
-  String communityId = '';
-  const userId = 'fakeAuthId';
+  late String communityId;
   const templateId = '9654988';
   final communityTestUtils = CommunityTestUtils();
   final eventTestUtils = EventTestUtils();
   setupTestFixture();
 
   setUp(() async {
-    final testCommunity = Community(
-      id: '2921159966669',
-      name: 'Testing Community',
-      isPublic: true,
-      profileImageUrl: 'http://someimage.com',
-      bannerImageUrl: 'http://mybanner.com',
-    );
-
-    final communityResult = await communityTestUtils.createCommunity(
-      community: testCommunity,
-      userId: userId,
-    );
-    communityId = communityResult['communityId'];
+    communityId = await communityTestUtils.createTestCommunity();
   });
 
   test('RSS calendar feed generated', () async {
@@ -40,7 +26,7 @@ void main() {
       status: EventStatus.active,
       communityId: communityId,
       templateId: templateId,
-      creatorId: userId,
+      creatorId: adminUserId,
       nullableEventType: EventType.hosted,
       collectionPath: '',
       isPublic: true,
@@ -55,7 +41,7 @@ void main() {
     );
     event = await eventTestUtils.createEvent(
       event: event,
-      userId: userId,
+      userId: adminUserId,
     );
 
     registerFallbackValue(event);

--- a/firebase/functions/test/events/calendar/calendar_feed_rss_test.dart
+++ b/firebase/functions/test/events/calendar/calendar_feed_rss_test.dart
@@ -5,11 +5,9 @@ import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 import 'package:functions/events/calendar/calendar_feed_rss.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
-import 'package:functions/utils/infra/firestore_utils.dart';
-import 'package:firebase_admin_interop/firebase_admin_interop.dart'
-    hide EventType;
 import '../../util/community_test_utils.dart';
 import '../../util/event_test_utils.dart';
+import '../../util/function_test_fixture.dart';
 
 void main() {
   String communityId = '';
@@ -17,10 +15,9 @@ void main() {
   const templateId = '9654988';
   final communityTestUtils = CommunityTestUtils();
   final eventTestUtils = EventTestUtils();
+  setupTestFixture();
 
   setUp(() async {
-    setFirebaseAppFactory(() => FirebaseAdmin.instance.initializeApp()!);
-
     final testCommunity = Community(
       id: '2921159966669',
       name: 'Testing Community',

--- a/firebase/functions/test/events/create_event_test.dart
+++ b/firebase/functions/test/events/create_event_test.dart
@@ -3,7 +3,6 @@ import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 import 'package:functions/events/live_meetings/breakouts/check_hostless_go_to_breakouts.dart';
 import 'package:functions/events/create_event.dart';
 import 'package:data_models/events/event.dart';
-import 'package:data_models/community/community.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 import 'package:data_models/cloud_functions/requests.dart';
@@ -12,27 +11,14 @@ import '../util/event_test_utils.dart';
 import '../util/function_test_fixture.dart';
 
 void main() {
-  String communityId = '';
-  const userId = 'fakeAuthId';
+  late String communityId;
   const templateId = '9654988';
   final communityTestUtils = CommunityTestUtils();
   final eventTestUtils = EventTestUtils();
   setupTestFixture();
 
   setUp(() async {
-    final testCommunity = Community(
-      id: '12349695999',
-      name: 'Testing Community',
-      isPublic: true,
-      profileImageUrl: 'http://someimage.com',
-      bannerImageUrl: 'http://mybanner.com',
-    );
-
-    final communityResult = await communityTestUtils.createCommunity(
-      community: testCommunity,
-      userId: userId,
-    );
-    communityId = communityResult['communityId'];
+    communityId = await communityTestUtils.createTestCommunity();
   });
 
   test('Emails are sent and reminders queued on event creation', () async {
@@ -41,7 +27,7 @@ void main() {
       status: EventStatus.active,
       communityId: communityId,
       templateId: templateId,
-      creatorId: userId,
+      creatorId: adminUserId,
       nullableEventType: EventType.hosted,
       collectionPath: '',
       agendaItems: [
@@ -54,7 +40,7 @@ void main() {
     );
     event = await eventTestUtils.createEvent(
       event: event,
-      userId: userId,
+      userId: adminUserId,
     );
 
     registerFallbackValue(event);
@@ -67,7 +53,7 @@ void main() {
     when(
       () => eventEmails.sendEmailsToUsers(
         eventPath: event.fullPath,
-        userIds: [userId],
+        userIds: [adminUserId],
         emailType: EventEmailType.initialSignUp,
       ),
     ).thenAnswer((_) async {
@@ -86,13 +72,13 @@ void main() {
 
     await eventCreator.action(
       req,
-      CallableContext(userId, null, 'fakeInstanceId'),
+      CallableContext(adminUserId, null, 'fakeInstanceId'),
     );
 
     verify(
       () => eventEmails.sendEmailsToUsers(
         eventPath: event.fullPath,
-        userIds: [userId],
+        userIds: [adminUserId],
         emailType: EventEmailType.initialSignUp,
       ),
     ).called(1);
@@ -118,7 +104,7 @@ void main() {
       status: EventStatus.active,
       communityId: communityId,
       templateId: templateId,
-      creatorId: userId,
+      creatorId: adminUserId,
       nullableEventType: EventType.hosted,
       collectionPath: '',
       agendaItems: [
@@ -131,7 +117,7 @@ void main() {
     );
     event = await eventTestUtils.createEvent(
       event: event,
-      userId: userId,
+      userId: adminUserId,
     );
 
     registerFallbackValue(event);
@@ -144,7 +130,7 @@ void main() {
     when(
       () => eventEmails.sendEmailsToUsers(
         eventPath: event.fullPath,
-        userIds: [userId],
+        userIds: [adminUserId],
         emailType: EventEmailType.initialSignUp,
       ),
     ).thenAnswer((_) async {
@@ -169,7 +155,7 @@ void main() {
     verify(
       () => eventEmails.sendEmailsToUsers(
         eventPath: event.fullPath,
-        userIds: [userId],
+        userIds: [adminUserId],
         emailType: EventEmailType.initialSignUp,
       ),
     ).called(1);
@@ -187,7 +173,7 @@ void main() {
       status: EventStatus.active,
       communityId: communityId,
       templateId: templateId,
-      creatorId: userId,
+      creatorId: adminUserId,
       nullableEventType: EventType.hostless,
       collectionPath: '',
       agendaItems: [
@@ -200,7 +186,7 @@ void main() {
     );
     event = await eventTestUtils.createEvent(
       event: event,
-      userId: userId,
+      userId: adminUserId,
     );
 
     final req = CreateEventRequest(
@@ -218,7 +204,7 @@ void main() {
     when(
       () => eventEmails.sendEmailsToUsers(
         eventPath: event.fullPath,
-        userIds: [userId],
+        userIds: [adminUserId],
         emailType: EventEmailType.initialSignUp,
       ),
     ).thenAnswer((_) async {
@@ -240,13 +226,13 @@ void main() {
 
     await eventCreator.action(
       req,
-      CallableContext(userId, null, 'fakeInstanceId'),
+      CallableContext(adminUserId, null, 'fakeInstanceId'),
     );
 
     verify(
       () => eventEmails.sendEmailsToUsers(
         eventPath: event.fullPath,
-        userIds: [userId],
+        userIds: [adminUserId],
         emailType: EventEmailType.initialSignUp,
       ),
     ).called(1);
@@ -276,7 +262,7 @@ void main() {
       status: EventStatus.active,
       communityId: communityId,
       templateId: templateId,
-      creatorId: userId,
+      creatorId: adminUserId,
       nullableEventType: EventType.hosted,
       collectionPath: '',
       agendaItems: [
@@ -289,7 +275,7 @@ void main() {
     );
     event = await eventTestUtils.createEvent(
       event: event,
-      userId: userId,
+      userId: adminUserId,
     );
 
     registerFallbackValue(event);

--- a/firebase/functions/test/events/create_event_test.dart
+++ b/firebase/functions/test/events/create_event_test.dart
@@ -7,11 +7,9 @@ import 'package:data_models/community/community.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 import 'package:data_models/cloud_functions/requests.dart';
-import 'package:functions/utils/infra/firestore_utils.dart';
-import 'package:firebase_admin_interop/firebase_admin_interop.dart'
-    hide EventType;
 import '../util/community_test_utils.dart';
 import '../util/event_test_utils.dart';
+import '../util/function_test_fixture.dart';
 
 void main() {
   String communityId = '';
@@ -19,10 +17,9 @@ void main() {
   const templateId = '9654988';
   final communityTestUtils = CommunityTestUtils();
   final eventTestUtils = EventTestUtils();
+  setupTestFixture();
 
   setUp(() async {
-    setFirebaseAppFactory(() => FirebaseAdmin.instance.initializeApp()!);
-
     final testCommunity = Community(
       id: '12349695999',
       name: 'Testing Community',

--- a/firebase/functions/test/events/event_ended_test.dart
+++ b/firebase/functions/test/events/event_ended_test.dart
@@ -11,27 +11,14 @@ import '../util/event_test_utils.dart';
 import '../util/function_test_fixture.dart';
 
 void main() {
-  String communityId = '';
-  const userId = 'fakeAuthId';
+  late String communityId;
   const templateId = '9654988';
   final communityTestUtils = CommunityTestUtils();
   final eventTestUtils = EventTestUtils();
   setupTestFixture();
 
   setUp(() async {
-    final testCommunity = Community(
-      id: '123496953333999',
-      name: 'Testing Community',
-      isPublic: true,
-      profileImageUrl: 'http://someimage.com',
-      bannerImageUrl: 'http://mybanner.com',
-    );
-
-    final communityResult = await communityTestUtils.createCommunity(
-      community: testCommunity,
-      userId: userId,
-    );
-    communityId = communityResult['communityId'];
+    communityId = await communityTestUtils.createTestCommunity();
   });
 
   test('Email sent when event has ended', () async {
@@ -40,7 +27,7 @@ void main() {
       status: EventStatus.active,
       communityId: communityId,
       templateId: templateId,
-      creatorId: userId,
+      creatorId: adminUserId,
       nullableEventType: EventType.hosted,
       collectionPath: '',
       agendaItems: [
@@ -53,7 +40,7 @@ void main() {
     );
     event = await eventTestUtils.createEvent(
       event: event,
-      userId: userId,
+      userId: adminUserId,
     );
 
     registerFallbackValue(event);
@@ -79,14 +66,14 @@ void main() {
 
     await eventEnded.action(
       req,
-      CallableContext(userId, null, 'fakeInstanceId'),
+      CallableContext(adminUserId, null, 'fakeInstanceId'),
     );
 
     final capturedMessage = verify(
       () => notificationsUtils.sendEventEndedEmail(
         event: any(named: 'event'),
         communityId: communityId,
-        userIds: [userId],
+        userIds: [adminUserId],
         emailType: EventEmailType.ended,
         generateMessage: captureAny(named: 'generateMessage'),
       ),

--- a/firebase/functions/test/events/event_ended_test.dart
+++ b/firebase/functions/test/events/event_ended_test.dart
@@ -9,6 +9,7 @@ import 'package:functions/utils/infra/firestore_utils.dart';
 import 'package:firebase_admin_interop/firebase_admin_interop.dart'
     as admin_interop hide EventType;
 import '../util/community_test_utils.dart';
+import '../util/email_test_utils.dart';
 import '../util/event_test_utils.dart';
 
 void main() {
@@ -101,5 +102,3 @@ void main() {
 }
 
 class MockCommunity extends Mock implements Community {}
-
-class MockUserRecord extends Mock implements admin_interop.UserRecord {}

--- a/firebase/functions/test/events/event_ended_test.dart
+++ b/firebase/functions/test/events/event_ended_test.dart
@@ -5,12 +5,10 @@ import 'package:functions/events/event_ended.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 import 'package:data_models/cloud_functions/requests.dart';
-import 'package:functions/utils/infra/firestore_utils.dart';
-import 'package:firebase_admin_interop/firebase_admin_interop.dart'
-    as admin_interop hide EventType;
 import '../util/community_test_utils.dart';
 import '../util/email_test_utils.dart';
 import '../util/event_test_utils.dart';
+import '../util/function_test_fixture.dart';
 
 void main() {
   String communityId = '';
@@ -18,12 +16,9 @@ void main() {
   const templateId = '9654988';
   final communityTestUtils = CommunityTestUtils();
   final eventTestUtils = EventTestUtils();
+  setupTestFixture();
 
   setUp(() async {
-    setFirebaseAppFactory(
-      () => admin_interop.FirebaseAdmin.instance.initializeApp()!,
-    );
-
     final testCommunity = Community(
       id: '123496953333999',
       name: 'Testing Community',

--- a/firebase/functions/test/events/join_event_test.dart
+++ b/firebase/functions/test/events/join_event_test.dart
@@ -4,11 +4,9 @@ import 'package:data_models/community/community.dart';
 import 'package:functions/events/join_event.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
-import 'package:functions/utils/infra/firestore_utils.dart';
-import 'package:firebase_admin_interop/firebase_admin_interop.dart'
-    hide EventType;
 import '../util/community_test_utils.dart';
 import '../util/event_test_utils.dart';
+import '../util/function_test_fixture.dart';
 
 void main() {
   String communityId = '';
@@ -16,10 +14,9 @@ void main() {
   const templateId = '9654988';
   final communityTestUtils = CommunityTestUtils();
   final eventTestUtils = EventTestUtils();
+  setupTestFixture();
 
   setUp(() async {
-    setFirebaseAppFactory(() => FirebaseAdmin.instance.initializeApp()!);
-
     final testCommunity = Community(
       id: '123492115999',
       name: 'Testing Community',

--- a/firebase/functions/test/events/join_event_test.dart
+++ b/firebase/functions/test/events/join_event_test.dart
@@ -1,6 +1,5 @@
 import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 import 'package:data_models/events/event.dart';
-import 'package:data_models/community/community.dart';
 import 'package:functions/events/join_event.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
@@ -9,27 +8,14 @@ import '../util/event_test_utils.dart';
 import '../util/function_test_fixture.dart';
 
 void main() {
-  String communityId = '';
-  const userId = 'fakeAuthId';
+  late String communityId;
   const templateId = '9654988';
   final communityTestUtils = CommunityTestUtils();
   final eventTestUtils = EventTestUtils();
   setupTestFixture();
 
   setUp(() async {
-    final testCommunity = Community(
-      id: '123492115999',
-      name: 'Testing Community',
-      isPublic: true,
-      profileImageUrl: 'http://someimage.com',
-      bannerImageUrl: 'http://mybanner.com',
-    );
-
-    final communityResult = await communityTestUtils.createCommunity(
-      community: testCommunity,
-      userId: userId,
-    );
-    communityId = communityResult['communityId'];
+    communityId = await communityTestUtils.createTestCommunity();
   });
 
   test('Registration email sent when user joins event', () async {
@@ -39,7 +25,7 @@ void main() {
       status: EventStatus.active,
       communityId: communityId,
       templateId: templateId,
-      creatorId: userId,
+      creatorId: adminUserId,
       nullableEventType: EventType.hosted,
       collectionPath: '',
       agendaItems: [
@@ -52,7 +38,7 @@ void main() {
     );
     event = await eventTestUtils.createEvent(
       event: event,
-      userId: userId,
+      userId: adminUserId,
     );
 
     await eventTestUtils.joinEvent(
@@ -97,7 +83,7 @@ void main() {
       status: EventStatus.active,
       communityId: communityId,
       templateId: templateId,
-      creatorId: userId,
+      creatorId: adminUserId,
       nullableEventType: EventType.hosted,
       collectionPath: '',
       agendaItems: [
@@ -110,7 +96,7 @@ void main() {
     );
     event = await eventTestUtils.createEvent(
       event: event,
-      userId: userId,
+      userId: adminUserId,
     );
 
     await eventTestUtils.joinEvent(
@@ -156,7 +142,7 @@ void main() {
       status: EventStatus.active,
       communityId: communityId,
       templateId: templateId,
-      creatorId: userId,
+      creatorId: adminUserId,
       nullableEventType: EventType.hosted,
       collectionPath: '',
       agendaItems: [
@@ -170,7 +156,7 @@ void main() {
     );
     event = await eventTestUtils.createEvent(
       event: event,
-      userId: userId,
+      userId: adminUserId,
     );
 
     await eventTestUtils.joinEvent(

--- a/firebase/functions/test/events/live_meetings/breakouts/check_advance_meeting_guide_test.dart
+++ b/firebase/functions/test/events/live_meetings/breakouts/check_advance_meeting_guide_test.dart
@@ -8,12 +8,11 @@ import 'package:data_models/events/live_meetings/meeting_guide.dart';
 import 'package:test/test.dart';
 import 'package:data_models/cloud_functions/requests.dart';
 import 'package:functions/utils/infra/firestore_utils.dart';
-import 'package:firebase_admin_interop/firebase_admin_interop.dart'
-    hide EventType;
 import 'package:uuid/uuid.dart';
 
 import '../../../util/community_test_utils.dart';
 import '../../../util/event_test_utils.dart';
+import '../../../util/function_test_fixture.dart';
 import '../../../util/live_meeting_test_utils.dart';
 
 void main() {
@@ -26,10 +25,9 @@ void main() {
   final communityTestUtils = CommunityTestUtils();
   final eventTestUtils = EventTestUtils();
   final liveMeetingTestUtils = LiveMeetingTestUtils();
+  setupTestFixture();
 
   setUp(() async {
-    setFirebaseAppFactory(() => FirebaseAdmin.instance.initializeApp()!);
-
     final testCommunity = Community(
       id: '12349999',
       name: 'Testing Community',

--- a/firebase/functions/test/events/live_meetings/breakouts/check_advance_meeting_guide_test.dart
+++ b/firebase/functions/test/events/live_meetings/breakouts/check_advance_meeting_guide_test.dart
@@ -2,7 +2,6 @@ import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 import 'package:get_it/get_it.dart';
 import 'package:functions/events/live_meetings/breakouts/check_advance_meeting_guide.dart';
 import 'package:data_models/events/event.dart';
-import 'package:data_models/community/community.dart';
 import 'package:data_models/events/live_meetings/live_meeting.dart';
 import 'package:data_models/events/live_meetings/meeting_guide.dart';
 import 'package:test/test.dart';
@@ -16,8 +15,7 @@ import '../../../util/function_test_fixture.dart';
 import '../../../util/live_meeting_test_utils.dart';
 
 void main() {
-  String communityId = '';
-  const userId = 'fakeAuthId';
+  late String communityId;
   const templateId = '9654';
   const uuid = Uuid();
   final breakoutSessionId = uuid.v1().toString();
@@ -28,19 +26,7 @@ void main() {
   setupTestFixture();
 
   setUp(() async {
-    final testCommunity = Community(
-      id: '12349999',
-      name: 'Testing Community',
-      isPublic: true,
-      profileImageUrl: 'http://someimage.com',
-      bannerImageUrl: 'http://mybanner.com',
-    );
-
-    final communityResult = await communityTestUtils.createCommunity(
-      community: testCommunity,
-      userId: userId,
-    );
-    communityId = communityResult['communityId'];
+    communityId = await communityTestUtils.createTestCommunity();
   });
 
   test('Agenda is advanced when half the participants are ready', () async {
@@ -49,7 +35,7 @@ void main() {
       status: EventStatus.active,
       communityId: communityId,
       templateId: templateId,
-      creatorId: userId,
+      creatorId: adminUserId,
       nullableEventType: EventType
           .hosted, //intentionally set to hosted even though we are simulating a hostless event to avoid enqueueing the CheckAssignToBreakoutServer, which causes an error
       collectionPath: '',
@@ -63,7 +49,7 @@ void main() {
     );
     event = await eventTestUtils.createEvent(
       event: event,
-      userId: userId,
+      userId: adminUserId,
     );
 
     // add 8 participants
@@ -85,7 +71,7 @@ void main() {
     await liveMeetingTestUtils.initiateBreakoutSession(
       event: event,
       breakoutSessionId: breakoutSessionId,
-      userId: userId,
+      userId: adminUserId,
     );
 
     final breakoutRoom = await liveMeetingTestUtils.getBreakoutRoom(
@@ -155,7 +141,7 @@ void main() {
       status: EventStatus.active,
       communityId: communityId,
       templateId: templateId,
-      creatorId: userId,
+      creatorId: adminUserId,
       nullableEventType: EventType
           .hosted, //intentionally set to hosted even though we are simulating a hostless event to avoid enqueueing the CheckAssignToBreakoutServer, which causes an error
       collectionPath: '',
@@ -169,7 +155,7 @@ void main() {
     );
     event = await eventTestUtils.createEvent(
       event: event,
-      userId: userId,
+      userId: adminUserId,
     );
 
     // add 8 participants
@@ -191,7 +177,7 @@ void main() {
     await liveMeetingTestUtils.initiateBreakoutSession(
       event: event,
       breakoutSessionId: breakoutSessionId,
-      userId: userId,
+      userId: adminUserId,
     );
 
     final breakoutRoom = await liveMeetingTestUtils.getBreakoutRoom(

--- a/firebase/functions/test/events/live_meetings/breakouts/check_assign_to_breakouts_test.dart
+++ b/firebase/functions/test/events/live_meetings/breakouts/check_assign_to_breakouts_test.dart
@@ -2,7 +2,6 @@ import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 import 'package:get_it/get_it.dart';
 import 'package:functions/events/live_meetings/breakouts/check_assign_to_breakouts.dart';
 import 'package:data_models/events/event.dart';
-import 'package:data_models/community/community.dart';
 import 'package:data_models/events/live_meetings/live_meeting.dart';
 import 'package:test/test.dart';
 import 'package:data_models/cloud_functions/requests.dart';
@@ -15,8 +14,7 @@ import '../../../util/function_test_fixture.dart';
 import '../../../util/live_meeting_test_utils.dart';
 
 void main() {
-  String communityId = '';
-  const userId = 'fakeAuthId';
+  late String communityId;
   const templateId = '9654';
   const uuid = Uuid();
   final breakoutSessionId = uuid.v1().toString();
@@ -27,19 +25,7 @@ void main() {
   setupTestFixture();
 
   setUp(() async {
-    final testCommunity = Community(
-      id: '12349999',
-      name: 'Testing Community',
-      isPublic: true,
-      profileImageUrl: 'http://someimage.com',
-      bannerImageUrl: 'http://mybanner.com',
-    );
-
-    final communityResult = await communityTestUtils.createCommunity(
-      community: testCommunity,
-      userId: userId,
-    );
-    communityId = communityResult['communityId'];
+    communityId = await communityTestUtils.createTestCommunity();
   });
 
   test('Breakouts are assigned with target per room', () async {
@@ -48,7 +34,7 @@ void main() {
       status: EventStatus.active,
       communityId: communityId,
       templateId: templateId,
-      creatorId: userId,
+      creatorId: adminUserId,
       nullableEventType: EventType.hosted,
       collectionPath: '',
       agendaItems: [
@@ -61,7 +47,7 @@ void main() {
     );
     event = await eventTestUtils.createEvent(
       event: event,
-      userId: userId,
+      userId: adminUserId,
     );
 
     // add 4 participants
@@ -84,7 +70,7 @@ void main() {
     await liveMeetingTestUtils.initiateBreakoutSession(
       event: event,
       breakoutSessionId: breakoutSessionId,
-      userId: userId,
+      userId: adminUserId,
     );
 
     final req = CheckAssignToBreakoutsRequest(
@@ -94,7 +80,10 @@ void main() {
 
     final assigner = CheckAssignToBreakouts();
 
-    await assigner.action(req, CallableContext(userId, null, 'fakeInstanceId'));
+    await assigner.action(
+      req,
+      CallableContext(adminUserId, null, 'fakeInstanceId'),
+    );
 
     // Verify breakout room session was created
     final breakoutSessionPath = liveMeetingTestUtils.getBreakoutSessionDoc(
@@ -138,7 +127,7 @@ void main() {
     final expectedRoom1 = BreakoutRoom(
       roomId: room1.roomId,
       roomName: '1',
-      creatorId: userId,
+      creatorId: adminUserId,
       createdDate: room1.createdDate,
       orderingPriority: 0,
       participantIds: ['333', '555'],
@@ -157,7 +146,7 @@ void main() {
     final expectedRoom2 = BreakoutRoom(
       roomId: room2.roomId,
       roomName: '2',
-      creatorId: userId,
+      creatorId: adminUserId,
       createdDate: room2.createdDate,
       orderingPriority: 1,
       participantIds: ['444', '666'],
@@ -173,7 +162,7 @@ void main() {
       status: EventStatus.active,
       communityId: communityId,
       templateId: templateId,
-      creatorId: userId,
+      creatorId: adminUserId,
       nullableEventType: EventType.hosted,
       collectionPath: '',
       agendaItems: [
@@ -186,7 +175,7 @@ void main() {
     );
     event = await eventTestUtils.createEvent(
       event: event,
-      userId: userId,
+      userId: adminUserId,
     );
 
     // add 4 participants
@@ -209,7 +198,7 @@ void main() {
     await liveMeetingTestUtils.initiateBreakoutSession(
       event: event,
       breakoutSessionId: breakoutSessionId,
-      userId: userId,
+      userId: adminUserId,
       assignmentMethod: BreakoutAssignmentMethod.smartMatch,
     );
 
@@ -220,7 +209,10 @@ void main() {
 
     final assigner = CheckAssignToBreakouts();
 
-    await assigner.action(req, CallableContext(userId, null, 'fakeInstanceId'));
+    await assigner.action(
+      req,
+      CallableContext(adminUserId, null, 'fakeInstanceId'),
+    );
 
     // Verify breakout room session was created
     final breakoutSessionPath = liveMeetingTestUtils.getBreakoutSessionDoc(
@@ -264,7 +256,7 @@ void main() {
     final expectedRoom1 = BreakoutRoom(
       roomId: room1.roomId,
       roomName: '1',
-      creatorId: userId,
+      creatorId: adminUserId,
       createdDate: room1.createdDate,
       orderingPriority: 0,
       participantIds: ['333', '444'],
@@ -283,7 +275,7 @@ void main() {
     final expectedRoom2 = BreakoutRoom(
       roomId: room2.roomId,
       roomName: '2',
-      creatorId: userId,
+      creatorId: adminUserId,
       createdDate: room2.createdDate,
       orderingPriority: 1,
       participantIds: ['555', '666'],

--- a/firebase/functions/test/events/live_meetings/breakouts/check_assign_to_breakouts_test.dart
+++ b/firebase/functions/test/events/live_meetings/breakouts/check_assign_to_breakouts_test.dart
@@ -7,12 +7,11 @@ import 'package:data_models/events/live_meetings/live_meeting.dart';
 import 'package:test/test.dart';
 import 'package:data_models/cloud_functions/requests.dart';
 import 'package:functions/utils/infra/firestore_utils.dart';
-import 'package:firebase_admin_interop/firebase_admin_interop.dart'
-    hide EventType;
 import 'package:uuid/uuid.dart';
 
 import '../../../util/community_test_utils.dart';
 import '../../../util/event_test_utils.dart';
+import '../../../util/function_test_fixture.dart';
 import '../../../util/live_meeting_test_utils.dart';
 
 void main() {
@@ -25,10 +24,9 @@ void main() {
   final communityTestUtils = CommunityTestUtils();
   final eventTestUtils = EventTestUtils();
   final liveMeetingTestUtils = LiveMeetingTestUtils();
+  setupTestFixture();
 
   setUp(() async {
-    setFirebaseAppFactory(() => FirebaseAdmin.instance.initializeApp()!);
-
     final testCommunity = Community(
       id: '12349999',
       name: 'Testing Community',

--- a/firebase/functions/test/events/live_meetings/breakouts/check_hostless_go_to_breakouts_test.dart
+++ b/firebase/functions/test/events/live_meetings/breakouts/check_hostless_go_to_breakouts_test.dart
@@ -6,10 +6,9 @@ import 'package:data_models/events/live_meetings/live_meeting.dart';
 import 'package:test/test.dart';
 import 'package:data_models/cloud_functions/requests.dart';
 import 'package:functions/utils/infra/firestore_utils.dart';
-import 'package:firebase_admin_interop/firebase_admin_interop.dart'
-    hide EventType;
 import '../../../util/community_test_utils.dart';
 import '../../../util/event_test_utils.dart';
+import '../../../util/function_test_fixture.dart';
 import '../../../util/live_meeting_test_utils.dart';
 
 void main() {
@@ -19,10 +18,9 @@ void main() {
   final communityTestUtils = CommunityTestUtils();
   final eventTestUtils = EventTestUtils();
   final liveMeetingTestUtils = LiveMeetingTestUtils();
+  setupTestFixture();
 
   setUp(() async {
-    setFirebaseAppFactory(() => FirebaseAdmin.instance.initializeApp()!);
-
     final testCommunity = Community(
       id: '1234',
       name: 'Testing Community',

--- a/firebase/functions/test/events/live_meetings/breakouts/get_breakout_room_assignment_test.dart
+++ b/firebase/functions/test/events/live_meetings/breakouts/get_breakout_room_assignment_test.dart
@@ -2,7 +2,6 @@ import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 import 'package:get_it/get_it.dart';
 import 'package:functions/events/live_meetings/breakouts/get_breakout_room_assignment.dart';
 import 'package:data_models/events/event.dart';
-import 'package:data_models/community/community.dart';
 import 'package:data_models/events/live_meetings/live_meeting.dart';
 import 'package:test/test.dart';
 import 'package:data_models/cloud_functions/requests.dart';
@@ -14,7 +13,6 @@ import '../../../util/live_meeting_test_utils.dart';
 
 void main() {
   String communityId = '';
-  const userId = 'fakeAuthId';
   const templateId = '9654';
   const uuid = Uuid();
   final breakoutSessionId = uuid.v1().toString();
@@ -25,19 +23,7 @@ void main() {
   setupTestFixture();
 
   setUp(() async {
-    final testCommunity = Community(
-      id: '234jksljf',
-      name: 'Another Testing Community',
-      isPublic: true,
-      profileImageUrl: 'http://someimage.com',
-      bannerImageUrl: 'http://mybanner.com',
-    );
-
-    final communityResult = await communityUtils.createCommunity(
-      community: testCommunity,
-      userId: userId,
-    );
-    communityId = communityResult['communityId'];
+    communityId = await communityUtils.createTestCommunity();
   });
 
   test('Room assignment is returned', () async {
@@ -46,7 +32,7 @@ void main() {
       status: EventStatus.active,
       communityId: communityId,
       templateId: templateId,
-      creatorId: userId,
+      creatorId: adminUserId,
       nullableEventType: EventType.hosted,
       collectionPath: '',
       agendaItems: [
@@ -59,7 +45,7 @@ void main() {
     );
     event = await eventUtils.createEvent(
       event: event,
-      userId: userId,
+      userId: adminUserId,
     );
 
     await eventUtils.joinEventMultiple(
@@ -99,7 +85,7 @@ void main() {
     await liveMeetingUtils.initiateBreakoutSession(
       event: event,
       breakoutSessionId: breakoutSessionId,
-      userId: userId,
+      userId: adminUserId,
     );
 
     // Retrieve a created breakout room

--- a/firebase/functions/test/events/live_meetings/breakouts/get_breakout_room_assignment_test.dart
+++ b/firebase/functions/test/events/live_meetings/breakouts/get_breakout_room_assignment_test.dart
@@ -6,12 +6,10 @@ import 'package:data_models/community/community.dart';
 import 'package:data_models/events/live_meetings/live_meeting.dart';
 import 'package:test/test.dart';
 import 'package:data_models/cloud_functions/requests.dart';
-import 'package:functions/utils/infra/firestore_utils.dart';
-import 'package:firebase_admin_interop/firebase_admin_interop.dart'
-    hide EventType;
 import 'package:uuid/uuid.dart';
 import '../../../util/community_test_utils.dart';
 import '../../../util/event_test_utils.dart';
+import '../../../util/function_test_fixture.dart';
 import '../../../util/live_meeting_test_utils.dart';
 
 void main() {
@@ -24,10 +22,9 @@ void main() {
   final eventUtils = EventTestUtils();
   final communityUtils = CommunityTestUtils();
   final liveMeetingUtils = LiveMeetingTestUtils();
+  setupTestFixture();
 
   setUp(() async {
-    setFirebaseAppFactory(() => FirebaseAdmin.instance.initializeApp()!);
-
     final testCommunity = Community(
       id: '234jksljf',
       name: 'Another Testing Community',

--- a/firebase/functions/test/events/live_meetings/breakouts/get_breakout_room_join_info_test.dart
+++ b/firebase/functions/test/events/live_meetings/breakouts/get_breakout_room_join_info_test.dart
@@ -10,13 +10,11 @@ import 'package:mocktail/mocktail.dart';
 
 import 'package:test/test.dart';
 import 'package:data_models/cloud_functions/requests.dart';
-import 'package:functions/utils/infra/firestore_utils.dart';
-import 'package:firebase_admin_interop/firebase_admin_interop.dart'
-    hide EventType;
 import 'package:uuid/uuid.dart';
 
 import '../../../util/community_test_utils.dart';
 import '../../../util/event_test_utils.dart';
+import '../../../util/function_test_fixture.dart';
 import '../../../util/live_meeting_test_utils.dart';
 
 void main() {
@@ -29,10 +27,9 @@ void main() {
   final eventUtils = EventTestUtils();
   final communityUtils = CommunityTestUtils();
   final liveMeetingUtils = LiveMeetingTestUtils();
+  setupTestFixture();
 
   setUp(() async {
-    setFirebaseAppFactory(() => FirebaseAdmin.instance.initializeApp()!);
-
     final testCommunity = Community(
       id: '6543',
       name: 'More Testing Community',

--- a/firebase/functions/test/events/live_meetings/breakouts/get_breakout_room_join_info_test.dart
+++ b/firebase/functions/test/events/live_meetings/breakouts/get_breakout_room_join_info_test.dart
@@ -4,7 +4,6 @@ import 'package:functions/events/live_meetings/breakouts/get_breakout_room_join_
 import 'package:functions/events/live_meetings/live_meeting_utils.dart';
 
 import 'package:data_models/events/event.dart';
-import 'package:data_models/community/community.dart';
 import 'package:data_models/events/live_meetings/live_meeting.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -19,7 +18,6 @@ import '../../../util/live_meeting_test_utils.dart';
 
 void main() {
   String communityId = '';
-  const userId = 'fakeAuthId';
   const templateId = '9654';
   const uuid = Uuid();
   final breakoutSessionId = uuid.v1().toString();
@@ -30,19 +28,7 @@ void main() {
   setupTestFixture();
 
   setUp(() async {
-    final testCommunity = Community(
-      id: '6543',
-      name: 'More Testing Community',
-      isPublic: true,
-      profileImageUrl: 'http://someimage.com',
-      bannerImageUrl: 'http://mybanner.com',
-    );
-
-    final communityResult = await communityUtils.createCommunity(
-      community: testCommunity,
-      userId: userId,
-    );
-    communityId = communityResult['communityId'];
+    communityId = await communityUtils.createTestCommunity();
   });
 
   test('Participant join info is returned', () async {
@@ -51,7 +37,7 @@ void main() {
       status: EventStatus.active,
       communityId: communityId,
       templateId: templateId,
-      creatorId: userId,
+      creatorId: adminUserId,
       nullableEventType: EventType.hosted,
       collectionPath: '',
       agendaItems: [
@@ -64,7 +50,7 @@ void main() {
     );
     event = await eventUtils.createEvent(
       event: event,
-      userId: userId,
+      userId: adminUserId,
     );
 
     await eventUtils.joinEventMultiple(
@@ -104,7 +90,7 @@ void main() {
     await liveMeetingUtils.initiateBreakoutSession(
       event: event,
       breakoutSessionId: breakoutSessionId,
-      userId: userId,
+      userId: adminUserId,
     );
 
     // Retrieve a created breakout room

--- a/firebase/functions/test/events/live_meetings/breakouts/initiate_breakouts_test.dart
+++ b/firebase/functions/test/events/live_meetings/breakouts/initiate_breakouts_test.dart
@@ -7,12 +7,11 @@ import 'package:data_models/events/live_meetings/live_meeting.dart';
 import 'package:test/test.dart';
 import 'package:data_models/cloud_functions/requests.dart';
 import 'package:functions/utils/infra/firestore_utils.dart';
-import 'package:firebase_admin_interop/firebase_admin_interop.dart'
-    hide EventType;
 import 'package:uuid/uuid.dart';
 
 import '../../../util/community_test_utils.dart';
 import '../../../util/event_test_utils.dart';
+import '../../../util/function_test_fixture.dart';
 import '../../../util/live_meeting_test_utils.dart';
 
 void main() {
@@ -25,10 +24,9 @@ void main() {
   final communityTestUtils = CommunityTestUtils();
   final eventTestUtils = EventTestUtils();
   final liveMeetingTestUtils = LiveMeetingTestUtils();
+  setupTestFixture();
 
   setUp(() async {
-    setFirebaseAppFactory(() => FirebaseAdmin.instance.initializeApp()!);
-
     final testCommunity = Community(
       id: '9966',
       name: 'Testing Community',

--- a/firebase/functions/test/events/live_meetings/breakouts/reassign_breakout_room_test.dart
+++ b/firebase/functions/test/events/live_meetings/breakouts/reassign_breakout_room_test.dart
@@ -8,13 +8,11 @@ import 'package:data_models/events/live_meetings/live_meeting.dart';
 
 import 'package:test/test.dart';
 import 'package:data_models/cloud_functions/requests.dart';
-import 'package:functions/utils/infra/firestore_utils.dart';
-import 'package:firebase_admin_interop/firebase_admin_interop.dart'
-    hide EventType;
 import 'package:uuid/uuid.dart';
 
 import '../../../util/community_test_utils.dart';
 import '../../../util/event_test_utils.dart';
+import '../../../util/function_test_fixture.dart';
 import '../../../util/live_meeting_test_utils.dart';
 
 void main() {
@@ -27,10 +25,9 @@ void main() {
   final eventUtils = EventTestUtils();
   final communityUtils = CommunityTestUtils();
   final liveMeetingUtils = LiveMeetingTestUtils();
+  setupTestFixture();
 
   setUp(() async {
-    setFirebaseAppFactory(() => FirebaseAdmin.instance.initializeApp()!);
-
     final testCommunity = Community(
       id: '175ff',
       name: 'Testing Community',

--- a/firebase/functions/test/events/live_meetings/breakouts/reassign_breakout_room_test.dart
+++ b/firebase/functions/test/events/live_meetings/breakouts/reassign_breakout_room_test.dart
@@ -3,7 +3,6 @@ import 'package:get_it/get_it.dart';
 import 'package:functions/events/live_meetings/breakouts/reassign_breakout_room.dart';
 
 import 'package:data_models/events/event.dart';
-import 'package:data_models/community/community.dart';
 import 'package:data_models/events/live_meetings/live_meeting.dart';
 
 import 'package:test/test.dart';
@@ -16,8 +15,7 @@ import '../../../util/function_test_fixture.dart';
 import '../../../util/live_meeting_test_utils.dart';
 
 void main() {
-  String communityId = '';
-  const userId = 'fakeAuthId';
+  late String communityId;
   const templateId = '9654';
   const uuid = Uuid();
   final breakoutSessionId = uuid.v1().toString();
@@ -28,19 +26,7 @@ void main() {
   setupTestFixture();
 
   setUp(() async {
-    final testCommunity = Community(
-      id: '175ff',
-      name: 'Testing Community',
-      isPublic: true,
-      profileImageUrl: 'http://someimage.com',
-      bannerImageUrl: 'http://mybanner.com',
-    );
-
-    final communityResult = await communityUtils.createCommunity(
-      community: testCommunity,
-      userId: userId,
-    );
-    communityId = communityResult['communityId'];
+    communityId = await communityUtils.createTestCommunity();
   });
 
   test('Participant is reassigned to specified breakout room', () async {
@@ -49,7 +35,7 @@ void main() {
       status: EventStatus.active,
       communityId: communityId,
       templateId: templateId,
-      creatorId: userId,
+      creatorId: adminUserId,
       nullableEventType: EventType.hosted,
       collectionPath: '',
       agendaItems: [
@@ -62,7 +48,7 @@ void main() {
     );
     event = await eventUtils.createEvent(
       event: event,
-      userId: userId,
+      userId: adminUserId,
     );
 
     await eventUtils.joinEventMultiple(
@@ -102,7 +88,7 @@ void main() {
     await liveMeetingUtils.initiateBreakoutSession(
       event: event,
       breakoutSessionId: breakoutSessionId,
-      userId: userId,
+      userId: adminUserId,
     );
 
     final req = ReassignBreakoutRoomRequest(
@@ -115,7 +101,7 @@ void main() {
 
     final result = await assigner.action(
       req,
-      CallableContext(userId, null, 'fakeInstanceId'),
+      CallableContext(adminUserId, null, 'fakeInstanceId'),
     );
     expect(result?['roomName'], equals('2'));
     expect(result?['participantIds'], equals(['444', '666', '333']));

--- a/firebase/functions/test/events/live_meetings/breakouts/update_breakout_room_flag_status_test.dart
+++ b/firebase/functions/test/events/live_meetings/breakouts/update_breakout_room_flag_status_test.dart
@@ -3,7 +3,6 @@ import 'package:get_it/get_it.dart';
 import 'package:functions/events/live_meetings/breakouts/update_breakout_room_flag_status.dart';
 
 import 'package:data_models/events/event.dart';
-import 'package:data_models/community/community.dart';
 import 'package:data_models/events/live_meetings/live_meeting.dart';
 
 import 'package:test/test.dart';
@@ -17,7 +16,6 @@ import '../../../util/live_meeting_test_utils.dart';
 
 void main() {
   String communityId = '';
-  const userId = 'fakeAuthId';
   const templateId = '9654';
   const uuid = Uuid();
   final breakoutSessionId = uuid.v1().toString();
@@ -28,19 +26,7 @@ void main() {
   setupTestFixture();
 
   setUp(() async {
-    final testCommunity = Community(
-      id: '0dsk3',
-      name: 'Testing Community',
-      isPublic: true,
-      profileImageUrl: 'http://someimage.com',
-      bannerImageUrl: 'http://mybanner.com',
-    );
-
-    final communityResult = await communityUtils.createCommunity(
-      community: testCommunity,
-      userId: userId,
-    );
-    communityId = communityResult['communityId'];
+    communityId = await communityUtils.createTestCommunity();
   });
 
   test('Flag status is updated', () async {
@@ -49,7 +35,7 @@ void main() {
       status: EventStatus.active,
       communityId: communityId,
       templateId: templateId,
-      creatorId: userId,
+      creatorId: adminUserId,
       nullableEventType: EventType.hosted,
       collectionPath: '',
       agendaItems: [
@@ -62,7 +48,7 @@ void main() {
     );
     event = await eventUtils.createEvent(
       event: event,
-      userId: userId,
+      userId: adminUserId,
     );
 
     await eventUtils.joinEventMultiple(
@@ -102,7 +88,7 @@ void main() {
     await liveMeetingUtils.initiateBreakoutSession(
       event: event,
       breakoutSessionId: breakoutSessionId,
-      userId: userId,
+      userId: adminUserId,
     );
 
     // Retrieve a created breakout room

--- a/firebase/functions/test/events/live_meetings/breakouts/update_breakout_room_flag_status_test.dart
+++ b/firebase/functions/test/events/live_meetings/breakouts/update_breakout_room_flag_status_test.dart
@@ -8,13 +8,11 @@ import 'package:data_models/events/live_meetings/live_meeting.dart';
 
 import 'package:test/test.dart';
 import 'package:data_models/cloud_functions/requests.dart';
-import 'package:functions/utils/infra/firestore_utils.dart';
-import 'package:firebase_admin_interop/firebase_admin_interop.dart'
-    hide EventType;
 import 'package:uuid/uuid.dart';
 
 import '../../../util/community_test_utils.dart';
 import '../../../util/event_test_utils.dart';
+import '../../../util/function_test_fixture.dart';
 import '../../../util/live_meeting_test_utils.dart';
 
 void main() {
@@ -27,10 +25,9 @@ void main() {
   final eventUtils = EventTestUtils();
   final communityUtils = CommunityTestUtils();
   final liveMeetingUtils = LiveMeetingTestUtils();
+  setupTestFixture();
 
   setUp(() async {
-    setFirebaseAppFactory(() => FirebaseAdmin.instance.initializeApp()!);
-
     final testCommunity = Community(
       id: '0dsk3',
       name: 'Testing Community',

--- a/firebase/functions/test/events/notifications/email_event_reminder_test.dart
+++ b/firebase/functions/test/events/notifications/email_event_reminder_test.dart
@@ -2,15 +2,12 @@ import 'package:data_models/cloud_functions/requests.dart';
 import 'package:data_models/events/event.dart';
 import 'package:data_models/community/community.dart';
 
-
 import 'package:functions/events/notifications/email_event_reminder.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
-import 'package:functions/utils/infra/firestore_utils.dart';
-import 'package:firebase_admin_interop/firebase_admin_interop.dart'
-    hide EventType;
 import '../../util/community_test_utils.dart';
 import '../../util/event_test_utils.dart';
+import '../../util/function_test_fixture.dart';
 
 void main() {
   String communityId = '';
@@ -18,10 +15,9 @@ void main() {
   const templateId = '9654988';
   final communityTestUtils = CommunityTestUtils();
   final eventTestUtils = EventTestUtils();
+  setupTestFixture();
 
   setUp(() async {
-    setFirebaseAppFactory(() => FirebaseAdmin.instance.initializeApp()!);
-
     final testCommunity = Community(
       id: '292115999',
       name: 'Testing Community',

--- a/firebase/functions/test/events/notifications/email_event_reminder_test.dart
+++ b/firebase/functions/test/events/notifications/email_event_reminder_test.dart
@@ -1,6 +1,5 @@
 import 'package:data_models/cloud_functions/requests.dart';
 import 'package:data_models/events/event.dart';
-import 'package:data_models/community/community.dart';
 
 import 'package:functions/events/notifications/email_event_reminder.dart';
 import 'package:mocktail/mocktail.dart';
@@ -10,27 +9,14 @@ import '../../util/event_test_utils.dart';
 import '../../util/function_test_fixture.dart';
 
 void main() {
-  String communityId = '';
-  const userId = 'fakeAuthId';
+  late String communityId;
   const templateId = '9654988';
   final communityTestUtils = CommunityTestUtils();
   final eventTestUtils = EventTestUtils();
   setupTestFixture();
 
   setUp(() async {
-    final testCommunity = Community(
-      id: '292115999',
-      name: 'Testing Community',
-      isPublic: true,
-      profileImageUrl: 'http://someimage.com',
-      bannerImageUrl: 'http://mybanner.com',
-    );
-
-    final communityResult = await communityTestUtils.createCommunity(
-      community: testCommunity,
-      userId: userId,
-    );
-    communityId = communityResult['communityId'];
+    communityId = await communityTestUtils.createTestCommunity();
   });
 
   test('One day reminder email sent to registered participants', () async {
@@ -40,7 +26,7 @@ void main() {
       status: EventStatus.active,
       communityId: communityId,
       templateId: templateId,
-      creatorId: userId,
+      creatorId: adminUserId,
       nullableEventType: EventType.hosted,
       collectionPath: '',
       scheduledTime: DateTime.now().add(const Duration(hours: 24)),
@@ -54,7 +40,7 @@ void main() {
     );
     event = await eventTestUtils.createEvent(
       event: event,
-      userId: userId,
+      userId: adminUserId,
     );
 
     await eventTestUtils.joinEventMultiple(
@@ -97,7 +83,7 @@ void main() {
         eventPath: event.fullPath,
         userIds: any(
           named: 'userIds',
-          that: unorderedEquals([...participantIds, userId]),
+          that: unorderedEquals([...participantIds, adminUserId]),
         ),
         emailType: EventEmailType.oneDayReminder,
       ),
@@ -111,7 +97,7 @@ void main() {
       status: EventStatus.active,
       communityId: communityId,
       templateId: templateId,
-      creatorId: userId,
+      creatorId: adminUserId,
       nullableEventType: EventType.hosted,
       collectionPath: '',
       scheduledTime: DateTime.now().add(const Duration(hours: 1)),
@@ -125,7 +111,7 @@ void main() {
     );
     event = await eventTestUtils.createEvent(
       event: event,
-      userId: userId,
+      userId: adminUserId,
     );
 
     await eventTestUtils.joinEventMultiple(
@@ -168,7 +154,7 @@ void main() {
         eventPath: event.fullPath,
         userIds: any(
           named: 'userIds',
-          that: unorderedEquals([...participantIds, userId]),
+          that: unorderedEquals([...participantIds, adminUserId]),
         ),
         emailType: EventEmailType.oneHourReminder,
       ),
@@ -182,7 +168,7 @@ void main() {
       status: EventStatus.active,
       communityId: communityId,
       templateId: templateId,
-      creatorId: userId,
+      creatorId: adminUserId,
       nullableEventType: EventType.hosted,
       collectionPath: '',
       scheduledTime: DateTime.now().add(const Duration(hours: 3)),
@@ -196,7 +182,7 @@ void main() {
     );
     event = await eventTestUtils.createEvent(
       event: event,
-      userId: userId,
+      userId: adminUserId,
     );
 
     await eventTestUtils.joinEventMultiple(
@@ -239,7 +225,7 @@ void main() {
         eventPath: event.fullPath,
         userIds: any(
           named: 'userIds',
-          that: unorderedEquals([...participantIds, userId]),
+          that: unorderedEquals([...participantIds, adminUserId]),
         ),
         emailType: EventEmailType.oneHourReminder,
       ),
@@ -253,7 +239,7 @@ void main() {
       status: EventStatus.active,
       communityId: communityId,
       templateId: templateId,
-      creatorId: userId,
+      creatorId: adminUserId,
       nullableEventType: EventType.hosted,
       collectionPath: '',
       scheduledTime: DateTime.now().add(const Duration(hours: 1)),
@@ -268,7 +254,7 @@ void main() {
     );
     event = await eventTestUtils.createEvent(
       event: event,
-      userId: userId,
+      userId: adminUserId,
     );
 
     await eventTestUtils.joinEventMultiple(
@@ -311,7 +297,7 @@ void main() {
         eventPath: event.fullPath,
         userIds: any(
           named: 'userIds',
-          that: unorderedEquals([...participantIds, userId]),
+          that: unorderedEquals([...participantIds, adminUserId]),
         ),
         emailType: EventEmailType.oneHourReminder,
       ),

--- a/firebase/functions/test/events/notifications/send_event_message_test.dart
+++ b/firebase/functions/test/events/notifications/send_event_message_test.dart
@@ -15,26 +15,13 @@ import '../../util/function_test_fixture.dart';
 
 void main() {
   String communityId = '';
-  const userId = 'fakeAuthId';
   const templateId = '9654988';
   final communityTestUtils = CommunityTestUtils();
   final eventTestUtils = EventTestUtils();
   setupTestFixture();
 
   setUp(() async {
-    final testCommunity = Community(
-      id: '123496953333999ddddd',
-      name: 'Testing Community',
-      isPublic: true,
-      profileImageUrl: 'http://someimage.com',
-      bannerImageUrl: 'http://mybanner.com',
-    );
-
-    final communityResult = await communityTestUtils.createCommunity(
-      community: testCommunity,
-      userId: userId,
-    );
-    communityId = communityResult['communityId'];
+    communityId = await communityTestUtils.createTestCommunity();
   });
 
   test('Event message sent and stored in database', () async {
@@ -44,7 +31,7 @@ void main() {
     template = await eventTestUtils.createTemplate(
       communityId: communityId,
       template: template,
-      creatorId: userId,
+      creatorId: adminUserId,
     );
 
     var event = Event(
@@ -52,7 +39,7 @@ void main() {
       status: EventStatus.active,
       communityId: communityId,
       templateId: templateId,
-      creatorId: userId,
+      creatorId: adminUserId,
       nullableEventType: EventType.hosted,
       collectionPath: '',
       scheduledTime: DateTime.now(),
@@ -66,7 +53,7 @@ void main() {
     );
     event = await eventTestUtils.createEvent(
       event: event,
-      userId: userId,
+      userId: adminUserId,
     );
 
     registerFallbackValue(event);
@@ -85,7 +72,7 @@ void main() {
 
     const msg = 'Something Important has happened';
     final eventMessage = EventMessage(
-      creatorId: userId,
+      creatorId: adminUserId,
       createdAt: DateTime.now(),
       message: msg,
     );
@@ -113,7 +100,7 @@ void main() {
 
     await eventMsgr.action(
       req,
-      CallableContext(userId, null, 'fakeInstanceId'),
+      CallableContext(adminUserId, null, 'fakeInstanceId'),
     );
 
     final capturedMessage = verify(

--- a/firebase/functions/test/events/notifications/send_event_message_test.dart
+++ b/firebase/functions/test/events/notifications/send_event_message_test.dart
@@ -8,11 +8,10 @@ import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 import 'package:data_models/cloud_functions/requests.dart';
 import 'package:functions/utils/infra/firestore_utils.dart';
-import 'package:firebase_admin_interop/firebase_admin_interop.dart'
-    as admin_interop hide EventType;
 import '../../util/community_test_utils.dart';
 import '../../util/email_test_utils.dart';
 import '../../util/event_test_utils.dart';
+import '../../util/function_test_fixture.dart';
 
 void main() {
   String communityId = '';
@@ -20,12 +19,9 @@ void main() {
   const templateId = '9654988';
   final communityTestUtils = CommunityTestUtils();
   final eventTestUtils = EventTestUtils();
+  setupTestFixture();
 
   setUp(() async {
-    setFirebaseAppFactory(
-      () => admin_interop.FirebaseAdmin.instance.initializeApp()!,
-    );
-
     final testCommunity = Community(
       id: '123496953333999ddddd',
       name: 'Testing Community',

--- a/firebase/functions/test/events/notifications/send_event_message_test.dart
+++ b/firebase/functions/test/events/notifications/send_event_message_test.dart
@@ -11,6 +11,7 @@ import 'package:functions/utils/infra/firestore_utils.dart';
 import 'package:firebase_admin_interop/firebase_admin_interop.dart'
     as admin_interop hide EventType;
 import '../../util/community_test_utils.dart';
+import '../../util/email_test_utils.dart';
 import '../../util/event_test_utils.dart';
 
 void main() {
@@ -154,5 +155,3 @@ void main() {
 }
 
 class MockCommunity extends Mock implements Community {}
-
-class MockUserRecord extends Mock implements admin_interop.UserRecord {}

--- a/firebase/functions/test/util/community_test_utils.dart
+++ b/firebase/functions/test/util/community_test_utils.dart
@@ -10,7 +10,20 @@ import 'package:functions/utils/infra/firebase_auth_utils.dart';
 import 'package:functions/utils/infra/firestore_utils.dart';
 import 'package:mocktail/mocktail.dart';
 
+const adminUserId = 'adminUser';
+
 class CommunityTestUtils {
+  static final testCommunity = Community(
+    id: '1999',
+    name: 'Testing Community',
+    isPublic: true,
+  );
+  Future<String> createTestCommunity() async {
+    final result =
+        await createCommunity(community: testCommunity, userId: adminUserId);
+    return result['communityId'];
+  }
+
   Future<Map<String, dynamic>> createCommunity({
     required Community community,
     required String userId,

--- a/firebase/functions/test/util/community_test_utils.dart
+++ b/firebase/functions/test/util/community_test_utils.dart
@@ -62,65 +62,6 @@ class CommunityTestUtils {
       );
     });
   }
-
-  Future<void> deleteAllCommunities() async {
-    // Clean up all test data
-
-    // Delete all communities
-    final communityDocs = await firestore.collection('community').get();
-    await Future.wait(
-      communityDocs.documents.map((doc) async {
-        // First delete all subcollections
-        final commId = doc.documentID;
-
-        // Delete join requests
-        final joinRequestDocs =
-            await firestore.collection('community/$commId/join-requests').get();
-        await Future.wait(
-          joinRequestDocs.documents.map((d) => d.reference.delete()),
-        );
-
-        // Delete events
-        final eventDocs = await firestore
-            .collectionGroup('events')
-            .where('communityId', isEqualTo: commId)
-            .get();
-        await Future.wait(
-          eventDocs.documents.map((d) => d.reference.delete()),
-        );
-
-        // Delete templates
-        final templateDocs =
-            await firestore.collection('community/$commId/templates').get();
-        await Future.wait(
-          templateDocs.documents.map((d) => d.reference.delete()),
-        );
-
-        // Delete the community document itself
-        await doc.reference.delete();
-      }),
-    );
-
-    // Delete all memberships
-    final membershipDocs =
-        await firestore.collectionGroup('community-membership').get();
-    await Future.wait(
-      membershipDocs.documents.map((doc) => doc.reference.delete()),
-    );
-
-    // Delete all user settings
-    final settingsDocs =
-        await firestore.collectionGroup('communityUserSettings').get();
-    await Future.wait(
-      settingsDocs.documents.map((doc) => doc.reference.delete()),
-    );
-
-    // Delete all email digests
-    final digestDocs = await firestore.collectionGroup('emailDigests').get();
-    await Future.wait(
-      digestDocs.documents.map((doc) => doc.reference.delete()),
-    );
-  }
 }
 
 class MockFirebaseAuthUtils extends Mock implements FirebaseAuthUtils {}

--- a/firebase/functions/test/util/community_test_utils.dart
+++ b/firebase/functions/test/util/community_test_utils.dart
@@ -1,10 +1,14 @@
-import 'package:firebase_admin_interop/firebase_admin_interop.dart';
+import 'package:data_models/community/membership_request.dart';
+import 'package:firebase_admin_interop/firebase_admin_interop.dart'
+    as admin_interop;
 import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 import 'package:functions/community/create_community.dart';
 import 'package:data_models/cloud_functions/requests.dart';
 import 'package:data_models/community/community.dart';
 import 'package:data_models/community/membership.dart';
+import 'package:functions/utils/infra/firebase_auth_utils.dart';
 import 'package:functions/utils/infra/firestore_utils.dart';
+import 'package:mocktail/mocktail.dart';
 
 class CommunityTestUtils {
   Future<Map<String, dynamic>> createCommunity({
@@ -29,7 +33,7 @@ class CommunityTestUtils {
       transaction.set(
         firestore
             .document('memberships/$userId/community-membership/$communityId'),
-        DocumentData.fromMap(
+        admin_interop.DocumentData.fromMap(
           firestoreUtils.toFirestoreJson(
             Membership(
               communityId: communityId,
@@ -41,4 +45,84 @@ class CommunityTestUtils {
       );
     });
   }
+
+  Future<void> addJoinRequest({
+    required MembershipRequest request,
+  }) async {
+    await firestore.runTransaction((transaction) async {
+      transaction.set(
+        firestore.document(
+          'community/${request.communityId}/join-requests/${request.userId}',
+        ),
+        admin_interop.DocumentData.fromMap(
+          firestoreUtils.toFirestoreJson(
+            request.toJson(),
+          ),
+        ),
+      );
+    });
+  }
+
+  Future<void> deleteAllCommunities() async {
+    // Clean up all test data
+
+    // Delete all communities
+    final communityDocs = await firestore.collection('community').get();
+    await Future.wait(
+      communityDocs.documents.map((doc) async {
+        // First delete all subcollections
+        final commId = doc.documentID;
+
+        // Delete join requests
+        final joinRequestDocs =
+            await firestore.collection('community/$commId/join-requests').get();
+        await Future.wait(
+          joinRequestDocs.documents.map((d) => d.reference.delete()),
+        );
+
+        // Delete events
+        final eventDocs = await firestore
+            .collectionGroup('events')
+            .where('communityId', isEqualTo: commId)
+            .get();
+        await Future.wait(
+          eventDocs.documents.map((d) => d.reference.delete()),
+        );
+
+        // Delete templates
+        final templateDocs =
+            await firestore.collection('community/$commId/templates').get();
+        await Future.wait(
+          templateDocs.documents.map((d) => d.reference.delete()),
+        );
+
+        // Delete the community document itself
+        await doc.reference.delete();
+      }),
+    );
+
+    // Delete all memberships
+    final membershipDocs =
+        await firestore.collectionGroup('community-membership').get();
+    await Future.wait(
+      membershipDocs.documents.map((doc) => doc.reference.delete()),
+    );
+
+    // Delete all user settings
+    final settingsDocs =
+        await firestore.collectionGroup('communityUserSettings').get();
+    await Future.wait(
+      settingsDocs.documents.map((doc) => doc.reference.delete()),
+    );
+
+    // Delete all email digests
+    final digestDocs = await firestore.collectionGroup('emailDigests').get();
+    await Future.wait(
+      digestDocs.documents.map((doc) => doc.reference.delete()),
+    );
+  }
 }
+
+class MockFirebaseAuthUtils extends Mock implements FirebaseAuthUtils {}
+
+class MockUserRecord extends Mock implements admin_interop.UserRecord {}

--- a/firebase/functions/test/util/email_test_utils.dart
+++ b/firebase/functions/test/util/email_test_utils.dart
@@ -1,0 +1,13 @@
+import 'package:data_models/cloud_functions/requests.dart';
+import 'package:functions/utils/notifications_utils.dart';
+import 'package:functions/utils/send_email_client.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockSendEmailClient extends Mock implements SendEmailClient {}
+
+// Create mock classes for SendGridEmail and SendGridEmailMessage
+class MockSendGridEmail extends Mock implements SendGridEmail {}
+
+class MockSendGridEmailMessage extends Mock implements SendGridEmailMessage {}
+
+class MockNotificationsUtils extends Mock implements NotificationsUtils {}

--- a/firebase/functions/test/util/event_test_utils.dart
+++ b/firebase/functions/test/util/event_test_utils.dart
@@ -4,7 +4,6 @@ import 'package:functions/events/notifications/event_emails.dart';
 import 'package:functions/utils/infra/firestore_utils.dart';
 import 'package:data_models/events/event.dart';
 import 'package:data_models/community/membership.dart';
-import 'package:functions/utils/notifications_utils.dart';
 import 'package:mocktail/mocktail.dart';
 
 class EventTestUtils {
@@ -215,5 +214,3 @@ class EventTestUtils {
 }
 
 class MockEventEmails extends Mock implements EventEmails {}
-
-class MockNotificationsUtils extends Mock implements NotificationsUtils {}

--- a/firebase/functions/test/util/function_test_fixture.dart
+++ b/firebase/functions/test/util/function_test_fixture.dart
@@ -1,0 +1,42 @@
+import 'package:firebase_admin_interop/firebase_admin_interop.dart';
+import 'package:functions/utils/infra/firestore_utils.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+import 'subscription_test_utils.dart';
+
+void setupTestFixture() {
+  final subscriptionTestUtils = SubscriptionTestUtils();
+
+  setUpAll(() async {
+    setFirebaseAppFactory(() => FirebaseAdmin.instance.initializeApp()!);
+    // App currently uses these unrestricted capabilities for all communities, which are preloaded into the DB
+    await subscriptionTestUtils.addUnrestrictedPlanCapabilities(
+      planCapabilities: SubscriptionTestUtils.unrestrictedPlan,
+    );
+  });
+
+  setUp(() async {
+    // clean up test database between test runs
+    await deleteAllCollections();
+  });
+  tearDown(() async {
+    resetMocktailState();
+  });
+}
+
+Future<void> deleteAllCollections() async {
+  final collections = await firestore.listCollections();
+  for (final collection in collections) {
+    // Delete all data except for preloaded unrestricted plan capabilities
+    if (collection.path != 'plan-capability-lists') {
+      final documents = await collection.get();
+
+      await Future.wait(
+        documents.documents.map((doc) async {
+          await doc.reference.delete();
+        }),
+      );
+    }
+  }
+}

--- a/firebase/functions/test/util/subscription_test_utils.dart
+++ b/firebase/functions/test/util/subscription_test_utils.dart
@@ -1,6 +1,8 @@
 import 'package:data_models/admin/plan_capability_list.dart';
 import 'package:firebase_admin_interop/firebase_admin_interop.dart';
 import 'package:functions/utils/infra/firestore_utils.dart';
+import 'package:functions/utils/subscription_plan_util.dart';
+import 'package:mocktail/mocktail.dart';
 
 class SubscriptionTestUtils {
   static final unrestrictedPlan = PlanCapabilityList(
@@ -50,3 +52,5 @@ class SubscriptionTestUtils {
     }
   }
 }
+
+class MockSubscriptionPlanUtil extends Mock implements SubscriptionPlanUtil {}

--- a/firebase/functions/test/util/subscription_test_utils.dart
+++ b/firebase/functions/test/util/subscription_test_utils.dart
@@ -1,0 +1,52 @@
+import 'package:data_models/admin/plan_capability_list.dart';
+import 'package:firebase_admin_interop/firebase_admin_interop.dart';
+import 'package:functions/utils/infra/firestore_utils.dart';
+
+class SubscriptionTestUtils {
+  static final unrestrictedPlan = PlanCapabilityList(
+    type: 'unrestricted',
+    adminCount: 1000000,
+    facilitatorCount: 1000000,
+    hasAdvancedBranding: true,
+    hasBasicAnalytics: true,
+    hasCustomAnalytics: true,
+    hasCustomUrls: true,
+    hasIntegrations: true,
+    hasLivestreams: true,
+    hasPrePost: true,
+    hasSmartMatching: true,
+    userHours: 1000000,
+  );
+  static final unrestrictedPlanWithQuotas =
+      unrestrictedPlan.copyWith(adminCount: 1, facilitatorCount: 1);
+
+  Future<void> addUnrestrictedPlanCapabilities({
+    required PlanCapabilityList planCapabilities,
+  }) async {
+    final planCollection = firestore.collection('/plan-capability-lists/');
+    final planDocRef = planCollection.document();
+    await firestore.runTransaction((transaction) async {
+      transaction.set(
+        planDocRef,
+        DocumentData.fromMap(
+          firestoreUtils.toFirestoreJson(planCapabilities.toJson()),
+        ),
+      );
+    });
+  }
+
+  Future<void> removeUnrestrictedPlanCapabilities() async {
+    final matchingCapabilities = await firestore
+        .collection('plan-capability-lists')
+        .where(
+          PlanCapabilityList.kFieldType,
+          isEqualTo: 'unrestricted',
+        )
+        .limit(1)
+        .get();
+
+    if (matchingCapabilities.documents.isNotEmpty) {
+      await matchingCapabilities.documents.first.reference.delete();
+    }
+  }
+}


### PR DESCRIPTION
## What is in this PR?
New tests of community-related Firebase functions


## Changes in the codebase
- Separated auth utils from firestore utils to support testing. Allows for mocking of auth functionality while still using firestore.
- Added 11 new tests of remaining community functions

## Changes outside the codebase
None 

## Testing this PR
Tests run in CI

