### PR TITLE
Fix incorrect function name for GetMeetingJoinInfo

### DIFF
--- a/firebase/functions/lib/events/live_meetings/get_meeting_join_info.dart
+++ b/firebase/functions/lib/events/live_meetings/get_meeting_join_info.dart
@@ -16,7 +16,7 @@ class GetMeetingJoinInfo extends OnCallMethod<GetMeetingJoinInfoRequest> {
   GetMeetingJoinInfo({LiveMeetingUtils? liveMeetingUtils})
       : liveMeetingUtils = liveMeetingUtils ?? LiveMeetingUtils(),
         super(
-          'GetBreakoutRoomJoinInfo',
+          'GetMeetingJoinInfo',
           (jsonMap) => GetMeetingJoinInfoRequest.fromJson(jsonMap),
         );
 


### PR DESCRIPTION
## What is in this PR?
Fix a bug introduced with recent addition of function tests


## Changes in the codebase
Fixed copy/paste error causing the GetMeetingJoinInfo function to be named GetBreakoutRoomJoinInfo instead

## Changes outside the codebase
None 

## Testing this PR
Staging works


