### PR TITLE
Fix image display in event agenda

### DIFF
--- a/client/lib/features/events/features/live_meeting/features/meeting_guide/presentation/widgets/meeting_guide_card_item_image.dart
+++ b/client/lib/features/events/features/live_meeting/features/meeting_guide/presentation/widgets/meeting_guide_card_item_image.dart
@@ -13,7 +13,7 @@ class MeetingGuideCardItemImage extends StatelessWidget {
     return Center(
       child: ProxiedImage(
         agendaItem.imageUrl,
-        fit: BoxFit.cover,
+        fit: BoxFit.contain,
       ),
     );
   }

--- a/client/lib/features/events/features/live_meeting/features/meeting_guide/presentation/widgets/meeting_guide_card_item_image.dart
+++ b/client/lib/features/events/features/live_meeting/features/meeting_guide/presentation/widgets/meeting_guide_card_item_image.dart
@@ -13,7 +13,7 @@ class MeetingGuideCardItemImage extends StatelessWidget {
     return Center(
       child: ProxiedImage(
         agendaItem.imageUrl,
-        fit: BoxFit.none,
+        fit: BoxFit.cover,
       ),
     );
   }


### PR DESCRIPTION

## What is in this PR?
Use cover BoxFit to display images in event agenda. Fixes issue where random parts of large images (like puppy fur) were being displayed.

## Changes in the codebase
Tiny change to use BoxFit: cover in widget

## Changes outside the codebase
None

## Testing this PR
See repro steps in the associated GH issue. The puppy's face is now shown in meetings!

## Additional information
I checked the commit history of relevant widgets and even of the media_service file (in case something changed about the way the image was manipulated when originally uploaded/added to the event's agenda). I can't find any indication that something we changed caused this. Best guess is that this particular image (and other larger dimension images) revealed an existing issue. I switched to cover BoxFit because that is used to show the image on the event page where the agenda is built (as opposed to the "live meeting" agenda view). Open to another solution......
