### PR TITLE
Unify sign-in widgets and retain consistent behavior of opening dialog for email sign-in.

### DIFF
--- a/client/lib/core/widgets/navbar/sidebar/sidebar.dart
+++ b/client/lib/core/widgets/navbar/sidebar/sidebar.dart
@@ -4,7 +4,6 @@ import 'package:dotted_border/dotted_border.dart';
 import 'package:flutter/material.dart';
 import 'package:client/features/community/features/create_community/presentation/widgets/freemium_dialog_flow.dart';
 import 'package:client/features/community/data/providers/community_provider.dart';
-import 'package:client/core/utils/error_utils.dart';
 import 'package:client/core/widgets/proxied_image.dart';
 import 'package:client/core/widgets/custom_ink_well.dart';
 import 'package:client/core/widgets/custom_list_view.dart';
@@ -131,6 +130,7 @@ class _SideBarState extends State<SideBar> {
     } else {
       return SignInOptionsContent(
         onComplete: () => Navigator.of(context).pop(),
+        openDialogOnEmailProviderSelected: true,
       );
     }
   }

--- a/client/lib/features/auth/presentation/views/sign_in_dialog.dart
+++ b/client/lib/features/auth/presentation/views/sign_in_dialog.dart
@@ -8,18 +8,21 @@ class SignInDialog extends StatefulWidget {
   final bool isNewUser;
   final bool isPurchasingSubscription;
   final bool isDismissable;
+  final bool showEmailFormOnly;
 
   const SignInDialog({
     Key? key,
     required this.isNewUser,
     this.isPurchasingSubscription = false,
     this.isDismissable = true,
+    this.showEmailFormOnly = false,
   }) : super(key: key);
 
   static Future<void> show({
     bool newUser = true,
     bool isPurchasingSubscription = false,
     bool isDismissable = true,
+    bool showEmailFormOnly = false,
     BuildContext? context,
   }) async {
     await showCustomDialog<void>(
@@ -29,6 +32,7 @@ class SignInDialog extends StatefulWidget {
         isNewUser: newUser,
         isPurchasingSubscription: isPurchasingSubscription,
         isDismissable: isDismissable,
+        showEmailFormOnly: showEmailFormOnly,
       ),
     );
   }
@@ -53,11 +57,12 @@ class _SignInDialogState extends State<SignInDialog> {
                 SignInOptionsContent(
                   isPurchasingSubscription: widget.isPurchasingSubscription,
                   isNewUser: widget.isNewUser,
+                  showEmailFormOnly: widget.showEmailFormOnly,
                 ),
                 if (isWKWebView) ...[
                   SizedBox(height: 8),
                   Text(
-                    'To sign in with Google open this page in Safari',
+                    'To sign in with Google, please open this page in your browser.',
                     textAlign: TextAlign.center,
                   ),
                 ],

--- a/client/lib/features/auth/presentation/widgets/sign_in_options_content.dart
+++ b/client/lib/features/auth/presentation/widgets/sign_in_options_content.dart
@@ -1,4 +1,5 @@
 import 'package:client/core/utils/navigation_utils.dart';
+import 'package:client/features/auth/presentation/views/sign_in_dialog.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:client/core/utils/error_utils.dart';
@@ -17,6 +18,8 @@ class SignInOptionsContent extends StatefulWidget {
   const SignInOptionsContent({
     this.isNewUser = true,
     this.isPurchasingSubscription = false,
+    this.openDialogOnEmailProviderSelected = false,
+    this.showEmailFormOnly = false,
     this.onComplete,
     Key? key,
   }) : super(key: key);
@@ -30,6 +33,8 @@ class SignInOptionsContent extends StatefulWidget {
 
   final bool isNewUser;
   final bool isPurchasingSubscription;
+  final bool openDialogOnEmailProviderSelected;
+  final bool showEmailFormOnly;
   final void Function()? onComplete;
 
   @override
@@ -37,7 +42,7 @@ class SignInOptionsContent extends StatefulWidget {
 }
 
 class _SignInOptionsContentState extends State<SignInOptionsContent> {
-  late bool _showEmailFormFields = false;
+  late bool _showEmailFormFields = widget.showEmailFormOnly;
   late bool _newUser = widget.isNewUser;
 
   final _displayNameController = TextEditingController();
@@ -83,7 +88,7 @@ class _SignInOptionsContentState extends State<SignInOptionsContent> {
   Widget build(BuildContext context) {
     return Stack(
       children: [
-        if (_showEmailFormFields)
+        if (_showEmailFormFields && !widget.showEmailFormOnly)
           Align(
             alignment: Alignment.topLeft,
             child: GestureDetector(
@@ -191,7 +196,9 @@ class _SignInOptionsContentState extends State<SignInOptionsContent> {
           ),
         ),
         backgroundColor: Colors.white,
-        onPressed: () => setState(() => _showEmailFormFields = true),
+        onPressed: () => widget.openDialogOnEmailProviderSelected
+            ? SignInDialog.show(showEmailFormOnly: true)
+            : setState(() => _showEmailFormFields = true),
         text: 'Sign ${widget.isNewUser ? 'up' : 'in'} with Email',
       ),
     ];

--- a/client/lib/features/home/presentation/widgets/sign_in_section.dart
+++ b/client/lib/features/home/presentation/widgets/sign_in_section.dart
@@ -32,6 +32,7 @@ class _HomePageSignInSectionState extends State<HomePageSignInSection> {
                 width: 300,
                 child: SignInOptionsContent(
                   isNewUser: true,
+                  openDialogOnEmailProviderSelected: true,
                 ),
               ),
             ],


### PR DESCRIPTION
## What is in this PR?
<!-- What is the goal of this PR? What steps are involved in achieving that goal? -->
PR #5 aimed to unify the sign-in widgets so that they're easier to maintain, but between this and main, we've lost the consistency of behavior where a dialog is opened after tapping the email provider (in home page and on sidebar). Also, the headers are slightly different between the dialog and the home page.

Also, the button keys now get shown twice when email provider is tapped, which is messing with some of the legacy tests.

This PR is a further effort to unify these widgets and standardize the behavior when they are clicked across the codebase.  

## Changes in the codebase
<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

* Removed some fields of the `SignInOptions` widget and added fields to control which page of the content is shown, and whether to show a new dialog when email is clicked. 
    * Note that this is not proposed as an ongoing solution; I would prefer to tackle a true refactoring when we get our new UI designs for the auth flow.
* Standardized/deduplicated the header text and removed variable toggle. 

## Changes outside the codebase
<!-- If you have made changes to external services, need to add additional values to the job settings, or need to add something new to the database, explain it here. This may include updates to third-party services, changes to infrastructure configuration, integration with external APIs, etc. -->

* None.

## Testing this PR
<!-- Give your reviewer some context or recommendations on how to test your work. -->

Check out the preview link and try pressing sign up/sign in from home page, buttons, and sidebar. It should be a lot more consistent now (shows a dialog each time no matter where you enter). 

## Additional information
<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->

