### PR TITLE
Add live meeting tests

### DIFF
--- a/firebase/functions/lib/events/live_meetings/get_meeting_join_info.dart
+++ b/firebase/functions/lib/events/live_meetings/get_meeting_join_info.dart
@@ -12,9 +12,11 @@ import 'package:data_models/user/public_user_info.dart';
 import 'package:data_models/utils/utils.dart';
 
 class GetMeetingJoinInfo extends OnCallMethod<GetMeetingJoinInfoRequest> {
-  GetMeetingJoinInfo()
-      : super(
-          'GetMeetingJoinInfo',
+  LiveMeetingUtils liveMeetingUtils;
+  GetMeetingJoinInfo({LiveMeetingUtils? liveMeetingUtils})
+      : liveMeetingUtils = liveMeetingUtils ?? LiveMeetingUtils(),
+        super(
+          'GetBreakoutRoomJoinInfo',
           (jsonMap) => GetMeetingJoinInfoRequest.fromJson(jsonMap),
         );
 
@@ -57,7 +59,7 @@ class GetMeetingJoinInfo extends OnCallMethod<GetMeetingJoinInfoRequest> {
         print('Public user display name: $displayName');
       }
 
-      final joinInfo = await LiveMeetingUtils().getMeetingJoinInfo(
+      final joinInfo = await liveMeetingUtils.getMeetingJoinInfo(
         transaction: transaction,
         event: event,
         communityId: event.communityId,
@@ -65,7 +67,6 @@ class GetMeetingJoinInfo extends OnCallMethod<GetMeetingJoinInfoRequest> {
         meetingId: event.id,
         userId: context.authUid!,
       );
-
       return joinInfo.toJson();
     });
   }

--- a/firebase/functions/lib/events/live_meetings/kick_participant.dart
+++ b/firebase/functions/lib/events/live_meetings/kick_participant.dart
@@ -10,8 +10,10 @@ import 'package:data_models/events/live_meetings/live_meeting.dart';
 import 'package:data_models/community/membership.dart';
 
 class KickParticipant extends OnCallMethod<KickParticipantRequest> {
-  KickParticipant()
-      : super(
+  AgoraUtils agoraUtils;
+  KickParticipant({AgoraUtils? agoraUtils})
+      : agoraUtils = agoraUtils ?? AgoraUtils(),
+        super(
           'KickParticipant',
           (json) => KickParticipantRequest.fromJson(json),
         );
@@ -52,8 +54,8 @@ class KickParticipant extends OnCallMethod<KickParticipantRequest> {
 
       // Kick participant
       final roomId = request.breakoutRoomId ?? liveMeeting.meetingId ?? '';
-      await AgoraUtils()
-          .kickParticipant(roomId: roomId, userId: request.userToKickId);
+      await agoraUtils.kickParticipant(
+          roomId: roomId, userId: request.userToKickId);
     });
 
     return '';

--- a/firebase/functions/lib/events/live_meetings/mux_client.dart
+++ b/firebase/functions/lib/events/live_meetings/mux_client.dart
@@ -4,7 +4,7 @@ import 'dart:convert';
 import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 import 'package:node_http/node_http.dart' as http;
 
-final muxApi = MuxApi();
+MuxApi muxApi = MuxApi();
 
 class MuxApi {
   static final _muxTokenId = functions.config.get('mux.token_id') as String;

--- a/firebase/functions/lib/events/live_meetings/update_live_stream_participant_count.dart
+++ b/firebase/functions/lib/events/live_meetings/update_live_stream_participant_count.dart
@@ -15,7 +15,7 @@ class UpdateLiveStreamParticipantCount implements CloudFunction {
   final Duration _updateInterval =
       Duration(seconds: (60.0 / _timesPerMinute).round());
 
-  FutureOr<void> _action(EventContext context) async {
+  FutureOr<void> action(EventContext context) async {
     try {
       // Do a first pass to only check for active livestreams in the next day.
       // If not, we can skip the rest of this action.
@@ -146,6 +146,6 @@ class UpdateLiveStreamParticipantCount implements CloudFunction {
         )
         .pubsub
         .schedule('every 1 minutes')
-        .onRun((_, context) => _action(context));
+        .onRun((_, context) => action(context));
   }
 }

--- a/firebase/functions/lib/events/live_meetings/vote_to_kick.dart
+++ b/firebase/functions/lib/events/live_meetings/vote_to_kick.dart
@@ -13,8 +13,10 @@ import 'package:data_models/utils/utils.dart';
 
 /// Cast a vote for or against kicking a user from a hostless meeting
 class VoteToKick extends OnCallMethod<VoteToKickRequest> {
-  VoteToKick()
-      : super('VoteToKick', (json) => VoteToKickRequest.fromJson(json));
+  AgoraUtils agoraUtils;
+  VoteToKick({AgoraUtils? agoraUtils})
+      : agoraUtils = agoraUtils ?? AgoraUtils(),
+        super('VoteToKick', (json) => VoteToKickRequest.fromJson(json));
 
   @override
   Future<void> action(
@@ -172,8 +174,10 @@ class VoteToKick extends OnCallMethod<VoteToKickRequest> {
       print('Current user location is: ${participant.currentBreakoutRoomId}');
       // Kick participant
       final roomId = participant.currentBreakoutRoomId ?? liveMeetingId;
-      await AgoraUtils()
-          .kickParticipant(roomId: roomId, userId: request.targetUserId);
+      await agoraUtils.kickParticipant(
+        roomId: roomId,
+        userId: request.targetUserId,
+      );
     }
   }
 }

--- a/firebase/functions/test/community/on_community_membership_test.dart
+++ b/firebase/functions/test/community/on_community_membership_test.dart
@@ -1,7 +1,5 @@
 import 'package:data_models/community/community.dart';
 import 'package:data_models/community/membership.dart';
-import 'package:firebase_functions_interop/firebase_functions_interop.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 import 'package:functions/utils/infra/firestore_utils.dart';
 import 'package:functions/community/on_community_membership.dart';
@@ -222,5 +220,3 @@ void main() {
     );
   });
 }
-
-class MockEventContext extends Mock implements EventContext {}

--- a/firebase/functions/test/community/trigger_email_digests_test.dart
+++ b/firebase/functions/test/community/trigger_email_digests_test.dart
@@ -367,5 +367,3 @@ void main() {
     verify(() => sendEmailClient.sendEmails([])).called(1);
   });
 }
-
-class MockEventContext extends Mock implements EventContext {}

--- a/firebase/functions/test/events/live_meetings/create_live_stream_test.dart
+++ b/firebase/functions/test/events/live_meetings/create_live_stream_test.dart
@@ -1,0 +1,85 @@
+import 'package:firebase_functions_interop/firebase_functions_interop.dart';
+import 'package:functions/events/live_meetings/create_live_stream.dart';
+import 'package:functions/events/live_meetings/mux_client.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+import 'package:data_models/cloud_functions/requests.dart';
+import '../../util/community_test_utils.dart';
+import '../../util/function_test_fixture.dart';
+import '../../util/live_meeting_test_utils.dart';
+
+void main() {
+  late String communityId;
+  final communityUtils = CommunityTestUtils();
+  muxApi = MockMuxApi();
+  setupTestFixture();
+
+  setUp(() async {
+    // Set up mock MUX response
+    when(() => muxApi.createLiveStream()).thenAnswer(
+      (_) async => {
+        'id': 'fake-mux-stream-id',
+        'playback_ids': [
+          {'id': 'fake-playback-id', 'policy': 'public'},
+        ],
+        'stream_key': 'fake-stream-key',
+      },
+    );
+    communityId = await communityUtils.createTestCommunity();
+  });
+
+  test('Successfully creates live stream for admin user', () async {
+    final req = CreateLiveStreamRequest(
+      communityId: communityId,
+    );
+
+    final createLiveStream = CreateLiveStream();
+
+    final result = await createLiveStream.action(
+      req,
+      CallableContext(adminUserId, null, 'fakeInstanceId'),
+    );
+
+    expect(result, isA<Map<String, dynamic>>());
+    expect(result['muxId'], equals('fake-mux-stream-id'));
+    expect(result['muxPlaybackId'], equals('fake-playback-id'));
+    expect(
+      result['streamServerUrl'],
+      equals('rtmp://global-live.mux.com:5222/app'),
+    );
+    expect(result['streamKey'], equals('fake-stream-key'));
+
+    verify(() => muxApi.createLiveStream()).called(1);
+  });
+
+  test('Throws unauthorized error for non-admin user', () async {
+    // Create non-admin membership
+    await communityUtils.addCommunityMember(
+      communityId: communityId,
+      userId: adminUserId,
+    );
+
+    final req = CreateLiveStreamRequest(
+      communityId: communityId,
+    );
+
+    final createLiveStream = CreateLiveStream();
+
+    expect(
+      () => createLiveStream.action(
+        req,
+        CallableContext(adminUserId, null, 'fakeInstanceId'),
+      ),
+      throwsA(
+        predicate(
+          (e) =>
+              e is HttpsError &&
+              e.code == HttpsError.failedPrecondition &&
+              e.message == 'unauthorized',
+        ),
+      ),
+    );
+
+    verifyNever(() => muxApi.createLiveStream());
+  });
+}

--- a/firebase/functions/test/events/live_meetings/get_meeting_chat_suggestion_data_test.dart
+++ b/firebase/functions/test/events/live_meetings/get_meeting_chat_suggestion_data_test.dart
@@ -1,0 +1,186 @@
+import 'package:data_models/chat/emotion.dart';
+import 'package:data_models/events/live_meetings/meeting_guide.dart';
+import 'package:data_models/user/public_user_info.dart';
+import 'package:firebase_functions_interop/firebase_functions_interop.dart';
+import 'package:functions/events/live_meetings/get_meeting_chat_suggestion_data.dart';
+import 'package:data_models/events/event.dart';
+import 'package:data_models/chat/chat.dart';
+import 'package:data_models/chat/chat_suggestion_data.dart';
+import 'package:functions/utils/infra/firebase_auth_utils.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+import 'package:data_models/cloud_functions/requests.dart';
+import '../../util/community_test_utils.dart';
+import '../../util/event_test_utils.dart';
+import '../../util/function_test_fixture.dart';
+import '../../util/live_meeting_test_utils.dart';
+
+void main() {
+  late String communityId;
+  const templateId = '9654';
+  final eventUtils = EventTestUtils();
+  final communityUtils = CommunityTestUtils();
+  final liveMeetingTestUtils = LiveMeetingTestUtils();
+  final mockFirebaseAuthUtils = MockFirebaseAuthUtils();
+  firebaseAuthUtils = mockFirebaseAuthUtils;
+  setupTestFixture();
+
+  setUp(() async {
+    communityId = await communityUtils.createTestCommunity();
+  });
+
+  test('Chat suggestion data is returned correctly', () async {
+    var event = Event(
+      id: '5678',
+      status: EventStatus.active,
+      communityId: communityId,
+      templateId: templateId,
+      creatorId: adminUserId,
+      nullableEventType: EventType.hosted,
+      collectionPath: '',
+      agendaItems: [
+        AgendaItem(
+          id: '555',
+          title: "Discussion",
+          content: "Group discussion topic",
+          nullableType: AgendaItemType.userSuggestions,
+        ),
+      ],
+    );
+
+    event = await eventUtils.createEvent(
+      event: event,
+      userId: adminUserId,
+    );
+
+    // Add test participants
+    await eventUtils.joinEventMultiple(
+      communityId: communityId,
+      templateId: templateId,
+      eventId: event.id,
+      participantIds: ['333', '444'],
+      breakoutSessionId: null,
+    );
+
+    // Add Community members with public user info
+    await communityUtils.addCommunityMember(
+      userId: '333',
+      communityId: communityId,
+    );
+    await communityUtils.addCommunityMember(
+      userId: '444',
+      communityId: communityId,
+    );
+
+    final publicUserInfo1 = PublicUserInfo(
+      id: '333',
+      displayName: 'Test User 1',
+      agoraId: 123,
+    );
+    await liveMeetingTestUtils.addPublicUser(publicUser: publicUserInfo1);
+
+    final publicUserInfo2 = PublicUserInfo(
+      id: '444',
+      displayName: 'Test User 2',
+      agoraId: 456,
+    );
+    await liveMeetingTestUtils.addPublicUser(publicUser: publicUserInfo2);
+
+    // Add some test chat messages
+    print("creating chat with ${event.fullPath}");
+    await liveMeetingTestUtils.addChatMessage(
+      parentPath: event.fullPath,
+      message: ChatMessage(
+        creatorId: '333',
+        message: 'Hello everyone',
+        createdDate: DateTime.now(),
+        messageStatus: ChatMessageStatus.active,
+        emotionType: EmotionType.exclamation,
+      ),
+    );
+
+    // Add some test suggestions
+    await liveMeetingTestUtils.addSuggestedAgendaItem(
+      parentPath: event.fullPath,
+      suggestion: SuggestedAgendaItem(
+        creatorId: '444',
+        content: 'Let\'s discuss this topic',
+        createdDate: DateTime.now(),
+        upvotedUserIds: ['333'],
+        downvotedUserIds: [],
+      ),
+    );
+    final liveMeetingPath = liveMeetingTestUtils.getLiveMeetingPath(event);
+    await liveMeetingTestUtils.addParticipantAgendaItemDetails(
+      event: event,
+      participantAgendaItemDetails: ParticipantAgendaItemDetails(
+        userId: '333',
+        meetingId: liveMeetingPath.split('/').last,
+        suggestions: [
+          MeetingUserSuggestion(id: '6221', suggestion: 'Do something else'),
+        ],
+      ),
+      agendaItemId: event.agendaItems.first.id,
+    );
+    final userRecord = MockUserRecord();
+    when(() => userRecord.uid).thenReturn('333');
+    when(() => userRecord.email).thenReturn('requester@example.com');
+    when(() => userRecord.displayName).thenReturn('Test User 1');
+    when(
+      () => mockFirebaseAuthUtils.getUser('333'),
+    ).thenAnswer((_) async => userRecord);
+
+    final userRecord2 = MockUserRecord();
+    when(() => userRecord2.uid).thenReturn('444');
+    when(() => userRecord2.email).thenReturn('requester2@example.com');
+    when(() => userRecord2.displayName).thenReturn('Test User 2');
+    when(
+      () => mockFirebaseAuthUtils.getUser('444'),
+    ).thenAnswer((_) async => userRecord2);
+
+    final req = GetMeetingChatsSuggestionsDataRequest(
+      eventPath: event.fullPath,
+    );
+
+    final chatInfo = GetMeetingChatSuggestionData();
+
+    final result = await chatInfo.action(
+      req,
+      CallableContext(adminUserId, null, 'fakeInstanceId'),
+    );
+
+    expect(result['chatsSuggestionsList'], isNotNull);
+    final suggestions = (result['chatsSuggestionsList'] as List)
+        .map((item) => ChatSuggestionData.fromJson(item))
+        .toList();
+    print("hi $suggestions");
+    expect(suggestions.length, equals(3));
+
+    // Verify chat message
+    final chatMessage = suggestions.firstWhere(
+      (s) => s.type == ChatSuggestionType.chat,
+    );
+    expect(chatMessage.creatorId, equals('333'));
+    expect(chatMessage.message, equals('Hello everyone'));
+    expect(chatMessage.emotionType, equals(EmotionType.exclamation));
+    expect(chatMessage.creatorName, equals('Test User 1'));
+
+    // Verify suggestion
+    final suggestion = suggestions.firstWhere(
+      (s) => s.type == ChatSuggestionType.suggestion && s.creatorId == '444',
+    );
+    expect(suggestion.message, equals('Let\'s discuss this topic'));
+    expect(suggestion.upvotes, equals(1));
+    expect(suggestion.downvotes, equals(0));
+    expect(suggestion.creatorName, equals('Test User 2'));
+
+    // Verify agenda item details
+    final agendaItemDetails = suggestions.firstWhere(
+      (s) => s.type == ChatSuggestionType.suggestion && s.creatorId == '333',
+    );
+    expect(agendaItemDetails.message, equals('Do something else'));
+    expect(agendaItemDetails.upvotes, equals(0));
+    expect(agendaItemDetails.downvotes, equals(0));
+    expect(agendaItemDetails.creatorName, equals('Test User 1'));
+  });
+}

--- a/firebase/functions/test/events/live_meetings/get_meeting_chat_suggestion_data_test.dart
+++ b/firebase/functions/test/events/live_meetings/get_meeting_chat_suggestion_data_test.dart
@@ -87,7 +87,6 @@ void main() {
     await liveMeetingTestUtils.addPublicUser(publicUser: publicUserInfo2);
 
     // Add some test chat messages
-    print("creating chat with ${event.fullPath}");
     await liveMeetingTestUtils.addChatMessage(
       parentPath: event.fullPath,
       message: ChatMessage(
@@ -153,7 +152,6 @@ void main() {
     final suggestions = (result['chatsSuggestionsList'] as List)
         .map((item) => ChatSuggestionData.fromJson(item))
         .toList();
-    print("hi $suggestions");
     expect(suggestions.length, equals(3));
 
     // Verify chat message

--- a/firebase/functions/test/events/live_meetings/get_meeting_join_info_test.dart
+++ b/firebase/functions/test/events/live_meetings/get_meeting_join_info_test.dart
@@ -1,0 +1,144 @@
+import 'package:data_models/events/live_meetings/live_meeting.dart';
+import 'package:firebase_functions_interop/firebase_functions_interop.dart';
+import 'package:functions/events/live_meetings/live_meeting_utils.dart';
+import 'package:get_it/get_it.dart';
+import 'package:functions/events/live_meetings/get_meeting_join_info.dart';
+import 'package:data_models/events/event.dart';
+import 'package:data_models/user/public_user_info.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+import 'package:data_models/cloud_functions/requests.dart';
+import 'package:uuid/uuid.dart';
+import '../../util/community_test_utils.dart';
+import '../../util/event_test_utils.dart';
+import '../../util/function_test_fixture.dart';
+import '../../util/live_meeting_test_utils.dart';
+
+void main() {
+  String communityId = '';
+  const userId = 'fakeAuthId';
+  const templateId = '9654';
+  GetIt.instance.registerSingleton(const Uuid());
+  final eventUtils = EventTestUtils();
+  final communityUtils = CommunityTestUtils();
+  final liveMeetingTestUtils = LiveMeetingTestUtils();
+  setupTestFixture();
+
+  setUp(() async {
+    communityId = await communityUtils.createTestCommunity();
+  });
+
+  test('Meeting join info is returned for active participant', () async {
+    // Create test event
+    var event = Event(
+      id: '5678',
+      status: EventStatus.active,
+      communityId: communityId,
+      templateId: templateId,
+      creatorId: userId,
+      nullableEventType: EventType.hosted,
+      collectionPath: '',
+      agendaItems: [
+        AgendaItem(
+          id: '555',
+          title: "Test Agenda",
+          content: "Test Content",
+        ),
+      ],
+    );
+    event = await eventUtils.createEvent(
+      event: event,
+      userId: userId,
+    );
+
+    await liveMeetingTestUtils.addMeetingEvent(
+      liveMeetingPath: liveMeetingTestUtils.getLiveMeetingPath(event),
+      meetingEvent: LiveMeetingEvent(
+        agendaItem: event.agendaItems.first.id,
+        event: LiveMeetingEventType.agendaItemStarted,
+      ),
+    );
+
+    // Create test public user info
+    final publicUserInfo = PublicUserInfo(
+      id: userId,
+      displayName: 'Test User',
+      agoraId: 123,
+      imageUrl: 'http://example.com/image.jpg',
+    );
+
+    await liveMeetingTestUtils.addPublicUser(publicUser: publicUserInfo);
+
+    final req = GetMeetingJoinInfoRequest(
+      eventPath: event.fullPath,
+    );
+    final agoraUtils = MockAgoraUtils();
+    when(
+      () => agoraUtils.createToken(
+        uid: liveMeetingTestUtils.uidToInt(userId),
+        roomId: event.id,
+      ),
+    ).thenReturn('fakeToken');
+
+    final getMeetingJoinInfo = GetMeetingJoinInfo(
+      liveMeetingUtils: LiveMeetingUtils(agoraUtils: agoraUtils),
+    );
+
+    final result = await getMeetingJoinInfo.action(
+      req,
+      CallableContext(userId, null, 'fakeInstanceId'),
+    );
+
+    expect(result, isA<Map<String, dynamic>>());
+    expect(result['identity'], equals(userId));
+    expect(result['meetingToken'], equals('fakeToken'));
+    expect(result['meetingId'], equals(event.id));
+  });
+
+  test('Throws unauthorized error for inactive participant', () async {
+    var event = Event(
+      id: '5678',
+      status: EventStatus.active,
+      communityId: communityId,
+      templateId: templateId,
+      creatorId: userId,
+      nullableEventType: EventType.hosted,
+      collectionPath: '',
+      agendaItems: [],
+    );
+    event = await eventUtils.createEvent(
+      event: event,
+      userId: userId,
+    );
+
+    // Join event as inactive participant
+    await eventUtils.joinEvent(
+      communityId: communityId,
+      templateId: templateId,
+      eventId: event.id,
+      uid: userId,
+      participantStatus: ParticipantStatus.banned,
+    );
+
+    final req = GetMeetingJoinInfoRequest(
+      eventPath: event.fullPath,
+    );
+
+    final getMeetingJoinInfo = GetMeetingJoinInfo();
+
+    expect(
+      () => getMeetingJoinInfo.action(
+        req,
+        CallableContext(userId, null, 'fakeInstanceId'),
+      ),
+      throwsA(
+        predicate(
+          (e) =>
+              e is HttpsError &&
+              e.code == HttpsError.failedPrecondition &&
+              e.message == 'unauthorized',
+        ),
+      ),
+    );
+  });
+}

--- a/firebase/functions/test/events/live_meetings/get_user_id_from_agora_id_test.dart
+++ b/firebase/functions/test/events/live_meetings/get_user_id_from_agora_id_test.dart
@@ -1,0 +1,86 @@
+import 'package:firebase_functions_interop/firebase_functions_interop.dart';
+import 'package:functions/events/live_meetings/get_user_id_from_agora_id.dart';
+import 'package:data_models/user/public_user_info.dart';
+import 'package:test/test.dart';
+import 'package:data_models/cloud_functions/requests.dart';
+
+import '../../util/function_test_fixture.dart';
+import '../../util/live_meeting_test_utils.dart';
+
+void main() {
+  const userId = 'testUserId';
+  const agoraId = 123;
+  final liveMeetingTestUtils = LiveMeetingTestUtils();
+  setupTestFixture();
+
+  test('Returns user ID when Agora ID exists', () async {
+    // Create test public user info
+    final publicUserInfo = PublicUserInfo(
+      id: userId,
+      displayName: 'Test User',
+      agoraId: agoraId,
+      imageUrl: 'http://example.com/image.jpg',
+    );
+    await liveMeetingTestUtils.addPublicUser(publicUser: publicUserInfo);
+
+    final req = GetUserIdFromAgoraIdRequest(
+      agoraId: agoraId,
+    );
+
+    final getUserIdFromAgoraId = GetUserIdFromAgoraId();
+
+    final result = await getUserIdFromAgoraId.action(
+      req,
+      CallableContext(userId, null, 'fakeInstanceId'),
+    );
+
+    expect(result, isA<Map<String, dynamic>>());
+    expect(result['userId'], equals(userId));
+  });
+
+  test('Throws not found error when Agora ID does not exist', () async {
+    final req = GetUserIdFromAgoraIdRequest(
+      agoraId: 999, // Non-existent Agora ID
+    );
+
+    final getUserIdFromAgoraId = GetUserIdFromAgoraId();
+
+    expect(
+      () => getUserIdFromAgoraId.action(
+        req,
+        CallableContext(userId, null, 'fakeInstanceId'),
+      ),
+      throwsA(
+        predicate(
+          (e) =>
+              e is HttpsError &&
+              e.code == HttpsError.notFound &&
+              e.message == 'User with agora ID 999 not found',
+        ),
+      ),
+    );
+  });
+
+  test('Throws unauthorized error when auth uid is null', () async {
+    final req = GetUserIdFromAgoraIdRequest(
+      agoraId: agoraId,
+    );
+
+    final getUserIdFromAgoraId = GetUserIdFromAgoraId();
+
+    expect(
+      () => getUserIdFromAgoraId.action(
+        req,
+        CallableContext(null, null, 'fakeInstanceId'),
+      ),
+      throwsA(
+        predicate(
+          (e) =>
+              e is HttpsError &&
+              e.code == HttpsError.failedPrecondition &&
+              e.message == 'unauthorized',
+        ),
+      ),
+    );
+  });
+}

--- a/firebase/functions/test/events/live_meetings/kick_participant_test.dart
+++ b/firebase/functions/test/events/live_meetings/kick_participant_test.dart
@@ -1,0 +1,176 @@
+import 'package:data_models/community/membership.dart';
+import 'package:firebase_functions_interop/firebase_functions_interop.dart';
+import 'package:functions/events/live_meetings/kick_participant.dart';
+import 'package:data_models/events/event.dart';
+import 'package:data_models/events/live_meetings/live_meeting.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+import 'package:data_models/cloud_functions/requests.dart';
+import '../../util/community_test_utils.dart';
+import '../../util/event_test_utils.dart';
+import '../../util/function_test_fixture.dart';
+import '../../util/live_meeting_test_utils.dart';
+
+void main() {
+  late String communityId;
+  const targetUserId = 'testUser2';
+  const templateId = '9654';
+  const liveMeetingId = 'testMeeting123';
+  final eventUtils = EventTestUtils();
+  final communityUtils = CommunityTestUtils();
+  late Event testEvent;
+  late MockAgoraUtils mockAgoraUtils;
+  final liveMeetingTestUtils = LiveMeetingTestUtils();
+  setupTestFixture();
+
+  setUp(() async {
+    communityId = await communityUtils.createTestCommunity();
+
+    // Create test event
+    testEvent = Event(
+      id: '5678',
+      status: EventStatus.active,
+      communityId: communityId,
+      templateId: templateId,
+      creatorId: adminUserId,
+      nullableEventType: EventType.hostless,
+      collectionPath: '',
+    );
+    testEvent = await eventUtils.createEvent(
+      event: testEvent,
+      userId: adminUserId,
+    );
+
+    // Add participant
+    await eventUtils.joinEvent(
+      communityId: communityId,
+      templateId: templateId,
+      eventId: testEvent.id,
+      uid: targetUserId,
+      participantStatus: ParticipantStatus.active,
+    );
+    await liveMeetingTestUtils.addMeetingEvent(
+      liveMeetingPath: liveMeetingTestUtils.getLiveMeetingPath(testEvent),
+      liveMeetingId: liveMeetingId,
+      meetingEvent: LiveMeetingEvent(
+        event: LiveMeetingEventType.agendaItemStarted,
+      ),
+    );
+
+    mockAgoraUtils = MockAgoraUtils();
+    when(
+      () => mockAgoraUtils.kickParticipant(
+        roomId: any(named: 'roomId'),
+        userId: any(named: 'userId'),
+      ),
+    ).thenAnswer((_) => Future.value());
+  });
+
+  test('Event creator can successfully kick participant', () async {
+    final req = KickParticipantRequest(
+      eventPath: testEvent.fullPath,
+      userToKickId: targetUserId,
+      breakoutRoomId: null,
+    );
+
+    final kickParticipant = KickParticipant(agoraUtils: mockAgoraUtils);
+
+    await kickParticipant.action(
+      req,
+      CallableContext(adminUserId, null, 'fakeInstanceId'),
+    );
+
+    verify(
+      () => mockAgoraUtils.kickParticipant(
+        roomId: liveMeetingId,
+        userId: targetUserId,
+      ),
+    ).called(1);
+  });
+
+  test('Moderator can successfully kick participant', () async {
+    // Create moderator user
+    const modUserId = 'modUser';
+    await communityUtils.addCommunityMember(
+      communityId: communityId,
+      userId: modUserId,
+      status: MembershipStatus.mod,
+    );
+
+    final req = KickParticipantRequest(
+      eventPath: testEvent.fullPath,
+      userToKickId: targetUserId,
+      breakoutRoomId: null,
+    );
+
+    final kickParticipant = KickParticipant(agoraUtils: mockAgoraUtils);
+
+    await kickParticipant.action(
+      req,
+      CallableContext(modUserId, null, 'fakeInstanceId'),
+    );
+
+    verify(
+      () => mockAgoraUtils.kickParticipant(
+        roomId: liveMeetingId,
+        userId: targetUserId,
+      ),
+    ).called(1);
+  });
+
+  test('Regular user cannot kick participant', () async {
+    // Create regular user
+    const regularUserId = 'regularUser';
+    await communityUtils.addCommunityMember(
+      communityId: communityId,
+      userId: regularUserId,
+      status: MembershipStatus.member,
+    );
+
+    final req = KickParticipantRequest(
+      eventPath: testEvent.fullPath,
+      userToKickId: targetUserId,
+      breakoutRoomId: null,
+    );
+
+    final kickParticipant = KickParticipant();
+
+    expect(
+      () => kickParticipant.action(
+        req,
+        CallableContext(regularUserId, null, 'fakeInstanceId'),
+      ),
+      throwsA(
+        predicate(
+          (e) =>
+              e is HttpsError &&
+              e.code == HttpsError.failedPrecondition &&
+              e.message == 'unauthorized',
+        ),
+      ),
+    );
+  });
+
+  test('Successfully kicks participant from breakout room', () async {
+    const breakoutRoomId = 'breakoutRoom123';
+    final req = KickParticipantRequest(
+      eventPath: testEvent.fullPath,
+      userToKickId: targetUserId,
+      breakoutRoomId: breakoutRoomId,
+    );
+
+    final kickParticipant = KickParticipant(agoraUtils: mockAgoraUtils);
+
+    await kickParticipant.action(
+      req,
+      CallableContext(adminUserId, null, 'fakeInstanceId'),
+    );
+
+    verify(
+      () => mockAgoraUtils.kickParticipant(
+        roomId: breakoutRoomId,
+        userId: targetUserId,
+      ),
+    ).called(1);
+  });
+}

--- a/firebase/functions/test/events/live_meetings/mux_webhooks_test.dart
+++ b/firebase/functions/test/events/live_meetings/mux_webhooks_test.dart
@@ -1,0 +1,148 @@
+import 'package:data_models/events/event.dart';
+import 'package:functions/events/live_meetings/mux_webhooks.dart';
+import 'package:functions/utils/infra/firestore_utils.dart';
+import 'package:functions/utils/utils.dart';
+import 'package:test/test.dart';
+import '../../util/event_test_utils.dart';
+import '../../util/function_test_fixture.dart';
+
+void main() {
+  final eventUtils = EventTestUtils();
+  setupTestFixture();
+
+  test('handles live stream status change correctly', () async {
+    // Create test event with live stream info
+    final event = await eventUtils.createEvent(
+      event: Event(
+        id: '1234',
+        status: EventStatus.active,
+        communityId: 'test-community',
+        templateId: 'template-123',
+        creatorId: 'test-user',
+        nullableEventType: EventType.hosted,
+        collectionPath: '',
+        liveStreamInfo: LiveStreamInfo(
+          muxId: 'stream-abc123',
+          muxStatus: 'idle',
+        ),
+      ),
+      userId: 'test-user',
+    );
+
+    final muxWebhooks = MuxWebhooks();
+
+    // Simulate Mux webhook payload for stream becoming active
+    final request = JsonMap({
+      'type': 'video.live_stream.active',
+      'object': {
+        'id': 'stream-abc123',
+      },
+      'data': {
+        'status': 'active',
+      },
+    });
+
+    await muxWebhooks.action(request);
+
+    // Verify event was updated with new status
+    final updatedEventSnapshot = await firestore.document(event.fullPath).get();
+
+    final updatedEvent = Event.fromJson(
+      firestoreUtils.fromFirestoreJson(updatedEventSnapshot.data.toMap()),
+    );
+
+    expect(updatedEvent.liveStreamInfo?.muxStatus, equals('active'));
+  });
+
+  test('handles live stream completion correctly', () async {
+    // Create test event with live stream info
+    final event = await eventUtils.createEvent(
+      event: Event(
+        id: '5678',
+        status: EventStatus.active,
+        communityId: 'test-community',
+        templateId: 'template-123',
+        creatorId: 'test-user',
+        nullableEventType: EventType.hosted,
+        collectionPath: '',
+        liveStreamInfo: LiveStreamInfo(
+          muxId: 'stream-xyz789',
+          muxStatus: 'active',
+        ),
+      ),
+      userId: 'test-user',
+    );
+
+    final muxWebhooks = MuxWebhooks();
+
+    // Simulate Mux webhook payload for stream completion
+    final request = JsonMap({
+      'type': 'video.asset.live_stream_completed',
+      'data': {
+        'live_stream_id': 'stream-xyz789',
+        'playback_ids': [
+          {'policy': 'public', 'id': 'playback-123'},
+          {'policy': 'private', 'id': 'playback-456'},
+        ],
+      },
+    });
+
+    await muxWebhooks.action(request);
+
+    // Verify event was updated with new playback ID
+    final updatedEventSnapshot = await firestore.document(event.fullPath).get();
+
+    final updatedEvent = Event.fromJson(
+      firestoreUtils.fromFirestoreJson(updatedEventSnapshot.data.toMap()),
+    );
+
+    expect(
+      updatedEvent.liveStreamInfo?.latestAssetPlaybackId,
+      equals('playback-123'),
+    );
+  });
+
+  test('ignores non-status change webhook events', () async {
+    // Create test event with live stream info
+    final event = await eventUtils.createEvent(
+      event: Event(
+        id: '9012',
+        status: EventStatus.active,
+        communityId: 'test-community',
+        templateId: 'template-123',
+        creatorId: 'test-user',
+        nullableEventType: EventType.hosted,
+        collectionPath: '',
+        liveStreamInfo: LiveStreamInfo(
+          muxId: 'stream-def456',
+          muxStatus: 'active',
+        ),
+      ),
+      userId: 'test-user',
+    );
+
+    final muxWebhooks = MuxWebhooks();
+
+    // Simulate Mux webhook payload for non-status change event
+    final request = JsonMap({
+      'type': 'video.live_stream.connected',
+      'object': {
+        'id': 'stream-def456',
+      },
+      'data': {
+        'status': 'connected',
+      },
+    });
+
+    await muxWebhooks.action(request);
+
+    // Verify event status was not changed
+    final updatedEventSnapshot = await firestore.document(event.fullPath).get();
+
+    final updatedEvent = Event.fromJson(
+      firestoreUtils.fromFirestoreJson(updatedEventSnapshot.data.toMap()),
+    );
+
+    expect(updatedEvent.liveStreamInfo?.muxStatus, equals('active'));
+  });
+}

--- a/firebase/functions/test/events/live_meetings/reset_participant_agenda_items_test.dart
+++ b/firebase/functions/test/events/live_meetings/reset_participant_agenda_items_test.dart
@@ -1,0 +1,209 @@
+import 'package:data_models/community/membership.dart';
+import 'package:data_models/events/live_meetings/live_meeting.dart';
+import 'package:firebase_functions_interop/firebase_functions_interop.dart';
+import 'package:functions/events/live_meetings/reset_participant_agenda_items.dart';
+import 'package:functions/utils/infra/firestore_utils.dart';
+import 'package:data_models/events/event.dart';
+import 'package:data_models/events/live_meetings/meeting_guide.dart';
+import 'package:test/test.dart';
+import 'package:data_models/cloud_functions/requests.dart';
+import '../../util/community_test_utils.dart';
+import '../../util/event_test_utils.dart';
+import '../../util/function_test_fixture.dart';
+import '../../util/live_meeting_test_utils.dart';
+
+void main() {
+  late String communityId;
+  const templateId = '9654';
+  const liveMeetingId = 'testMeeting123';
+  final eventUtils = EventTestUtils();
+  final communityUtils = CommunityTestUtils();
+  late Event testEvent;
+  final liveMeetingTestUtils = LiveMeetingTestUtils();
+  setupTestFixture();
+
+  setUp(() async {
+    communityId = await communityUtils.createTestCommunity();
+
+    // Create test event
+    testEvent = Event(
+      id: '5678',
+      status: EventStatus.active,
+      communityId: communityId,
+      templateId: templateId,
+      creatorId: adminUserId,
+      nullableEventType: EventType.hostless,
+      collectionPath: '',
+      agendaItems: [
+        AgendaItem(
+          id: '55005',
+          title: "Role call",
+          content: "Shout out if you're here",
+        ),
+      ],
+    );
+    testEvent = await eventUtils.createEvent(
+      event: testEvent,
+      userId: adminUserId,
+    );
+    final liveMeetingPath = liveMeetingTestUtils.getLiveMeetingPath(testEvent);
+    // Create live meeting
+    await liveMeetingTestUtils.addMeetingEvent(
+      liveMeetingPath: liveMeetingPath,
+      liveMeetingId: liveMeetingId,
+      meetingEvent: LiveMeetingEvent(
+        event: LiveMeetingEventType.agendaItemStarted,
+      ),
+    );
+    await liveMeetingTestUtils.addParticipantAgendaItemDetails(
+      event: testEvent,
+      participantAgendaItemDetails: ParticipantAgendaItemDetails(
+        userId: 'user1',
+        meetingId: liveMeetingPath.split('/').last,
+      ),
+      agendaItemId: testEvent.agendaItems.first.id,
+    );
+    await liveMeetingTestUtils.addParticipantAgendaItemDetails(
+      event: testEvent,
+      participantAgendaItemDetails: ParticipantAgendaItemDetails(
+        userId: 'user2',
+        meetingId: liveMeetingPath.split('/').last,
+      ),
+      agendaItemId: testEvent.agendaItems.first.id,
+    );
+  });
+
+  test('Event creator can successfully reset participant agenda items',
+      () async {
+    final req = ResetParticipantAgendaItemsRequest(
+      liveMeetingPath: liveMeetingTestUtils.getLiveMeetingPath(testEvent),
+    );
+
+    final resetAgendaItems = ResetParticipantAgendaItems();
+
+    await resetAgendaItems.action(
+      req,
+      CallableContext(adminUserId, null, 'fakeInstanceId'),
+    );
+
+    // Verify that participant details were deleted
+    final participantDetails = await firestore
+        .collectionGroup('participant-details')
+        .where(
+          ParticipantAgendaItemDetails.kFieldMeetingId,
+          isEqualTo: liveMeetingId,
+        )
+        .get();
+
+    expect(participantDetails.documents, isEmpty);
+  });
+
+  test('Admin can successfully reset participant agenda items', () async {
+    // Create admin user
+    const adminUserId2 = 'adminUser';
+    await communityUtils.addCommunityMember(
+      communityId: communityId,
+      userId: adminUserId2,
+      status: MembershipStatus.admin,
+    );
+
+    final req = ResetParticipantAgendaItemsRequest(
+      liveMeetingPath: liveMeetingTestUtils.getLiveMeetingPath(testEvent),
+    );
+
+    final resetAgendaItems = ResetParticipantAgendaItems();
+
+    await resetAgendaItems.action(
+      req,
+      CallableContext(adminUserId2, null, 'fakeInstanceId'),
+    );
+
+    final participantDetails = await firestore
+        .collectionGroup('participant-details')
+        .where(
+          ParticipantAgendaItemDetails.kFieldMeetingId,
+          isEqualTo: liveMeetingId,
+        )
+        .get();
+
+    expect(participantDetails.documents, isEmpty);
+  });
+
+  test('Regular user cannot reset participant agenda items', () async {
+    // Create regular user
+    const regularUserId = 'regularUser';
+    await communityUtils.addCommunityMember(
+      communityId: communityId,
+      userId: regularUserId,
+      status: MembershipStatus.member,
+    );
+
+    final req = ResetParticipantAgendaItemsRequest(
+      liveMeetingPath: liveMeetingTestUtils.getLiveMeetingPath(testEvent),
+    );
+
+    final resetAgendaItems = ResetParticipantAgendaItems();
+
+    expect(
+      () => resetAgendaItems.action(
+        req,
+        CallableContext(regularUserId, null, 'fakeInstanceId'),
+      ),
+      throwsA(
+        predicate(
+          (e) =>
+              e is HttpsError &&
+              e.code == HttpsError.failedPrecondition &&
+              e.message == 'Unauthorized',
+        ),
+      ),
+    );
+  });
+
+  test('Throws error for malformed meeting path', () async {
+    final req = ResetParticipantAgendaItemsRequest(
+      liveMeetingPath: 'invalid/path',
+    );
+
+    final resetAgendaItems = ResetParticipantAgendaItems();
+
+    expect(
+      () => resetAgendaItems.action(
+        req,
+        CallableContext(adminUserId, null, 'fakeInstanceId'),
+      ),
+      throwsA(
+        predicate(
+          (e) =>
+              e is HttpsError &&
+              e.code == HttpsError.invalidArgument &&
+              e.message == 'LiveMeetingPath malformed.',
+        ),
+      ),
+    );
+  });
+
+  test('Throws error for non-existent meeting', () async {
+    final req = ResetParticipantAgendaItemsRequest(
+      liveMeetingPath:
+          'community/$communityId/templates/$templateId/events/nonexistent/live-meetings/fake',
+    );
+
+    final resetAgendaItems = ResetParticipantAgendaItems();
+
+    expect(
+      () => resetAgendaItems.action(
+        req,
+        CallableContext(adminUserId, null, 'fakeInstanceId'),
+      ),
+      throwsA(
+        predicate(
+          (e) =>
+              e is HttpsError &&
+              e.code == HttpsError.failedPrecondition &&
+              e.message == 'Incorrect meeting path',
+        ),
+      ),
+    );
+  });
+}

--- a/firebase/functions/test/events/live_meetings/toggle_like_dislike_on_meeting_user_suggestion_test.dart
+++ b/firebase/functions/test/events/live_meetings/toggle_like_dislike_on_meeting_user_suggestion_test.dart
@@ -1,0 +1,207 @@
+import 'package:firebase_functions_interop/firebase_functions_interop.dart';
+import 'package:functions/events/live_meetings/toggle_like_dislike_on_meeting_user_suggestion.dart';
+import 'package:functions/utils/infra/firestore_utils.dart';
+
+import 'package:data_models/events/event.dart';
+import 'package:data_models/events/live_meetings/meeting_guide.dart';
+import 'package:data_models/discussion_threads/discussion_thread.dart';
+import 'package:test/test.dart';
+import '../../util/community_test_utils.dart';
+import '../../util/event_test_utils.dart';
+import '../../util/function_test_fixture.dart';
+import '../../util/live_meeting_test_utils.dart';
+
+void main() {
+  const voterId = 'voterUser1';
+  const suggestionId = 'suggestion123';
+  const liveMeetingId = 'testMeeting123';
+  const agendaItemId = 'agendaItem123';
+  final liveMeetingTestUtils = LiveMeetingTestUtils();
+  final communityUtils = CommunityTestUtils();
+  final eventUtils = EventTestUtils();
+  late ParticipantAgendaItemDetails testAgendaItemDetails;
+  late String documentPath;
+  late String userSuggestionId;
+  setupTestFixture();
+
+  setUp(() async {
+    final communityId = await communityUtils.createTestCommunity();
+    // Create test agenda item details with a suggestion
+    testAgendaItemDetails = ParticipantAgendaItemDetails(
+      userId: adminUserId,
+      meetingId: liveMeetingId,
+      suggestions: [
+        MeetingUserSuggestion(
+          id: suggestionId,
+          suggestion: 'Test suggestion',
+          likedByIds: [],
+          dislikedByIds: [],
+        ),
+      ],
+    );
+    userSuggestionId = testAgendaItemDetails.suggestions.first.id;
+    // Create test event and add participant agenda item details
+    var testEvent = Event(
+      id: '5678',
+      status: EventStatus.active,
+      communityId: communityId,
+      templateId: 'template123',
+      creatorId: adminUserId,
+      nullableEventType: EventType.hostless,
+      collectionPath: '',
+      agendaItems: [
+        AgendaItem(
+          id: agendaItemId,
+          title: "Test Agenda",
+          content: "Test Content",
+        ),
+      ],
+    );
+    testEvent = await eventUtils.createEvent(
+      event: testEvent,
+      userId: adminUserId,
+    );
+    await liveMeetingTestUtils.addParticipantAgendaItemDetails(
+      event: testEvent,
+      participantAgendaItemDetails: testAgendaItemDetails,
+      agendaItemId: agendaItemId,
+    );
+    documentPath =
+        '${liveMeetingTestUtils.getLiveMeetingPath(testEvent)}/participant-agenda-item-details/${testEvent.agendaItems.first.id}/participant-details/$adminUserId';
+  });
+
+  test('Successfully toggle like on user suggestion', () async {
+    final req = ParticipantAgendaItemDetailsMeta(
+      documentPath: documentPath,
+      userSuggestionId: userSuggestionId,
+      voterId: voterId,
+      likeType: LikeType.like,
+    );
+
+    final toggleLikeDislike = ToggleLikeDislikeOnMeetingUserSuggestion();
+
+    await toggleLikeDislike.action(
+      req,
+      CallableContext(voterId, null, 'fakeInstanceId'),
+    );
+
+    // Verify that like was added
+    final updatedDoc = await firestore.document(documentPath).get();
+    final updatedDetails = ParticipantAgendaItemDetails.fromJson(
+      firestoreUtils.fromFirestoreJson(updatedDoc.data.toMap()),
+    );
+
+    final suggestion = updatedDetails.suggestions.first;
+    expect(suggestion.likedByIds, contains(voterId));
+    expect(suggestion.dislikedByIds, isEmpty);
+  });
+
+  test('Successfully toggle dislike on user suggestion', () async {
+    final req = ParticipantAgendaItemDetailsMeta(
+      documentPath: documentPath,
+      userSuggestionId: suggestionId,
+      voterId: voterId,
+      likeType: LikeType.dislike,
+    );
+
+    final toggleLikeDislike = ToggleLikeDislikeOnMeetingUserSuggestion();
+
+    await toggleLikeDislike.action(
+      req,
+      CallableContext(voterId, null, 'fakeInstanceId'),
+    );
+
+    // Verify that dislike was added
+    final updatedDoc = await firestore.document(documentPath).get();
+    final updatedDetails = ParticipantAgendaItemDetails.fromJson(
+      firestoreUtils.fromFirestoreJson(updatedDoc.data.toMap()),
+    );
+
+    final suggestion = updatedDetails.suggestions.first;
+    expect(suggestion.dislikedByIds, contains(voterId));
+    expect(suggestion.likedByIds, isEmpty);
+  });
+
+  test('Successfully remove like/dislike when toggling to neutral', () async {
+    // First add a like
+    final addLikeReq = ParticipantAgendaItemDetailsMeta(
+      documentPath: documentPath,
+      userSuggestionId: suggestionId,
+      voterId: voterId,
+      likeType: LikeType.like,
+    );
+
+    final toggleLikeDislike = ToggleLikeDislikeOnMeetingUserSuggestion();
+
+    await toggleLikeDislike.action(
+      addLikeReq,
+      CallableContext(voterId, null, 'fakeInstanceId'),
+    );
+
+    // Then toggle to neutral
+    final neutralReq = ParticipantAgendaItemDetailsMeta(
+      documentPath: documentPath,
+      userSuggestionId: suggestionId,
+      voterId: voterId,
+      likeType: LikeType.neutral,
+    );
+
+    await toggleLikeDislike.action(
+      neutralReq,
+      CallableContext(voterId, null, 'fakeInstanceId'),
+    );
+
+    // Verify that like was removed
+    final updatedDoc = await firestore.document(documentPath).get();
+    final updatedDetails = ParticipantAgendaItemDetails.fromJson(
+      firestoreUtils.fromFirestoreJson(updatedDoc.data.toMap()),
+    );
+
+    final suggestion = updatedDetails.suggestions.first;
+    expect(suggestion.likedByIds, isEmpty);
+    expect(suggestion.dislikedByIds, isEmpty);
+  });
+
+  test('No effect when toggling like on non-existent suggestion', () async {
+    final req = ParticipantAgendaItemDetailsMeta(
+      documentPath: documentPath,
+      userSuggestionId: 'nonexistent',
+      voterId: voterId,
+      likeType: LikeType.like,
+    );
+
+    final toggleLikeDislike = ToggleLikeDislikeOnMeetingUserSuggestion();
+
+    await toggleLikeDislike.action(
+      req,
+      CallableContext(voterId, null, 'fakeInstanceId'),
+    );
+
+    // Verify that nothing changed
+    final updatedDoc = await firestore.document(documentPath).get();
+    final updatedDetails = ParticipantAgendaItemDetails.fromJson(
+      firestoreUtils.fromFirestoreJson(updatedDoc.data.toMap()),
+    );
+
+    final suggestion = updatedDetails.suggestions.first;
+    expect(suggestion.likedByIds, isEmpty);
+    expect(suggestion.dislikedByIds, isEmpty);
+  });
+
+  test('No effect when document path does not exist', () async {
+    final req = ParticipantAgendaItemDetailsMeta(
+      documentPath: 'invalid/path',
+      userSuggestionId: suggestionId,
+      voterId: voterId,
+      likeType: LikeType.like,
+    );
+
+    final toggleLikeDislike = ToggleLikeDislikeOnMeetingUserSuggestion();
+
+    // Should complete without throwing error
+    await toggleLikeDislike.action(
+      req,
+      CallableContext(voterId, null, 'fakeInstanceId'),
+    );
+  });
+}

--- a/firebase/functions/test/events/live_meetings/update_live_stream_participant_count_test.dart
+++ b/firebase/functions/test/events/live_meetings/update_live_stream_participant_count_test.dart
@@ -1,8 +1,6 @@
 @Timeout(Duration(seconds: 90))
-import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 import 'package:functions/events/live_meetings/update_live_stream_participant_count.dart';
 import 'package:functions/utils/infra/firestore_utils.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 import 'package:data_models/events/event.dart';
 import 'package:uuid/uuid.dart';
@@ -223,5 +221,3 @@ void main() {
     expect(updatedFutureEvent.presentParticipantCountEstimate, equals(0));
   });
 }
-
-class MockEventContext extends Mock implements EventContext {}

--- a/firebase/functions/test/events/live_meetings/update_live_stream_participant_count_test.dart
+++ b/firebase/functions/test/events/live_meetings/update_live_stream_participant_count_test.dart
@@ -1,0 +1,227 @@
+@Timeout(Duration(seconds: 90))
+import 'package:firebase_functions_interop/firebase_functions_interop.dart';
+import 'package:functions/events/live_meetings/update_live_stream_participant_count.dart';
+import 'package:functions/utils/infra/firestore_utils.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+import 'package:data_models/events/event.dart';
+import 'package:uuid/uuid.dart';
+import 'package:get_it/get_it.dart';
+import '../../util/community_test_utils.dart';
+import '../../util/event_test_utils.dart';
+import '../../util/function_test_fixture.dart';
+
+void main() {
+  late String communityId;
+  const templateId = '9654';
+  GetIt.instance.registerSingleton(const Uuid());
+  final eventUtils = EventTestUtils();
+  final communityUtils = CommunityTestUtils();
+  setupTestFixture();
+
+  setUp(() async {
+    communityId = await communityUtils.createTestCommunity();
+  });
+
+  test('Updates participant counts for multiple active livestream events',
+      () async {
+    // Create first test event
+    var event1 = Event(
+      id: '5678',
+      status: EventStatus.active,
+      communityId: communityId,
+      templateId: templateId,
+      creatorId: adminUserId,
+      nullableEventType: EventType.livestream,
+      collectionPath: '',
+      scheduledTime: DateTime.now().add(const Duration(hours: 1)),
+      participantCountEstimate: 0,
+      presentParticipantCountEstimate: 0,
+    );
+
+    event1 = await eventUtils.createEvent(
+      event: event1,
+      userId: adminUserId,
+    );
+
+    // Create second test event
+    var event2 = Event(
+      id: '9012',
+      status: EventStatus.active,
+      communityId: communityId,
+      templateId: templateId,
+      creatorId: adminUserId,
+      nullableEventType: EventType.livestream,
+      collectionPath: '',
+      scheduledTime: DateTime.now().add(const Duration(minutes: 30)),
+      participantCountEstimate: 0,
+      presentParticipantCountEstimate: 0,
+    );
+
+    event2 = await eventUtils.createEvent(
+      event: event2,
+      userId: adminUserId,
+    );
+
+    // Add participants to first event
+    final participants1 = [
+      {'userId': 'user1', 'isPresent': true},
+      {'userId': 'user2', 'isPresent': true},
+      {'userId': 'user3', 'isPresent': false},
+    ];
+
+    for (final participant in participants1) {
+      await eventUtils.joinEvent(
+        communityId: communityId,
+        templateId: templateId,
+        eventId: event1.id,
+        uid: participant['userId']! as String,
+        participantStatus: ParticipantStatus.active,
+        isPresent: participant['isPresent']! as bool,
+      );
+    }
+
+    // Add participants to second event
+    final participants2 = [
+      {'userId': 'user4', 'isPresent': true},
+      {'userId': 'user5', 'isPresent': false},
+    ];
+
+    for (final participant in participants2) {
+      await eventUtils.joinEvent(
+        communityId: communityId,
+        templateId: templateId,
+        eventId: event2.id,
+        uid: participant['userId']! as String,
+        participantStatus: ParticipantStatus.active,
+        isPresent: participant['isPresent']! as bool,
+      );
+    }
+
+    // Add banned participants to both events that shouldn't be counted
+    await eventUtils.joinEvent(
+      communityId: communityId,
+      templateId: templateId,
+      eventId: event1.id,
+      uid: 'bannedUser1',
+      participantStatus: ParticipantStatus.banned,
+      isPresent: true,
+    );
+
+    await eventUtils.joinEvent(
+      communityId: communityId,
+      templateId: templateId,
+      eventId: event2.id,
+      uid: 'bannedUser2',
+      participantStatus: ParticipantStatus.banned,
+      isPresent: true,
+    );
+
+    // Simulate scheduled function execution
+    final updateFunction = UpdateLiveStreamParticipantCount();
+    await updateFunction.action(MockEventContext());
+
+    // Verify updated counts for first event
+    final updatedEventDoc1 = await firestore.document(event1.fullPath).get();
+    final updatedEvent1 = Event.fromJson(
+      firestoreUtils.fromFirestoreJson(updatedEventDoc1.data.toMap()),
+    );
+
+    expect(updatedEvent1.participantCountEstimate, equals(4));
+    // event creator not present
+    expect(updatedEvent1.presentParticipantCountEstimate, equals(2));
+
+    // Verify updated counts for second event
+    final updatedEventDoc2 = await firestore.document(event2.fullPath).get();
+    final updatedEvent2 = Event.fromJson(
+      firestoreUtils.fromFirestoreJson(updatedEventDoc2.data.toMap()),
+    );
+
+    expect(updatedEvent2.participantCountEstimate, equals(3));
+    expect(updatedEvent2.presentParticipantCountEstimate, equals(1));
+  });
+
+  test('Skips hosted events and events outside time window', () async {
+    // Create hosted event (should be skipped)
+    var hostedEvent = Event(
+      id: '5678',
+      status: EventStatus.active,
+      communityId: communityId,
+      templateId: templateId,
+      creatorId: adminUserId,
+      nullableEventType: EventType.hosted,
+      collectionPath: '',
+      scheduledTime: DateTime.now().add(const Duration(hours: 1)),
+      participantCountEstimate: 0,
+      presentParticipantCountEstimate: 0,
+    );
+
+    hostedEvent = await eventUtils.createEvent(
+      event: hostedEvent,
+      userId: adminUserId,
+    );
+
+    // Create future event (should be skipped)
+    var futureEvent = Event(
+      id: '9012',
+      status: EventStatus.active,
+      communityId: communityId,
+      templateId: templateId,
+      creatorId: adminUserId,
+      nullableEventType: EventType.livestream,
+      collectionPath: '',
+      scheduledTime: DateTime.now().add(const Duration(days: 2)),
+      participantCountEstimate: 0,
+      presentParticipantCountEstimate: 0,
+    );
+
+    futureEvent = await eventUtils.createEvent(
+      event: futureEvent,
+      userId: adminUserId,
+    );
+
+    // Add participants to both events
+    await eventUtils.joinEvent(
+      communityId: communityId,
+      templateId: templateId,
+      eventId: hostedEvent.id,
+      uid: 'user1',
+      participantStatus: ParticipantStatus.active,
+      isPresent: true,
+    );
+
+    await eventUtils.joinEvent(
+      communityId: communityId,
+      templateId: templateId,
+      eventId: futureEvent.id,
+      uid: 'user2',
+      participantStatus: ParticipantStatus.active,
+      isPresent: true,
+    );
+
+    // Simulate scheduled function execution
+    final updateFunction = UpdateLiveStreamParticipantCount();
+    await updateFunction.action(MockEventContext());
+    // Verify hosted event counts weren't updated
+    final updatedHostedDoc =
+        await firestore.document(hostedEvent.fullPath).get();
+    final updatedHostedEvent = Event.fromJson(
+      firestoreUtils.fromFirestoreJson(updatedHostedDoc.data.toMap()),
+    );
+
+    expect(updatedHostedEvent.participantCountEstimate, equals(0));
+    expect(updatedHostedEvent.presentParticipantCountEstimate, equals(0));
+
+    // Verify future event counts weren't updated
+    final updatedFutureDoc =
+        await firestore.document(futureEvent.fullPath).get();
+    final updatedFutureEvent = Event.fromJson(
+      firestoreUtils.fromFirestoreJson(updatedFutureDoc.data.toMap()),
+    );
+
+    expect(updatedFutureEvent.participantCountEstimate, equals(0));
+    expect(updatedFutureEvent.presentParticipantCountEstimate, equals(0));
+  });
+}
+
+class MockEventContext extends Mock implements EventContext {}

--- a/firebase/functions/test/events/live_meetings/vote_to_kick_test.dart
+++ b/firebase/functions/test/events/live_meetings/vote_to_kick_test.dart
@@ -1,0 +1,222 @@
+import 'package:data_models/community/membership.dart';
+import 'package:data_models/events/event_proposal.dart';
+import 'package:firebase_functions_interop/firebase_functions_interop.dart';
+import 'package:functions/events/live_meetings/vote_to_kick.dart';
+import 'package:functions/utils/infra/firestore_utils.dart';
+
+import 'package:data_models/events/event.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+import 'package:data_models/cloud_functions/requests.dart';
+import 'package:firebase_admin_interop/firebase_admin_interop.dart'
+    hide EventType;
+
+import '../../util/community_test_utils.dart';
+import '../../util/event_test_utils.dart';
+import '../../util/function_test_fixture.dart';
+import '../../util/live_meeting_test_utils.dart';
+
+void main() {
+  late String communityId;
+  const targetUserId = 'testUser2';
+  const templateId = '9654';
+  const liveMeetingId = 'testMeeting123';
+  //GetIt.instance.registerSingleton(const Uuid());
+  final eventUtils = EventTestUtils();
+  final communityUtils = CommunityTestUtils();
+  late Event testEvent;
+  late MockAgoraUtils mockAgoraUtils;
+  setupTestFixture();
+
+  setUp(() async {
+    setFirebaseAppFactory(() => FirebaseAdmin.instance.initializeApp()!);
+
+    communityId = await communityUtils.createTestCommunity();
+
+    // Create test event
+    testEvent = Event(
+      id: '5678',
+      status: EventStatus.active,
+      communityId: communityId,
+      templateId: templateId,
+      creatorId: adminUserId,
+      nullableEventType: EventType.hostless,
+      collectionPath: '',
+    );
+    testEvent = await eventUtils.createEvent(
+      event: testEvent,
+      userId: adminUserId,
+    );
+
+    // Add participant
+    await eventUtils.joinEvent(
+      communityId: communityId,
+      templateId: templateId,
+      eventId: testEvent.id,
+      uid: targetUserId,
+      participantStatus: ParticipantStatus.active,
+    );
+
+    mockAgoraUtils = MockAgoraUtils();
+    when(
+      () => mockAgoraUtils.kickParticipant(
+        roomId: any(named: 'roomId'),
+        userId: any(named: 'userId'),
+      ),
+    ).thenAnswer((_) => Future.value());
+  });
+
+  test('Successfully creates new kick proposal', () async {
+    final req = VoteToKickRequest(
+      eventPath: testEvent.fullPath,
+      liveMeetingPath: '${testEvent.fullPath}/live-meetings/$liveMeetingId',
+      targetUserId: targetUserId,
+      inFavor: true,
+      reason: 'Inappropriate behavior',
+    );
+
+    final voteToKick = VoteToKick(agoraUtils: mockAgoraUtils);
+
+    await voteToKick.action(
+      req,
+      CallableContext(adminUserId, null, 'fakeInstanceId'),
+    );
+
+    final proposalsSnapshot = await firestore
+        .collection('${req.liveMeetingPath}/proposals')
+        .where('type', isEqualTo: 'kick')
+        .where('targetUserId', isEqualTo: targetUserId)
+        .get();
+
+    expect(proposalsSnapshot.documents.length, equals(1));
+    final proposal = EventProposal.fromJson(
+      firestoreUtils.fromFirestoreJson(
+        proposalsSnapshot.documents.first.data.toMap(),
+      ),
+    );
+    expect(proposal.initiatingUserId, equals(adminUserId));
+    expect(proposal.targetUserId, equals(targetUserId));
+    expect(proposal.status, equals(EventProposalStatus.open));
+    expect(proposal.votes?.length, equals(1));
+    expect(proposal.votes?.first.inFavor, isTrue);
+    expect(proposal.votes?.first.reason, equals('Inappropriate behavior'));
+  });
+
+  test('User gets kicked when receiving sufficient votes', () async {
+    final req = VoteToKickRequest(
+      eventPath: testEvent.fullPath,
+      liveMeetingPath: '${testEvent.fullPath}/live-meetings/$liveMeetingId',
+      targetUserId: targetUserId,
+      inFavor: true,
+      reason: 'Inappropriate behavior',
+    );
+
+    final voteToKick = VoteToKick(agoraUtils: mockAgoraUtils);
+
+    // First vote
+    await voteToKick.action(
+      req,
+      CallableContext(adminUserId, null, 'fakeInstanceId'),
+    );
+
+    // Second vote from different user
+    await voteToKick.action(
+      req,
+      CallableContext('testUser3', null, 'fakeInstanceId'),
+    );
+
+    final participantSnapshot = await firestore
+        .document('${testEvent.fullPath}/event-participants/$targetUserId')
+        .get();
+    final participant = Participant.fromJson(
+      firestoreUtils.fromFirestoreJson(participantSnapshot.data.toMap()),
+    );
+
+    expect(participant.status, equals(ParticipantStatus.banned));
+
+    verify(
+      () => mockAgoraUtils.kickParticipant(
+        roomId: liveMeetingId,
+        userId: targetUserId,
+      ),
+    ).called(1);
+  });
+
+  test('Throws unauthorized error when target user is a moderator', () async {
+    // Make target user a moderator
+
+    await eventUtils.joinEvent(
+      communityId: communityId,
+      templateId: templateId,
+      eventId: testEvent.id,
+      uid: targetUserId,
+      participantStatus: ParticipantStatus.active,
+      participantMembershipStatus: MembershipStatus.mod,
+    );
+
+    final req = VoteToKickRequest(
+      eventPath: testEvent.fullPath,
+      liveMeetingPath: '${testEvent.fullPath}/live-meetings/$liveMeetingId',
+      targetUserId: targetUserId,
+      inFavor: true,
+      reason: 'Test reason',
+    );
+
+    final voteToKick = VoteToKick(agoraUtils: mockAgoraUtils);
+
+    expect(
+      () => voteToKick.action(
+        req,
+        CallableContext(adminUserId, null, 'fakeInstanceId'),
+      ),
+      throwsA(
+        predicate(
+          (e) =>
+              e is HttpsError &&
+              e.code == HttpsError.failedPrecondition &&
+              e.message == 'unauthorized',
+        ),
+      ),
+    );
+  });
+
+  test('Proposal gets rejected when receiving sufficient opposing votes',
+      () async {
+    final req = VoteToKickRequest(
+      eventPath: testEvent.fullPath,
+      liveMeetingPath: '${testEvent.fullPath}/live-meetings/$liveMeetingId',
+      targetUserId: targetUserId,
+      inFavor: false,
+      reason: 'Not necessary',
+    );
+
+    final voteToKick = VoteToKick(agoraUtils: mockAgoraUtils);
+
+    // First vote against
+    await voteToKick.action(
+      req,
+      CallableContext(adminUserId, null, 'fakeInstanceId'),
+    );
+
+    // Second vote against from different user
+    await voteToKick.action(
+      req,
+      CallableContext('testUser3', null, 'fakeInstanceId'),
+    );
+
+    final proposalsSnapshot = await firestore
+        .collection('${req.liveMeetingPath}/proposals')
+        .where('type', isEqualTo: 'kick')
+        .where('targetUserId', isEqualTo: targetUserId)
+        .get();
+
+    final proposal = EventProposal.fromJson(
+      firestoreUtils.fromFirestoreJson(
+        proposalsSnapshot.documents.first.data.toMap(),
+      ),
+    );
+
+    expect(proposal.status, equals(EventProposalStatus.rejected));
+    expect(proposal.closedAt, isNotNull);
+  });
+}

--- a/firebase/functions/test/util/community_test_utils.dart
+++ b/firebase/functions/test/util/community_test_utils.dart
@@ -80,3 +80,5 @@ class CommunityTestUtils {
 class MockFirebaseAuthUtils extends Mock implements FirebaseAuthUtils {}
 
 class MockUserRecord extends Mock implements admin_interop.UserRecord {}
+
+class MockEventContext extends Mock implements EventContext {}

--- a/firebase/functions/test/util/event_test_utils.dart
+++ b/firebase/functions/test/util/event_test_utils.dart
@@ -103,6 +103,7 @@ class EventTestUtils {
     bool isPresent = true,
     bool setAttendeeStatus = true,
     ParticipantStatus? participantStatus = ParticipantStatus.active,
+    MembershipStatus? participantMembershipStatus = MembershipStatus.attendee,
   }) async {
     final reference = eventReference(
       communityId: communityId,
@@ -123,7 +124,7 @@ class EventTestUtils {
       scheduledTime: event.scheduledTime,
       availableForBreakoutSessionId: breakoutSessionId,
       isPresent: isPresent,
-      membershipStatus: MembershipStatus.attendee,
+      membershipStatus: participantMembershipStatus,
       /**joinParameters: queryParametersService.mostRecentQueryParameters,
       breakoutRoomSurveyQuestions: breakoutRoomSurveyResults?.questions ?? [],
       zipCode: breakoutRoomSurveyResults?.zipCode,**/

--- a/firebase/functions/test/util/function_test_fixture.dart
+++ b/firebase/functions/test/util/function_test_fixture.dart
@@ -39,4 +39,21 @@ Future<void> deleteAllCollections() async {
       );
     }
   }
+  // The above doesn't delete subcollections. Do some additional cleanup of collectionGroups where needed
+  final knownCollectionIds = [
+    'events',
+    'event-participants',
+    'participant-details'
+  ];
+
+  for (final collectionId in knownCollectionIds) {
+    final collectionGroup = firestore.collectionGroup(collectionId);
+    final documents = await collectionGroup.get();
+
+    await Future.wait(
+      documents.documents.map((doc) async {
+        await doc.reference.delete();
+      }),
+    );
+  }
 }


### PR DESCRIPTION
## What is in this PR?
Adds tests for the remaining live meeting functions


## Changes in the codebase
New tests, also slight improvement to test data cleanup to delete some orphaned collectionGroups

## Changes outside the codebase
None

## Testing this PR
Execute tests

## Additional information
I considered extracting creation of a test event to the util class, but not sure it's worth the ROI since pretty much all of the function tests have already been written and will be rewritten in the near future. 

