### PR TITLE
Fix GitHub actions to update Google auth ID on deployment

### DIFF
--- a/.github/workflows/deploy_client_prod.yaml
+++ b/.github/workflows/deploy_client_prod.yaml
@@ -33,7 +33,6 @@ jobs:
           sed -i 's/__VERSION__/${{ github.ref_name }}/g' ${{ github.workspace }}/client/web/index.html
 
       - name: Update Google Auth Client ID
-        if: steps.changes.outputs.client == 'true'  && steps.test.outcome == 'success'
         run: |
           sed -i 's/__GOOGLE_ID__/${{ secrets.GOOGLE_SIGN_IN_ID }}/g' ${{ github.workspace }}/client/web/index.html
 

--- a/.github/workflows/deploy_client_staging.yaml
+++ b/.github/workflows/deploy_client_staging.yaml
@@ -58,7 +58,7 @@ jobs:
           sed -i 's/__VERSION__/${{ github.sha }}/g' ${{ github.workspace }}/client/web/index.html
 
       - name: Update Google Auth Client ID
-        if: steps.changes.outputs.client == 'true'  && steps.test.outcome == 'success'
+        if: steps.changes.outputs.client == 'true'  || github.event_name== 'workflow_dispatch'
         run: |
           sed -i 's/__GOOGLE_ID__/${{ secrets.GOOGLE_SIGN_IN_ID }}/g' ${{ github.workspace }}/client/web/index.html
 


### PR DESCRIPTION
## What is in this PR?
Quick bug fix to ensure the Google Auth ID placeholder is updated in index.html on deployment to staging and prod


## Changes in the codebase
Update GitHub actions

## Changes outside the codebase
None

## Testing this PR
Ran a manual deployment in another branch (how bug was discovered)


