### PR TITLE
Fix participant removal for all event types

### DIFF
--- a/client/lib/features/events/features/live_meeting/features/admin_panel/presentation/widgets/admin_panel.dart
+++ b/client/lib/features/events/features/live_meeting/features/admin_panel/presentation/widgets/admin_panel.dart
@@ -695,6 +695,9 @@ class __ParticipantMenuState extends State<_ParticipantMenu> {
           if (!(confirmResult?.kickParticipant ?? false)) return;
 
           final event = EventProvider.read(context).event;
+          if (event.creatorId == widget.kickedUserId) {
+            throw VisibleException('Can\'t kick the event creator.');
+          }
           final breakoutRoomId = widget.breakoutRoomId;
 
           await swallowErrors(

--- a/firebase/firestore/firestore.rules
+++ b/firebase/firestore/firestore.rules
@@ -47,6 +47,10 @@ service cloud.firestore {
             return status in ['owner', 'admin', 'mod'];
         }
 
+        function isFacilitator(status) {
+            return status in ['owner', 'admin', 'mod', 'facilitator'];
+        }
+
         function requiresApprovalToJoin(communityId) {
             return 'requireApprovalToJoin' in getOrDefault(get(/databases/$(database)/documents/community/$(communityId)), 'enabledFeatureFlags', []);
         }
@@ -131,6 +135,9 @@ service cloud.firestore {
                 return hasAuth() && getMembershipStatus(communityId) in memberSet;
             }
 
+             function isCommunityFacilitator() {
+                return hasAuth() && isFacilitator(getMembershipStatus(communityId));
+            }
             function isCommunityMod() {
                 return hasAuth() && isMod(getMembershipStatus(communityId));
             }
@@ -274,6 +281,7 @@ service cloud.firestore {
                         allow write: if isCommunityMod()
                                         || isDocCreator(getEventDataAfter())
                                         || request.auth.uid == participantId;
+                        allow update: if isCommunityFacilitator() && (request.resource.data.diff(resource.data).affectedKeys().hasOnly(['status','lastUpdatedTime']));
 
                         allow read: if hasAuth() && (isHosted() || isCommunityMod() || request.auth.uid == participantId);
                     }

--- a/firebase/firestore/test/firestore-rules/firestore.spec.js
+++ b/firebase/firestore/test/firestore-rules/firestore.spec.js
@@ -40,27 +40,27 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const path = __importStar(require("path"));
 const firestore_rules_helper_1 = require("./firestore-rules-helper");
 require("mocha");
-const firebase = require('@firebase/rules-unit-testing');
-const fs = require('fs');
-const http = require('http');
+const firebase = require("@firebase/rules-unit-testing");
+const fs = require("fs");
+const http = require("http");
 /**
  * The emulator will accept any project ID for testing.
  */
-const PROJECT_ID = 'firestore-emulator-example';
+const PROJECT_ID = "firestore-emulator-example";
 /**
  * The FIRESTORE_EMULATOR_HOST environment variable is set automatically
  * by "firebase emulators:exec"
  */
 // Hard-coding path for now since we are running `npm run test`
 // More about test report - https://firebase.google.com/docs/rules/emulator-reports
-process.env.FIRESTORE_EMULATOR_HOST = 'localhost:8080';
+process.env.FIRESTORE_EMULATOR_HOST = "localhost:8080";
 const COVERAGE_URL = `http://${process.env.FIRESTORE_EMULATOR_HOST}/emulator/v1/projects/${PROJECT_ID}:ruleCoverage.html`;
 // Fields
-const fieldCreatorId = 'creatorId';
-const fieldMembershipStatusSnapshot = 'membershipStatusSnapshot';
+const fieldCreatorId = "creatorId";
+const fieldMembershipStatusSnapshot = "membershipStatusSnapshot";
 // Data
-const originalDataMap = { someField: 'someValue' };
-const updateDataMap = { someField: 'someUpdatedValue' };
+const originalDataMap = { someField: "someValue" };
+const updateDataMap = { someField: "someUpdatedValue" };
 // Create a reference for DB Admin
 let dbAdmin;
 /**
@@ -82,7 +82,7 @@ afterEach(() => __awaiter(void 0, void 0, void 0, function* () {
 }));
 before(() => __awaiter(void 0, void 0, void 0, function* () {
     // Load the rules file before the tests begin
-    const rules = fs.readFileSync(path.join(__dirname, '../', '../', '../', 'firestore', 'firestore.rules'), 'utf8');
+    const rules = fs.readFileSync(path.join(__dirname, "../", "../", "../", "firestore", "firestore.rules"), "utf8");
     yield firebase.loadFirestoreRules({
         projectId: PROJECT_ID,
         rules,
@@ -93,26 +93,28 @@ after(() => __awaiter(void 0, void 0, void 0, function* () {
     // Note: this does not affect or clear any data
     yield Promise.all(firebase.apps().map((app) => app.delete()));
     // Write the coverage report to a file
-    const coverageFile = 'firestore-coverage.html';
+    const coverageFile = "firestore-coverage.html";
     const fstream = fs.createWriteStream(coverageFile);
     yield new Promise((resolve, reject) => {
         http.get(COVERAGE_URL, (res) => {
             res.pipe(fstream, { end: true });
-            res.on('end', resolve);
-            res.on('error', reject);
+            res.on("end", resolve);
+            res.on("error", reject);
         });
     });
     console.log(`View firestore rule coverage information at ${COVERAGE_URL} or ${coverageFile}\n`);
 }));
-describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, function* () {
+describe("Firestore security rules", () => __awaiter(void 0, void 0, void 0, function* () {
     // For some reason `before` executes semi-after describe, leaving `dbAdmin` not initialised.
-    dbAdmin = yield firebase.initializeAdminApp({ projectId: PROJECT_ID }).firestore();
-    describe('/publicUser/{userId}', () => {
-        const collection = 'publicUser';
+    dbAdmin = yield firebase
+        .initializeAdminApp({ projectId: PROJECT_ID })
+        .firestore();
+    describe("/publicUser/{userId}", () => {
+        const collection = "publicUser";
         const communityRulesHelper = new firestore_rules_helper_1.CommunityRulesHelper(dbAdmin, [
-            { collection: collection, document: 'alice' },
+            { collection: collection, document: "alice" },
         ]);
-        it('not authorized', () => __awaiter(void 0, void 0, void 0, function* () {
+        it("not authorized", () => __awaiter(void 0, void 0, void 0, function* () {
             yield communityRulesHelper.getDocumentRef(dbAdmin).set(originalDataMap);
             const user = getAuthedFirestore(undefined);
             const userColRef = communityRulesHelper.getCollectionRef(user);
@@ -123,9 +125,9 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
             yield firebase.assertFails(userDocRef.update(updateDataMap));
             yield firebase.assertFails(userDocRef.delete());
         }));
-        it('authorized, same id', () => __awaiter(void 0, void 0, void 0, function* () {
+        it("authorized, same id", () => __awaiter(void 0, void 0, void 0, function* () {
             yield communityRulesHelper.getDocumentRef(dbAdmin).set(originalDataMap);
-            const user = getAuthedFirestore('alice');
+            const user = getAuthedFirestore("alice");
             const userColRef = communityRulesHelper.getCollectionRef(user);
             const userDocRef = communityRulesHelper.getDocumentRef(user);
             yield firebase.assertFails(userColRef.add(originalDataMap));
@@ -134,9 +136,9 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
             yield firebase.assertSucceeds(userDocRef.update(originalDataMap));
             yield firebase.assertSucceeds(userDocRef.delete());
         }));
-        it('authorized, different id', () => __awaiter(void 0, void 0, void 0, function* () {
+        it("authorized, different id", () => __awaiter(void 0, void 0, void 0, function* () {
             yield communityRulesHelper.getDocumentRef(dbAdmin).set(originalDataMap);
-            const user = getAuthedFirestore('bob');
+            const user = getAuthedFirestore("bob");
             const userColRef = communityRulesHelper.getCollectionRef(user);
             const userDocRef = communityRulesHelper.getDocumentRef(user);
             yield firebase.assertFails(userColRef.add(originalDataMap));
@@ -145,10 +147,10 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
             yield firebase.assertFails(userDocRef.update(originalDataMap));
             yield firebase.assertFails(userDocRef.delete());
         }));
-        it('authorized, updating with same appRole', () => __awaiter(void 0, void 0, void 0, function* () {
-            const adminRoleDataMap = { appRole: 'owner', otherField: 'otherValue' };
+        it("authorized, updating with same appRole", () => __awaiter(void 0, void 0, void 0, function* () {
+            const adminRoleDataMap = { appRole: "owner", otherField: "otherValue" };
             yield communityRulesHelper.getDocumentRef(dbAdmin).set(adminRoleDataMap);
-            const user = getAuthedFirestore('alice');
+            const user = getAuthedFirestore("alice");
             const userColRef = communityRulesHelper.getCollectionRef(user);
             const userDocRef = communityRulesHelper.getDocumentRef(user);
             yield firebase.assertFails(userColRef.add(originalDataMap));
@@ -156,27 +158,27 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
             yield firebase.assertSucceeds(userDocRef.update(adminRoleDataMap));
             yield firebase.assertSucceeds(userDocRef.delete());
         }));
-        it('authorized, updating with different appRole', () => __awaiter(void 0, void 0, void 0, function* () {
-            const adminRoleDataMap = { appRole: 'user', otherField: 'otherValue' };
+        it("authorized, updating with different appRole", () => __awaiter(void 0, void 0, void 0, function* () {
+            const adminRoleDataMap = { appRole: "user", otherField: "otherValue" };
             yield communityRulesHelper.getDocumentRef(dbAdmin).set(adminRoleDataMap);
-            const user = getAuthedFirestore('alice');
+            const user = getAuthedFirestore("alice");
             const userColRef = communityRulesHelper.getCollectionRef(user);
             const userDocRef = communityRulesHelper.getDocumentRef(user);
             yield firebase.assertFails(userColRef.add(originalDataMap));
             yield firebase.assertSucceeds(userDocRef.get());
-            yield firebase.assertFails(userDocRef.update({ appRole: 'owner', otherField: 'otherValue' }));
+            yield firebase.assertFails(userDocRef.update({ appRole: "owner", otherField: "otherValue" }));
             yield firebase.assertSucceeds(userDocRef.delete());
         }));
     });
-    describe('/privateUserData/{userId}', () => {
-        const colPrivateUserData = 'privateUserData';
+    describe("/privateUserData/{userId}", () => {
+        const colPrivateUserData = "privateUserData";
         const communityRulesHelper = new firestore_rules_helper_1.CommunityRulesHelper(dbAdmin, [
-            { collection: colPrivateUserData, document: 'alice' },
+            { collection: colPrivateUserData, document: "alice" },
         ]);
         beforeEach(() => __awaiter(void 0, void 0, void 0, function* () {
             yield communityRulesHelper.getDocumentRef(dbAdmin).set(originalDataMap);
         }));
-        it('not authorized', () => __awaiter(void 0, void 0, void 0, function* () {
+        it("not authorized", () => __awaiter(void 0, void 0, void 0, function* () {
             const user = getAuthedFirestore(undefined);
             const userColRef = communityRulesHelper.getCollectionRef(user);
             const userDocRef = communityRulesHelper.getDocumentRef(user);
@@ -186,8 +188,8 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
             yield firebase.assertFails(userDocRef.update(updateDataMap));
             yield firebase.assertFails(userDocRef.delete());
         }));
-        it('authorized, same id', () => __awaiter(void 0, void 0, void 0, function* () {
-            const user = getAuthedFirestore('alice');
+        it("authorized, same id", () => __awaiter(void 0, void 0, void 0, function* () {
+            const user = getAuthedFirestore("alice");
             const userColRef = communityRulesHelper.getCollectionRef(user);
             const userDocRef = communityRulesHelper.getDocumentRef(user);
             yield firebase.assertFails(userColRef.add(originalDataMap));
@@ -196,8 +198,8 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
             yield firebase.assertSucceeds(userDocRef.update(updateDataMap));
             yield firebase.assertSucceeds(userDocRef.delete());
         }));
-        it('authorized, different id', () => __awaiter(void 0, void 0, void 0, function* () {
-            const user = getAuthedFirestore('bob');
+        it("authorized, different id", () => __awaiter(void 0, void 0, void 0, function* () {
+            const user = getAuthedFirestore("bob");
             const userColRef = communityRulesHelper.getCollectionRef(user);
             const userDocRef = communityRulesHelper.getDocumentRef(user);
             yield firebase.assertFails(userColRef.add(originalDataMap));
@@ -206,22 +208,22 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
             yield firebase.assertFails(userDocRef.update(updateDataMap));
             yield firebase.assertFails(userDocRef.delete());
         }));
-        describe('/communityUserSettings/{communityId}', () => {
-            const colCommunityUserSettings = 'communityUserSettings';
+        describe("/communityUserSettings/{communityId}", () => {
+            const colCommunityUserSettings = "communityUserSettings";
             const communityRulesHelper = new firestore_rules_helper_1.CommunityRulesHelper(dbAdmin, [
                 {
                     collection: colPrivateUserData,
-                    document: 'alice',
+                    document: "alice",
                 },
                 {
                     collection: colCommunityUserSettings,
-                    document: 'alice2',
+                    document: "alice2",
                 },
             ]);
             beforeEach(() => __awaiter(void 0, void 0, void 0, function* () {
                 yield communityRulesHelper.getDocumentRef(dbAdmin).set(originalDataMap);
             }));
-            it('not authorized', () => __awaiter(void 0, void 0, void 0, function* () {
+            it("not authorized", () => __awaiter(void 0, void 0, void 0, function* () {
                 const user = getAuthedFirestore(undefined);
                 const userColRef = communityRulesHelper.getCollectionRef(user);
                 const userDocRef = communityRulesHelper.getDocumentRef(user);
@@ -231,8 +233,8 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                 yield firebase.assertFails(userDocRef.update(updateDataMap));
                 yield firebase.assertFails(userDocRef.delete());
             }));
-            it('authorized, same id', () => __awaiter(void 0, void 0, void 0, function* () {
-                const user = getAuthedFirestore('alice');
+            it("authorized, same id", () => __awaiter(void 0, void 0, void 0, function* () {
+                const user = getAuthedFirestore("alice");
                 const userColRef = communityRulesHelper.getCollectionRef(user);
                 const userDocRef = communityRulesHelper.getDocumentRef(user);
                 yield firebase.assertSucceeds(userColRef.add(originalDataMap));
@@ -241,8 +243,8 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                 yield firebase.assertSucceeds(userDocRef.update(updateDataMap));
                 yield firebase.assertSucceeds(userDocRef.delete());
             }));
-            it('authorized, different id', () => __awaiter(void 0, void 0, void 0, function* () {
-                const user = getAuthedFirestore('bob');
+            it("authorized, different id", () => __awaiter(void 0, void 0, void 0, function* () {
+                const user = getAuthedFirestore("bob");
                 const userColRef = communityRulesHelper.getCollectionRef(user);
                 const userDocRef = communityRulesHelper.getDocumentRef(user);
                 yield firebase.assertFails(userColRef.add(originalDataMap));
@@ -253,15 +255,15 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
             }));
         });
     });
-    describe('/community/{communityId}', () => {
-        const collectionCommunity = 'community';
+    describe("/community/{communityId}", () => {
+        const collectionCommunity = "community";
         const communityRulesHelper = new firestore_rules_helper_1.CommunityRulesHelper(dbAdmin, [
-            { collection: collectionCommunity, document: 'communityId' },
+            { collection: collectionCommunity, document: "communityId" },
         ]);
         beforeEach(() => __awaiter(void 0, void 0, void 0, function* () {
             yield communityRulesHelper.getDocumentRef(dbAdmin).set(originalDataMap);
         }));
-        it('not authorized', () => __awaiter(void 0, void 0, void 0, function* () {
+        it("not authorized", () => __awaiter(void 0, void 0, void 0, function* () {
             const user = getAuthedFirestore(undefined);
             const userColRef = communityRulesHelper.getCollectionRef(user);
             const userDocRef = communityRulesHelper.getDocumentRef(user);
@@ -271,29 +273,31 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
             yield firebase.assertFails(userDocRef.update(updateDataMap));
             yield firebase.assertFails(userDocRef.delete());
         }));
-        describe('authorized reader', () => __awaiter(void 0, void 0, void 0, function* () {
+        describe("authorized reader", () => __awaiter(void 0, void 0, void 0, function* () {
             const communityRulesHelper = new firestore_rules_helper_1.CommunityRulesHelper(dbAdmin, [
-                { collection: collectionCommunity, document: 'communityId' },
+                { collection: collectionCommunity, document: "communityId" },
             ]);
-            it('create', () => __awaiter(void 0, void 0, void 0, function* () {
-                const user = getAuthedFirestore('alice');
+            it("create", () => __awaiter(void 0, void 0, void 0, function* () {
+                const user = getAuthedFirestore("alice");
                 const userColRef = communityRulesHelper.getCollectionRef(user);
                 // Trying to add a document without `creatorId` being the owner
                 yield firebase.assertFails(userColRef.add(originalDataMap));
                 // Trying to add a document with `creatorId` being the owner
-                yield firebase.assertFails(userColRef.add({ [fieldCreatorId]: 'alice' }));
+                yield firebase.assertFails(userColRef.add({ [fieldCreatorId]: "alice" }));
             }));
-            it('get', () => __awaiter(void 0, void 0, void 0, function* () {
-                const user = getAuthedFirestore('alice');
+            it("get", () => __awaiter(void 0, void 0, void 0, function* () {
+                const user = getAuthedFirestore("alice");
                 const userDocRef = communityRulesHelper.getDocumentRef(user);
                 yield firebase.assertSucceeds(userDocRef.get());
             }));
-            it('update', () => __awaiter(void 0, void 0, void 0, function* () {
-                const user = getAuthedFirestore('alice');
+            it("update", () => __awaiter(void 0, void 0, void 0, function* () {
+                const user = getAuthedFirestore("alice");
                 const userDocRef = communityRulesHelper.getDocumentRef(user);
-                yield communityRulesHelper.getDocumentRef(dbAdmin).set({ someKey: 'value' });
+                yield communityRulesHelper
+                    .getDocumentRef(dbAdmin)
+                    .set({ someKey: "value" });
                 for (const membership of Object.keys(firestore_rules_helper_1.Membership)) {
-                    yield communityRulesHelper.createMembership('alice', membership);
+                    yield communityRulesHelper.createMembership("alice", membership);
                     switch (membership) {
                         case firestore_rules_helper_1.Membership.owner:
                         case firestore_rules_helper_1.Membership.admin:
@@ -307,31 +311,35 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                     }
                 }
             }));
-            it('delete', () => __awaiter(void 0, void 0, void 0, function* () {
-                const user = getAuthedFirestore('alice');
+            it("delete", () => __awaiter(void 0, void 0, void 0, function* () {
+                const user = getAuthedFirestore("alice");
                 const userDocRef = communityRulesHelper.getDocumentRef(user);
-                yield communityRulesHelper.getDocumentRef(dbAdmin).set({ someKey: 'value' });
+                yield communityRulesHelper
+                    .getDocumentRef(dbAdmin)
+                    .set({ someKey: "value" });
                 yield firebase.assertFails(userDocRef.delete());
             }));
         }));
-        describe('/chats/{messageId=**}', () => {
-            const collectionChats = 'chats';
+        describe("/chats/{messageId=**}", () => {
+            const collectionChats = "chats";
             const communityRulesHelper = new firestore_rules_helper_1.CommunityRulesHelper(dbAdmin, [
-                { collection: collectionCommunity, document: 'communityId' },
-                { collection: collectionChats, document: 'messageId' },
+                { collection: collectionCommunity, document: "communityId" },
+                { collection: collectionChats, document: "messageId" },
             ]);
-            describe('authorized', () => {
-                const user = getAuthedFirestore('alice');
+            describe("authorized", () => {
+                const user = getAuthedFirestore("alice");
                 const userColRef = communityRulesHelper.getCollectionRef(user);
                 const userDocRef = communityRulesHelper.getDocumentRef(user);
                 beforeEach(() => __awaiter(void 0, void 0, void 0, function* () {
-                    yield communityRulesHelper.getDocumentRef(dbAdmin).set(originalDataMap);
+                    yield communityRulesHelper
+                        .getDocumentRef(dbAdmin)
+                        .set(originalDataMap);
                 }));
-                it('isDocCreator', () => __awaiter(void 0, void 0, void 0, function* () {
-                    yield communityRulesHelper.makeDocCreator('alice');
+                it("isDocCreator", () => __awaiter(void 0, void 0, void 0, function* () {
+                    yield communityRulesHelper.makeDocCreator("alice");
                     function testDifferentMembership(membership) {
                         return __awaiter(this, void 0, void 0, function* () {
-                            yield communityRulesHelper.createMembership('alice', membership);
+                            yield communityRulesHelper.createMembership("alice", membership);
                             // Currently there is no influence based on membership rule. But in the future there might be
                             // so leaving this switch for now more convenience.
                             switch (membership) {
@@ -343,8 +351,8 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                                 case firestore_rules_helper_1.Membership.nonmember:
                                 case firestore_rules_helper_1.Membership.attendee:
                                     yield firebase.assertSucceeds(userDocRef.set({
-                                        [fieldCreatorId]: 'alice',
-                                        someKey: 'someValue',
+                                        [fieldCreatorId]: "alice",
+                                        someKey: "someValue",
                                     }));
                                     // Merging to keep `creatorId` set.
                                     yield firebase.assertSucceeds(userDocRef.set(originalDataMap, { merge: true }));
@@ -358,18 +366,18 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                         yield testDifferentMembership(membership);
                     }
                 }));
-                it('not docCreator but mod', () => __awaiter(void 0, void 0, void 0, function* () {
-                    yield communityRulesHelper.makeDocCreator('bob');
+                it("not docCreator but mod", () => __awaiter(void 0, void 0, void 0, function* () {
+                    yield communityRulesHelper.makeDocCreator("bob");
                     function testDifferentMembership(membership) {
                         return __awaiter(this, void 0, void 0, function* () {
-                            yield communityRulesHelper.createMembership('alice', membership);
+                            yield communityRulesHelper.createMembership("alice", membership);
                             switch (membership) {
                                 case firestore_rules_helper_1.Membership.owner:
                                 case firestore_rules_helper_1.Membership.admin:
                                 case firestore_rules_helper_1.Membership.mod:
                                     yield firebase.assertSucceeds(userDocRef.set({
-                                        [fieldCreatorId]: 'bob',
-                                        someKey: 'someValue',
+                                        [fieldCreatorId]: "bob",
+                                        someKey: "someValue",
                                     }));
                                     // Merging to keep `creatorId` set.
                                     yield firebase.assertSucceeds(userDocRef.set(originalDataMap, { merge: true }));
@@ -381,8 +389,8 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                                 case firestore_rules_helper_1.Membership.nonmember:
                                 case firestore_rules_helper_1.Membership.attendee:
                                     yield firebase.assertFails(userDocRef.set({
-                                        [fieldCreatorId]: 'bob',
-                                        someKey: 'someValue',
+                                        [fieldCreatorId]: "bob",
+                                        someKey: "someValue",
                                     }));
                                     // Merging to keep `creatorId` set.
                                     yield firebase.assertFails(userDocRef.set(originalDataMap, { merge: true }));
@@ -397,14 +405,14 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                     }
                 }));
             });
-            it('not authorized', () => __awaiter(void 0, void 0, void 0, function* () {
-                const user = getAuthedFirestore('bob');
+            it("not authorized", () => __awaiter(void 0, void 0, void 0, function* () {
+                const user = getAuthedFirestore("bob");
                 const userDocRef = communityRulesHelper.getDocumentRef(user);
                 yield communityRulesHelper.getDocumentRef(dbAdmin).set(originalDataMap);
-                yield communityRulesHelper.makeDocCreator('alice');
+                yield communityRulesHelper.makeDocCreator("alice");
                 function testDifferentMembership(membership) {
                     return __awaiter(this, void 0, void 0, function* () {
-                        yield communityRulesHelper.createMembership('alice', membership);
+                        yield communityRulesHelper.createMembership("alice", membership);
                         // Currently there is no influence based on membership rule. But in the future there might be
                         // so leaving this switch for now more convenience.
                         switch (membership) {
@@ -416,8 +424,8 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                             case firestore_rules_helper_1.Membership.nonmember:
                             case firestore_rules_helper_1.Membership.attendee:
                                 yield firebase.assertFails(userDocRef.set({
-                                    [fieldCreatorId]: 'alice',
-                                    someKey: 'someValue',
+                                    [fieldCreatorId]: "alice",
+                                    someKey: "someValue",
                                 }));
                                 // Merging to keep `creatorId` set.
                                 yield firebase.assertFails(userDocRef.set(originalDataMap, { merge: true }));
@@ -432,23 +440,25 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                 }
             }));
         });
-        describe('/featured/{featuredId=**}', () => {
-            const collectionFeatured = 'featured';
+        describe("/featured/{featuredId=**}", () => {
+            const collectionFeatured = "featured";
             const communityRulesHelper = new firestore_rules_helper_1.CommunityRulesHelper(dbAdmin, [
-                { collection: collectionCommunity, document: 'communityId' },
-                { collection: collectionFeatured, document: 'featuredId' },
+                { collection: collectionCommunity, document: "communityId" },
+                { collection: collectionFeatured, document: "featuredId" },
             ]);
-            describe('authorized', () => {
+            describe("authorized", () => {
                 beforeEach(() => __awaiter(void 0, void 0, void 0, function* () {
-                    yield communityRulesHelper.getDocumentRef(dbAdmin).set(originalDataMap);
+                    yield communityRulesHelper
+                        .getDocumentRef(dbAdmin)
+                        .set(originalDataMap);
                 }));
-                it('isCommunityAdmin', () => __awaiter(void 0, void 0, void 0, function* () {
-                    const user = getAuthedFirestore('alice');
+                it("isCommunityAdmin", () => __awaiter(void 0, void 0, void 0, function* () {
+                    const user = getAuthedFirestore("alice");
                     const userColRef = communityRulesHelper.getCollectionRef(user);
                     const userDocRef = communityRulesHelper.getDocumentRef(user);
                     function testDifferentMembership(membership) {
                         return __awaiter(this, void 0, void 0, function* () {
-                            yield communityRulesHelper.createMembership('alice', membership);
+                            yield communityRulesHelper.createMembership("alice", membership);
                             switch (membership) {
                                 case firestore_rules_helper_1.Membership.owner:
                                 case firestore_rules_helper_1.Membership.admin:
@@ -477,14 +487,14 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                     }
                 }));
             });
-            it('not authorized', () => __awaiter(void 0, void 0, void 0, function* () {
+            it("not authorized", () => __awaiter(void 0, void 0, void 0, function* () {
                 yield communityRulesHelper.getDocumentRef(dbAdmin).set(originalDataMap);
-                const user = getAuthedFirestore('bob');
+                const user = getAuthedFirestore("bob");
                 const userColRef = communityRulesHelper.getCollectionRef(user);
                 const userDocRef = communityRulesHelper.getDocumentRef(user);
                 function testDifferentMembership(membership) {
                     return __awaiter(this, void 0, void 0, function* () {
-                        yield communityRulesHelper.createMembership('alice', membership);
+                        yield communityRulesHelper.createMembership("alice", membership);
                         // Currently there is no influence based on membership rule. But in the future there might be
                         // so leaving this switch for now more convenience.
                         switch (membership) {
@@ -509,30 +519,32 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                 }
             }));
         });
-        describe('/announcements/{announcementId}', () => {
-            const collectionAnnouncements = 'announcements';
+        describe("/announcements/{announcementId}", () => {
+            const collectionAnnouncements = "announcements";
             const communityRulesHelper = new firestore_rules_helper_1.CommunityRulesHelper(dbAdmin, [
-                { collection: collectionCommunity, document: 'communityId' },
-                { collection: collectionAnnouncements, document: 'announcementId' },
+                { collection: collectionCommunity, document: "communityId" },
+                { collection: collectionAnnouncements, document: "announcementId" },
             ]);
-            describe('authorized', () => {
+            describe("authorized", () => {
                 beforeEach(() => __awaiter(void 0, void 0, void 0, function* () {
-                    yield communityRulesHelper.getDocumentRef(dbAdmin).set(originalDataMap);
+                    yield communityRulesHelper
+                        .getDocumentRef(dbAdmin)
+                        .set(originalDataMap);
                 }));
-                it('isCommunityAdmin', () => __awaiter(void 0, void 0, void 0, function* () {
-                    const user = getAuthedFirestore('alice');
+                it("isCommunityAdmin", () => __awaiter(void 0, void 0, void 0, function* () {
+                    const user = getAuthedFirestore("alice");
                     const userColRef = communityRulesHelper.getCollectionRef(user);
                     const userDocRef = communityRulesHelper.getDocumentRef(user);
                     function testDifferentMembership(membership) {
                         return __awaiter(this, void 0, void 0, function* () {
-                            yield communityRulesHelper.createMembership('alice', membership);
+                            yield communityRulesHelper.createMembership("alice", membership);
                             switch (membership) {
                                 case firestore_rules_helper_1.Membership.owner:
                                 case firestore_rules_helper_1.Membership.admin:
                                     yield firebase.assertFails(userColRef.add(originalDataMap));
                                     yield firebase.assertSucceeds(userColRef.add({
-                                        [fieldCreatorId]: 'alice',
-                                        someKey: 'someValue',
+                                        [fieldCreatorId]: "alice",
+                                        someKey: "someValue",
                                     }));
                                     yield firebase.assertSucceeds(userDocRef.get());
                                     yield firebase.assertSucceeds(userDocRef.set(originalDataMap));
@@ -546,8 +558,8 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                                 case firestore_rules_helper_1.Membership.attendee:
                                     yield firebase.assertFails(userColRef.add(originalDataMap));
                                     yield firebase.assertFails(userColRef.add({
-                                        [fieldCreatorId]: 'alice',
-                                        someKey: 'someValue',
+                                        [fieldCreatorId]: "alice",
+                                        someKey: "someValue",
                                     }));
                                     yield firebase.assertSucceeds(userDocRef.get());
                                     yield firebase.assertFails(userDocRef.set(originalDataMap));
@@ -562,7 +574,7 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                     }
                 }));
             });
-            it('not authorized', () => __awaiter(void 0, void 0, void 0, function* () {
+            it("not authorized", () => __awaiter(void 0, void 0, void 0, function* () {
                 yield communityRulesHelper.getDocumentRef(dbAdmin).set(originalDataMap);
                 const user = getAuthedFirestore(undefined);
                 const userColRef = communityRulesHelper.getCollectionRef(user);
@@ -582,7 +594,7 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                                 yield firebase.assertFails(userColRef.add(originalDataMap));
                                 yield firebase.assertFails(userColRef.add({
                                     [fieldCreatorId]: null,
-                                    someKey: 'someValue',
+                                    someKey: "someValue",
                                 }));
                                 yield firebase.assertFails(userDocRef.get());
                                 yield firebase.assertFails(userDocRef.set(originalDataMap));
@@ -597,28 +609,28 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                 }
             }));
         });
-        describe('/templates/{templateId}', () => {
-            const collectionTemplates = 'templates';
+        describe("/templates/{templateId}", () => {
+            const collectionTemplates = "templates";
             const communityRulesHelper = new firestore_rules_helper_1.CommunityRulesHelper(dbAdmin, [
-                { collection: collectionCommunity, document: 'communityId' },
-                { collection: collectionTemplates, document: 'templateId' },
+                { collection: collectionCommunity, document: "communityId" },
+                { collection: collectionTemplates, document: "templateId" },
             ]);
-            it('authorized', () => __awaiter(void 0, void 0, void 0, function* () {
+            it("authorized", () => __awaiter(void 0, void 0, void 0, function* () {
                 yield communityRulesHelper.getDocumentRef(dbAdmin).set(originalDataMap);
-                const user = getAuthedFirestore('alice');
+                const user = getAuthedFirestore("alice");
                 const userColRef = communityRulesHelper.getCollectionRef(user);
                 const userDocRef = communityRulesHelper.getDocumentRef(user);
                 function testDifferentMembership(membership) {
                     return __awaiter(this, void 0, void 0, function* () {
-                        yield communityRulesHelper.createMembership('alice', membership);
+                        yield communityRulesHelper.createMembership("alice", membership);
                         switch (membership) {
                             case firestore_rules_helper_1.Membership.owner:
                             case firestore_rules_helper_1.Membership.admin:
                             case firestore_rules_helper_1.Membership.mod:
                                 yield firebase.assertFails(userColRef.add(originalDataMap));
                                 yield firebase.assertSucceeds(userColRef.add({
-                                    [fieldCreatorId]: 'alice',
-                                    someKey: 'someValue',
+                                    [fieldCreatorId]: "alice",
+                                    someKey: "someValue",
                                 }));
                                 yield firebase.assertSucceeds(userDocRef.get());
                                 yield firebase.assertSucceeds(userDocRef.set(originalDataMap, { merge: true }));
@@ -629,8 +641,8 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                             case firestore_rules_helper_1.Membership.member:
                                 yield firebase.assertFails(userColRef.add(originalDataMap));
                                 yield firebase.assertSucceeds(userColRef.add({
-                                    [fieldCreatorId]: 'alice',
-                                    someKey: 'someValue',
+                                    [fieldCreatorId]: "alice",
+                                    someKey: "someValue",
                                 }));
                                 yield firebase.assertSucceeds(userDocRef.get());
                                 yield firebase.assertFails(userDocRef.set(originalDataMap, { merge: true }));
@@ -641,8 +653,8 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                             case firestore_rules_helper_1.Membership.attendee:
                                 yield firebase.assertFails(userColRef.add(originalDataMap));
                                 yield firebase.assertFails(userColRef.add({
-                                    [fieldCreatorId]: 'alice',
-                                    someKey: 'someValue',
+                                    [fieldCreatorId]: "alice",
+                                    someKey: "someValue",
                                 }));
                                 yield firebase.assertSucceeds(userDocRef.get());
                                 yield firebase.assertFails(userDocRef.set(originalDataMap, { merge: true }));
@@ -656,7 +668,7 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                     yield testDifferentMembership(membership);
                 }
             }));
-            it('not authorized', () => __awaiter(void 0, void 0, void 0, function* () {
+            it("not authorized", () => __awaiter(void 0, void 0, void 0, function* () {
                 yield communityRulesHelper.getDocumentRef(dbAdmin).set(originalDataMap);
                 const user = getAuthedFirestore(undefined);
                 const userColRef = communityRulesHelper.getCollectionRef(user);
@@ -674,7 +686,7 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                                 yield firebase.assertFails(userColRef.add(originalDataMap));
                                 yield firebase.assertFails(userColRef.add({
                                     [fieldCreatorId]: null,
-                                    someKey: 'someValue',
+                                    someKey: "someValue",
                                 }));
                                 yield firebase.assertFails(userDocRef.get());
                                 yield firebase.assertFails(userDocRef.set(originalDataMap, { merge: true }));
@@ -688,28 +700,30 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                     yield testDifferentMembership(membership);
                 }
             }));
-            describe('/events/{eventId}', () => {
-                const collectionEvents = 'events';
+            describe("/events/{eventId}", () => {
+                const collectionEvents = "events";
                 const communityRulesHelper = new firestore_rules_helper_1.CommunityRulesHelper(dbAdmin, [
-                    { collection: collectionCommunity, document: 'communityId' },
-                    { collection: collectionTemplates, document: 'templateId' },
-                    { collection: collectionEvents, document: 'eventId' },
+                    { collection: collectionCommunity, document: "communityId" },
+                    { collection: collectionTemplates, document: "templateId" },
+                    { collection: collectionEvents, document: "eventId" },
                 ]);
                 beforeEach(() => __awaiter(void 0, void 0, void 0, function* () {
-                    yield communityRulesHelper.getDocumentRef(dbAdmin).set(originalDataMap);
+                    yield communityRulesHelper
+                        .getDocumentRef(dbAdmin)
+                        .set(originalDataMap);
                 }));
-                describe('authorized', () => {
-                    it('isDocCreator', () => __awaiter(void 0, void 0, void 0, function* () {
+                describe("authorized", () => {
+                    it("isDocCreator", () => __awaiter(void 0, void 0, void 0, function* () {
                         yield communityRulesHelper.getDocumentRef(dbAdmin).set({
-                            [fieldCreatorId]: 'alice',
-                            someKey: 'someValue',
+                            [fieldCreatorId]: "alice",
+                            someKey: "someValue",
                         });
-                        const user = getAuthedFirestore('alice');
+                        const user = getAuthedFirestore("alice");
                         const userColRef = communityRulesHelper.getCollectionRef(user);
                         const userDocRef = communityRulesHelper.getDocumentRef(user);
                         function testDifferentMembership(membership) {
                             return __awaiter(this, void 0, void 0, function* () {
-                                yield communityRulesHelper.createMembership('alice', membership);
+                                yield communityRulesHelper.createMembership("alice", membership);
                                 switch (membership) {
                                     case firestore_rules_helper_1.Membership.owner:
                                     case firestore_rules_helper_1.Membership.admin:
@@ -720,8 +734,8 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                                     case firestore_rules_helper_1.Membership.attendee:
                                         yield firebase.assertFails(userColRef.add(originalDataMap));
                                         yield firebase.assertSucceeds(userColRef.add({
-                                            [fieldCreatorId]: 'alice',
-                                            someKey: 'someValue',
+                                            [fieldCreatorId]: "alice",
+                                            someKey: "someValue",
                                         }));
                                         yield firebase.assertSucceeds(userDocRef.get());
                                         yield firebase.assertSucceeds(userDocRef.set(originalDataMap, { merge: true }));
@@ -735,25 +749,25 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                             yield testDifferentMembership(membership);
                         }
                     }));
-                    it('!isDocCreator', () => __awaiter(void 0, void 0, void 0, function* () {
+                    it("!isDocCreator", () => __awaiter(void 0, void 0, void 0, function* () {
                         yield communityRulesHelper.getDocumentRef(dbAdmin).set({
-                            [fieldCreatorId]: 'alice',
-                            someKey: 'someValue',
+                            [fieldCreatorId]: "alice",
+                            someKey: "someValue",
                         });
-                        const user = getAuthedFirestore('bob');
+                        const user = getAuthedFirestore("bob");
                         const userColRef = communityRulesHelper.getCollectionRef(user);
                         const userDocRef = communityRulesHelper.getDocumentRef(user);
                         function testDifferentMembership(membership) {
                             return __awaiter(this, void 0, void 0, function* () {
-                                yield communityRulesHelper.createMembership('bob', membership);
+                                yield communityRulesHelper.createMembership("bob", membership);
                                 switch (membership) {
                                     case firestore_rules_helper_1.Membership.owner:
                                     case firestore_rules_helper_1.Membership.admin:
                                     case firestore_rules_helper_1.Membership.mod:
                                         yield firebase.assertFails(userColRef.add(originalDataMap));
                                         yield firebase.assertSucceeds(userColRef.add({
-                                            [fieldCreatorId]: 'bob',
-                                            someKey: 'someValue',
+                                            [fieldCreatorId]: "bob",
+                                            someKey: "someValue",
                                         }));
                                         yield firebase.assertSucceeds(userDocRef.get());
                                         yield firebase.assertSucceeds(userDocRef.update(updateDataMap));
@@ -766,8 +780,8 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                                     case firestore_rules_helper_1.Membership.attendee:
                                         yield firebase.assertFails(userColRef.add(originalDataMap));
                                         yield firebase.assertSucceeds(userColRef.add({
-                                            [fieldCreatorId]: 'bob',
-                                            someKey: 'someValue',
+                                            [fieldCreatorId]: "bob",
+                                            someKey: "someValue",
                                         }));
                                         yield firebase.assertSucceeds(userDocRef.get());
                                         yield firebase.assertFails(userDocRef.set(originalDataMap, { merge: true }));
@@ -781,17 +795,17 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                             yield testDifferentMembership(membership);
                         }
                     }));
-                    describe('update', () => __awaiter(void 0, void 0, void 0, function* () {
-                        it('isDocCreator', () => __awaiter(void 0, void 0, void 0, function* () {
-                            const user = getAuthedFirestore('alice');
+                    describe("update", () => __awaiter(void 0, void 0, void 0, function* () {
+                        it("isDocCreator", () => __awaiter(void 0, void 0, void 0, function* () {
+                            const user = getAuthedFirestore("alice");
                             const userDocRef = communityRulesHelper.getDocumentRef(user);
                             yield communityRulesHelper.getDocumentRef(dbAdmin).set({
-                                [fieldCreatorId]: 'alice',
-                                someKey: 'someValue',
+                                [fieldCreatorId]: "alice",
+                                someKey: "someValue",
                             });
                             function testDifferentMembership(membership) {
                                 return __awaiter(this, void 0, void 0, function* () {
-                                    yield communityRulesHelper.createMembership('alice', membership);
+                                    yield communityRulesHelper.createMembership("alice", membership);
                                     switch (membership) {
                                         case firestore_rules_helper_1.Membership.owner:
                                         case firestore_rules_helper_1.Membership.admin:
@@ -810,13 +824,15 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                                 yield testDifferentMembership(membership);
                             }
                         }));
-                        it('isCommunityMod', () => __awaiter(void 0, void 0, void 0, function* () {
-                            yield communityRulesHelper.getDocumentRef(dbAdmin).set(originalDataMap);
-                            const user = getAuthedFirestore('alice');
+                        it("isCommunityMod", () => __awaiter(void 0, void 0, void 0, function* () {
+                            yield communityRulesHelper
+                                .getDocumentRef(dbAdmin)
+                                .set(originalDataMap);
+                            const user = getAuthedFirestore("alice");
                             const userDocRef = communityRulesHelper.getDocumentRef(user);
                             function testDifferentMembership(membership) {
                                 return __awaiter(this, void 0, void 0, function* () {
-                                    yield communityRulesHelper.createMembership('alice', membership);
+                                    yield communityRulesHelper.createMembership("alice", membership);
                                     switch (membership) {
                                         case firestore_rules_helper_1.Membership.owner:
                                         case firestore_rules_helper_1.Membership.admin:
@@ -840,10 +856,10 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                         }));
                     }));
                 });
-                it('is not authorized', () => __awaiter(void 0, void 0, void 0, function* () {
+                it("is not authorized", () => __awaiter(void 0, void 0, void 0, function* () {
                     yield communityRulesHelper.getDocumentRef(dbAdmin).set({
                         [fieldCreatorId]: null,
-                        someKey: 'someValue',
+                        someKey: "someValue",
                     });
                     const user = getAuthedFirestore(undefined);
                     const userColRef = communityRulesHelper.getCollectionRef(user);
@@ -860,8 +876,8 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                                 case firestore_rules_helper_1.Membership.attendee:
                                     yield firebase.assertFails(userColRef.add(originalDataMap));
                                     yield firebase.assertFails(userColRef.add({
-                                        [fieldCreatorId]: 'alice',
-                                        someKey: 'someValue',
+                                        [fieldCreatorId]: "alice",
+                                        someKey: "someValue",
                                     }));
                                     yield firebase.assertFails(userDocRef.get());
                                     yield firebase.assertFails(userDocRef.set(originalDataMap, { merge: true }));
@@ -875,27 +891,29 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                         yield testDifferentMembership(membership);
                     }
                 }));
-                describe('/event-participants/{participantId}', () => {
-                    const collectionEventsParticipants = 'event-participants';
+                describe("/event-participants/{participantId}", () => {
+                    const collectionEventsParticipants = "event-participants";
                     const communityRulesHelper = new firestore_rules_helper_1.CommunityRulesHelper(dbAdmin, [
-                        { collection: collectionCommunity, document: 'communityId' },
-                        { collection: collectionTemplates, document: 'templateId' },
-                        { collection: collectionEvents, document: 'eventId' },
+                        { collection: collectionCommunity, document: "communityId" },
+                        { collection: collectionTemplates, document: "templateId" },
+                        { collection: collectionEvents, document: "eventId" },
                         {
                             collection: collectionEventsParticipants,
-                            document: 'eventParticipantId',
+                            document: "eventParticipantId",
                         },
                     ]);
                     beforeEach(() => __awaiter(void 0, void 0, void 0, function* () {
-                        yield communityRulesHelper.getDocumentRef(dbAdmin).set(originalDataMap);
+                        yield communityRulesHelper
+                            .getDocumentRef(dbAdmin)
+                            .set(originalDataMap);
                     }));
-                    it('different membership', () => __awaiter(void 0, void 0, void 0, function* () {
-                        const user = getAuthedFirestore('alice');
+                    it("different membership", () => __awaiter(void 0, void 0, void 0, function* () {
+                        const user = getAuthedFirestore("alice");
                         const userColRef = communityRulesHelper.getCollectionRef(user);
                         const userDocRef = communityRulesHelper.getDocumentRef(user);
                         function testDifferentMembership(membership) {
                             return __awaiter(this, void 0, void 0, function* () {
-                                yield communityRulesHelper.createMembership('alice', membership);
+                                yield communityRulesHelper.createMembership("alice", membership);
                                 switch (membership) {
                                     case firestore_rules_helper_1.Membership.owner:
                                     case firestore_rules_helper_1.Membership.admin:
@@ -912,8 +930,8 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                                     case firestore_rules_helper_1.Membership.attendee:
                                         yield firebase.assertFails(userColRef.add(originalDataMap));
                                         yield firebase.assertSucceeds(userDocRef.get());
-                                        yield firebase.assertFails(userDocRef.set(originalDataMap));
-                                        yield firebase.assertFails(userDocRef.update(updateDataMap));
+                                        yield firebase.assertFails(userDocRef.set(updateDataMap));
+                                        yield firebase.assertFails(userDocRef.update({ someField: "adiffvalue" }));
                                         yield firebase.assertFails(userDocRef.delete());
                                         break;
                                 }
@@ -923,20 +941,20 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                             yield testDifferentMembership(membership);
                         }
                     }));
-                    it('isDocCreator', () => __awaiter(void 0, void 0, void 0, function* () {
+                    it("isDocCreator", () => __awaiter(void 0, void 0, void 0, function* () {
                         // When we are in event-participants collection, we check ownership of previous
                         // collection (event). Very important not to mix it.
                         const eventsHelper = new firestore_rules_helper_1.CommunityRulesHelper(dbAdmin, [
-                            { collection: collectionCommunity, document: 'communityId' },
-                            { collection: collectionTemplates, document: 'templateId' },
-                            { collection: collectionEvents, document: 'eventId' },
+                            { collection: collectionCommunity, document: "communityId" },
+                            { collection: collectionTemplates, document: "templateId" },
+                            { collection: collectionEvents, document: "eventId" },
                         ]);
-                        yield eventsHelper.makeDocCreator('alice');
+                        yield eventsHelper.makeDocCreator("alice");
                         yield communityRulesHelper
                             .getDocumentRef(dbAdmin)
-                            .set({ someKey: 'someValue' });
-                        yield communityRulesHelper.createMembership('alice', 'nonmember');
-                        const user = getAuthedFirestore('alice');
+                            .set({ someKey: "someValue" });
+                        yield communityRulesHelper.createMembership("alice", "nonmember");
+                        const user = getAuthedFirestore("alice");
                         const userColRef = communityRulesHelper.getCollectionRef(user);
                         const userDocRef = communityRulesHelper.getDocumentRef(user);
                         yield firebase.assertSucceeds(userColRef.add(originalDataMap));
@@ -945,9 +963,9 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                         yield firebase.assertSucceeds(userDocRef.update(updateDataMap));
                         yield firebase.assertSucceeds(userDocRef.delete());
                     }));
-                    describe('request by uid', () => {
-                        it('request by same user', () => __awaiter(void 0, void 0, void 0, function* () {
-                            const user = getAuthedFirestore('eventParticipantId');
+                    describe("request by uid", () => {
+                        it("request by same user", () => __awaiter(void 0, void 0, void 0, function* () {
+                            const user = getAuthedFirestore("eventParticipantId");
                             const userColRef = communityRulesHelper.getCollectionRef(user);
                             const userDocRef = communityRulesHelper.getDocumentRef(user);
                             yield firebase.assertFails(userColRef.add(originalDataMap));
@@ -956,8 +974,8 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                             yield firebase.assertSucceeds(userDocRef.update(updateDataMap));
                             yield firebase.assertSucceeds(userDocRef.delete());
                         }));
-                        it('request by different user', () => __awaiter(void 0, void 0, void 0, function* () {
-                            const user = getAuthedFirestore('bob');
+                        it("request by different user", () => __awaiter(void 0, void 0, void 0, function* () {
+                            const user = getAuthedFirestore("bob");
                             const userColRef = communityRulesHelper.getCollectionRef(user);
                             const userDocRef = communityRulesHelper.getDocumentRef(user);
                             yield firebase.assertFails(userColRef.add(originalDataMap));
@@ -967,19 +985,47 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                             yield firebase.assertFails(userDocRef.delete());
                         }));
                     });
-                    it('!isLiveStream', () => __awaiter(void 0, void 0, void 0, function* () {
+                    it("facilitator updating status to banned", () => __awaiter(void 0, void 0, void 0, function* () {
+                        const statusDataMap = { status: "banned" };
+                        yield communityRulesHelper
+                            .getDocumentRef(dbAdmin)
+                            .set(statusDataMap);
+                        const user = getAuthedFirestore("alice");
+                        const userColRef = communityRulesHelper.getCollectionRef(user);
+                        const userDocRef = communityRulesHelper.getDocumentRef(user);
+                        yield communityRulesHelper.createMembership("alice", "facilitator");
+                        yield firebase.assertFails(userColRef.add(originalDataMap));
+                        yield firebase.assertSucceeds(userDocRef.get());
+                        yield firebase.assertSucceeds(userDocRef.set(statusDataMap));
+                        yield firebase.assertFails(userDocRef.delete());
+                    }));
+                    it("facilitator updating lastUpdatedTime and status to banned ", () => __awaiter(void 0, void 0, void 0, function* () {
+                        const statusDataMap = { status: "banned", lastUpdatedTime: "123" };
+                        yield communityRulesHelper
+                            .getDocumentRef(dbAdmin)
+                            .set(statusDataMap);
+                        const user = getAuthedFirestore("alice");
+                        const userColRef = communityRulesHelper.getCollectionRef(user);
+                        const userDocRef = communityRulesHelper.getDocumentRef(user);
+                        yield communityRulesHelper.createMembership("alice", "facilitator");
+                        yield firebase.assertFails(userColRef.add(originalDataMap));
+                        yield firebase.assertSucceeds(userDocRef.get());
+                        yield firebase.assertSucceeds(userDocRef.update(statusDataMap));
+                        yield firebase.assertFails(userDocRef.delete());
+                    }));
+                    it("!isLiveStream", () => __awaiter(void 0, void 0, void 0, function* () {
                         // Only applicable to `get` but testing through more cases just in case.
                         // `liveStreamInfo` must be null (in `events` collection) in order `get` to succeed.
                         const eventsHelper = new firestore_rules_helper_1.CommunityRulesHelper(dbAdmin, [
-                            { collection: collectionCommunity, document: 'communityId' },
-                            { collection: collectionTemplates, document: 'templateId' },
-                            { collection: collectionEvents, document: 'eventId' },
+                            { collection: collectionCommunity, document: "communityId" },
+                            { collection: collectionTemplates, document: "templateId" },
+                            { collection: collectionEvents, document: "eventId" },
                         ]);
                         yield eventsHelper.updateDocumentsField({ liveStreamInfo: null });
                         yield communityRulesHelper
                             .getDocumentRef(dbAdmin)
-                            .set({ someKey: 'someValue' });
-                        const user = getAuthedFirestore('alice');
+                            .set({ someKey: "someValue" });
+                        const user = getAuthedFirestore("alice");
                         const userColRef = communityRulesHelper.getCollectionRef(user);
                         const userDocRef = communityRulesHelper.getDocumentRef(user);
                         yield firebase.assertFails(userColRef.add(originalDataMap));
@@ -989,46 +1035,48 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                         yield firebase.assertFails(userDocRef.delete());
                     }));
                 });
-                describe('/chats/{messageId=**}', () => {
-                    const collectionChats = 'chats';
+                describe("/chats/{messageId=**}", () => {
+                    const collectionChats = "chats";
                     const communityRulesHelper = new firestore_rules_helper_1.CommunityRulesHelper(dbAdmin, [
-                        { collection: collectionCommunity, document: 'communityId' },
-                        { collection: collectionTemplates, document: 'templateId' },
-                        { collection: collectionEvents, document: 'eventId' },
-                        { collection: collectionChats, document: 'messageId' },
+                        { collection: collectionCommunity, document: "communityId" },
+                        { collection: collectionTemplates, document: "templateId" },
+                        { collection: collectionEvents, document: "eventId" },
+                        { collection: collectionChats, document: "messageId" },
                     ]);
                     beforeEach(() => __awaiter(void 0, void 0, void 0, function* () {
-                        yield communityRulesHelper.getDocumentRef(dbAdmin).set(originalDataMap);
+                        yield communityRulesHelper
+                            .getDocumentRef(dbAdmin)
+                            .set(originalDataMap);
                     }));
-                    describe('authorized', () => {
-                        it('only authorized', () => __awaiter(void 0, void 0, void 0, function* () {
-                            const user = getAuthedFirestore('alice');
+                    describe("authorized", () => {
+                        it("only authorized", () => __awaiter(void 0, void 0, void 0, function* () {
+                            const user = getAuthedFirestore("alice");
                             const userColRef = communityRulesHelper.getCollectionRef(user);
                             const userDocRef = communityRulesHelper.getDocumentRef(user);
                             yield firebase.assertFails(userColRef.add(originalDataMap));
-                            yield firebase.assertFails(userColRef.add({ creatorId: 'alice' }));
-                            yield firebase.assertFails(userColRef.add({ creatorId: 'bob' }));
+                            yield firebase.assertFails(userColRef.add({ creatorId: "alice" }));
+                            yield firebase.assertFails(userColRef.add({ creatorId: "bob" }));
                             yield firebase.assertFails(userDocRef.get());
                             yield firebase.assertFails(userDocRef.set(originalDataMap));
-                            yield firebase.assertFails(userDocRef.set({ creatorId: 'alice' }));
-                            yield firebase.assertFails(userDocRef.set({ creatorId: 'bob' }));
+                            yield firebase.assertFails(userDocRef.set({ creatorId: "alice" }));
+                            yield firebase.assertFails(userDocRef.set({ creatorId: "bob" }));
                             yield firebase.assertFails(userDocRef.update(updateDataMap));
                             yield firebase.assertFails(userDocRef.delete());
                         }));
-                        it('isParticipant', () => __awaiter(void 0, void 0, void 0, function* () {
-                            yield communityRulesHelper.makeParticipant('communityId', 'templateId', 'eventId', 'alice');
-                            const user = getAuthedFirestore('alice');
+                        it("isParticipant", () => __awaiter(void 0, void 0, void 0, function* () {
+                            yield communityRulesHelper.makeParticipant("communityId", "templateId", "eventId", "alice");
+                            const user = getAuthedFirestore("alice");
                             const userColRef = communityRulesHelper.getCollectionRef(user);
                             const userDocRef = communityRulesHelper.getDocumentRef(user);
                             yield firebase.assertSucceeds(userColRef.add(originalDataMap));
                             yield firebase.assertSucceeds(userDocRef.get());
-                            yield firebase.assertFails(userDocRef.set({ creatorId: 'alice' }, { merge: true }));
+                            yield firebase.assertFails(userDocRef.set({ creatorId: "alice" }, { merge: true }));
                             yield firebase.assertFails(userDocRef.update(updateDataMap));
                             yield firebase.assertFails(userDocRef.delete());
                         }));
-                        it('isDocCreator', () => __awaiter(void 0, void 0, void 0, function* () {
-                            yield communityRulesHelper.makeDocCreator('alice');
-                            const user = getAuthedFirestore('alice');
+                        it("isDocCreator", () => __awaiter(void 0, void 0, void 0, function* () {
+                            yield communityRulesHelper.makeDocCreator("alice");
+                            const user = getAuthedFirestore("alice");
                             const userColRef = communityRulesHelper.getCollectionRef(user);
                             const userDocRef = communityRulesHelper.getDocumentRef(user);
                             yield firebase.assertFails(userColRef.add(originalDataMap));
@@ -1037,13 +1085,13 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                             yield firebase.assertSucceeds(userDocRef.update(updateDataMap));
                             yield firebase.assertFails(userDocRef.delete());
                         }));
-                        it('different membership', () => __awaiter(void 0, void 0, void 0, function* () {
-                            const user = getAuthedFirestore('alice');
+                        it("different membership", () => __awaiter(void 0, void 0, void 0, function* () {
+                            const user = getAuthedFirestore("alice");
                             const userColRef = communityRulesHelper.getCollectionRef(user);
                             const userDocRef = communityRulesHelper.getDocumentRef(user);
                             function testDifferentMembership(membership) {
                                 return __awaiter(this, void 0, void 0, function* () {
-                                    yield communityRulesHelper.createMembership('alice', membership);
+                                    yield communityRulesHelper.createMembership("alice", membership);
                                     switch (membership) {
                                         case firestore_rules_helper_1.Membership.owner:
                                         case firestore_rules_helper_1.Membership.admin:
@@ -1059,12 +1107,12 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                                         case firestore_rules_helper_1.Membership.nonmember:
                                         case firestore_rules_helper_1.Membership.attendee:
                                             yield firebase.assertFails(userColRef.add(originalDataMap));
-                                            yield firebase.assertFails(userColRef.add({ creatorId: 'alice' }));
-                                            yield firebase.assertFails(userColRef.add({ creatorId: 'bob' }));
+                                            yield firebase.assertFails(userColRef.add({ creatorId: "alice" }));
+                                            yield firebase.assertFails(userColRef.add({ creatorId: "bob" }));
                                             yield firebase.assertFails(userDocRef.get());
                                             yield firebase.assertFails(userDocRef.set(originalDataMap));
-                                            yield firebase.assertFails(userDocRef.set({ creatorId: 'alice' }));
-                                            yield firebase.assertFails(userDocRef.set({ creatorId: 'bob' }));
+                                            yield firebase.assertFails(userDocRef.set({ creatorId: "alice" }));
+                                            yield firebase.assertFails(userDocRef.set({ creatorId: "bob" }));
                                             yield firebase.assertFails(userDocRef.update(updateDataMap));
                                             yield firebase.assertFails(userDocRef.delete());
                                             break;
@@ -1076,7 +1124,7 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                             }
                         }));
                     });
-                    it('not authorized', () => __awaiter(void 0, void 0, void 0, function* () {
+                    it("not authorized", () => __awaiter(void 0, void 0, void 0, function* () {
                         const user = getAuthedFirestore(undefined);
                         const userColRef = communityRulesHelper.getCollectionRef(user);
                         const userDocRef = communityRulesHelper.getDocumentRef(user);
@@ -1087,46 +1135,48 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                         yield firebase.assertFails(userDocRef.delete());
                     }));
                 });
-                describe('/event-messages/{eventMessageId}', () => {
-                    const collectionMessages = 'event-messages';
+                describe("/event-messages/{eventMessageId}", () => {
+                    const collectionMessages = "event-messages";
                     const communityRulesHelper = new firestore_rules_helper_1.CommunityRulesHelper(dbAdmin, [
-                        { collection: collectionCommunity, document: 'communityId' },
-                        { collection: collectionTemplates, document: 'templateId' },
-                        { collection: collectionEvents, document: 'eventId' },
-                        { collection: collectionMessages, document: 'eventMessageId' },
+                        { collection: collectionCommunity, document: "communityId" },
+                        { collection: collectionTemplates, document: "templateId" },
+                        { collection: collectionEvents, document: "eventId" },
+                        { collection: collectionMessages, document: "eventMessageId" },
                     ]);
                     beforeEach(() => __awaiter(void 0, void 0, void 0, function* () {
-                        yield communityRulesHelper.getDocumentRef(dbAdmin).set(originalDataMap);
+                        yield communityRulesHelper
+                            .getDocumentRef(dbAdmin)
+                            .set(originalDataMap);
                     }));
-                    describe('authorized', () => {
-                        it('only authorized', () => __awaiter(void 0, void 0, void 0, function* () {
-                            const user = getAuthedFirestore('alice');
+                    describe("authorized", () => {
+                        it("only authorized", () => __awaiter(void 0, void 0, void 0, function* () {
+                            const user = getAuthedFirestore("alice");
                             const userColRef = communityRulesHelper.getCollectionRef(user);
                             const userDocRef = communityRulesHelper.getDocumentRef(user);
                             yield firebase.assertFails(userColRef.add(originalDataMap));
-                            yield firebase.assertFails(userColRef.add({ creatorId: 'alice' }));
-                            yield firebase.assertFails(userColRef.add({ creatorId: 'bob' }));
+                            yield firebase.assertFails(userColRef.add({ creatorId: "alice" }));
+                            yield firebase.assertFails(userColRef.add({ creatorId: "bob" }));
                             yield firebase.assertFails(userDocRef.get());
                             yield firebase.assertFails(userDocRef.set(originalDataMap));
-                            yield firebase.assertFails(userDocRef.set({ creatorId: 'alice' }));
-                            yield firebase.assertFails(userDocRef.set({ creatorId: 'bob' }));
+                            yield firebase.assertFails(userDocRef.set({ creatorId: "alice" }));
+                            yield firebase.assertFails(userDocRef.set({ creatorId: "bob" }));
                             yield firebase.assertFails(userDocRef.update(updateDataMap));
                             yield firebase.assertFails(userDocRef.delete());
                         }));
-                        it('isParticipant', () => __awaiter(void 0, void 0, void 0, function* () {
-                            yield communityRulesHelper.makeParticipant('communityId', 'templateId', 'eventId', 'alice');
-                            const user = getAuthedFirestore('alice');
+                        it("isParticipant", () => __awaiter(void 0, void 0, void 0, function* () {
+                            yield communityRulesHelper.makeParticipant("communityId", "templateId", "eventId", "alice");
+                            const user = getAuthedFirestore("alice");
                             const userColRef = communityRulesHelper.getCollectionRef(user);
                             const userDocRef = communityRulesHelper.getDocumentRef(user);
                             yield firebase.assertFails(userColRef.add(originalDataMap));
                             yield firebase.assertSucceeds(userDocRef.get());
-                            yield firebase.assertFails(userDocRef.set({ creatorId: 'alice' }, { merge: true }));
+                            yield firebase.assertFails(userDocRef.set({ creatorId: "alice" }, { merge: true }));
                             yield firebase.assertFails(userDocRef.update(updateDataMap));
                             yield firebase.assertFails(userDocRef.delete());
                         }));
-                        it('isDocCreator', () => __awaiter(void 0, void 0, void 0, function* () {
-                            yield communityRulesHelper.makeDocCreator('alice');
-                            const user = getAuthedFirestore('alice');
+                        it("isDocCreator", () => __awaiter(void 0, void 0, void 0, function* () {
+                            yield communityRulesHelper.makeDocCreator("alice");
+                            const user = getAuthedFirestore("alice");
                             const userColRef = communityRulesHelper.getCollectionRef(user);
                             const userDocRef = communityRulesHelper.getDocumentRef(user);
                             yield firebase.assertFails(userColRef.add(originalDataMap));
@@ -1136,7 +1186,7 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                             yield firebase.assertSucceeds(userDocRef.delete());
                         }));
                     });
-                    it('not authorized', () => __awaiter(void 0, void 0, void 0, function* () {
+                    it("not authorized", () => __awaiter(void 0, void 0, void 0, function* () {
                         const user = getAuthedFirestore(undefined);
                         const userColRef = communityRulesHelper.getCollectionRef(user);
                         const userDocRef = communityRulesHelper.getDocumentRef(user);
@@ -1147,31 +1197,33 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                         yield firebase.assertFails(userDocRef.delete());
                     }));
                 });
-                describe('/user-suggestions/{suggestionId=**}', () => {
-                    const collectionUserSuggestions = 'user-suggestions';
+                describe("/user-suggestions/{suggestionId=**}", () => {
+                    const collectionUserSuggestions = "user-suggestions";
                     const communityRulesHelper = new firestore_rules_helper_1.CommunityRulesHelper(dbAdmin, [
-                        { collection: collectionCommunity, document: 'communityId' },
-                        { collection: collectionTemplates, document: 'templateId' },
-                        { collection: collectionEvents, document: 'eventId' },
-                        { collection: collectionUserSuggestions, document: 'suggestionId' },
+                        { collection: collectionCommunity, document: "communityId" },
+                        { collection: collectionTemplates, document: "templateId" },
+                        { collection: collectionEvents, document: "eventId" },
+                        { collection: collectionUserSuggestions, document: "suggestionId" },
                     ]);
                     beforeEach(() => __awaiter(void 0, void 0, void 0, function* () {
-                        yield communityRulesHelper.getDocumentRef(dbAdmin).set(originalDataMap);
+                        yield communityRulesHelper
+                            .getDocumentRef(dbAdmin)
+                            .set(originalDataMap);
                     }));
-                    describe('authorized', () => {
-                        it('only authorized', () => __awaiter(void 0, void 0, void 0, function* () {
-                            const user = getAuthedFirestore('alice');
+                    describe("authorized", () => {
+                        it("only authorized", () => __awaiter(void 0, void 0, void 0, function* () {
+                            const user = getAuthedFirestore("alice");
                             const userColRef = communityRulesHelper.getCollectionRef(user);
                             const userDocRef = communityRulesHelper.getDocumentRef(user);
-                            yield firebase.assertFails(userColRef.add({ creatorId: 'alice' }));
+                            yield firebase.assertFails(userColRef.add({ creatorId: "alice" }));
                             yield firebase.assertFails(userDocRef.get());
                             yield firebase.assertSucceeds(userDocRef.set(originalDataMap, { merge: true }));
                             yield firebase.assertSucceeds(userDocRef.update(updateDataMap));
                             yield firebase.assertFails(userDocRef.delete());
                         }));
-                        it('isDocCreator', () => __awaiter(void 0, void 0, void 0, function* () {
-                            yield communityRulesHelper.makeDocCreator('alice');
-                            const user = getAuthedFirestore('alice');
+                        it("isDocCreator", () => __awaiter(void 0, void 0, void 0, function* () {
+                            yield communityRulesHelper.makeDocCreator("alice");
+                            const user = getAuthedFirestore("alice");
                             const userColRef = communityRulesHelper.getCollectionRef(user);
                             const userDocRef = communityRulesHelper.getDocumentRef(user);
                             yield firebase.assertFails(userColRef.add(originalDataMap));
@@ -1180,43 +1232,43 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                             yield firebase.assertSucceeds(userDocRef.update(updateDataMap));
                             yield firebase.assertSucceeds(userDocRef.delete());
                         }));
-                        it('isParticipant', () => __awaiter(void 0, void 0, void 0, function* () {
-                            yield communityRulesHelper.makeParticipant('communityId', 'templateId', 'eventId', 'alice');
-                            const user = getAuthedFirestore('alice');
+                        it("isParticipant", () => __awaiter(void 0, void 0, void 0, function* () {
+                            yield communityRulesHelper.makeParticipant("communityId", "templateId", "eventId", "alice");
+                            const user = getAuthedFirestore("alice");
                             const userColRef = communityRulesHelper.getCollectionRef(user);
                             const userDocRef = communityRulesHelper.getDocumentRef(user);
-                            yield firebase.assertSucceeds(userColRef.add({ creatorId: 'alice' }));
+                            yield firebase.assertSucceeds(userColRef.add({ creatorId: "alice" }));
                             yield firebase.assertSucceeds(userDocRef.get());
                             yield firebase.assertSucceeds(userDocRef.set(originalDataMap, { merge: true }));
                             yield firebase.assertSucceeds(userDocRef.update(updateDataMap));
                             yield firebase.assertFails(userDocRef.delete());
                         }));
-                        it('!isParticipant', () => __awaiter(void 0, void 0, void 0, function* () {
-                            const user = getAuthedFirestore('alice');
+                        it("!isParticipant", () => __awaiter(void 0, void 0, void 0, function* () {
+                            const user = getAuthedFirestore("alice");
                             const userColRef = communityRulesHelper.getCollectionRef(user);
                             const userDocRef = communityRulesHelper.getDocumentRef(user);
-                            yield firebase.assertFails(userColRef.add({ creatorId: 'alice' }));
+                            yield firebase.assertFails(userColRef.add({ creatorId: "alice" }));
                             yield firebase.assertFails(userDocRef.get());
                             yield firebase.assertSucceeds(userDocRef.set(originalDataMap, { merge: true }));
                             yield firebase.assertSucceeds(userDocRef.update(updateDataMap));
                             yield firebase.assertFails(userDocRef.delete());
                         }));
-                        it('different membership', () => __awaiter(void 0, void 0, void 0, function* () {
-                            const user = getAuthedFirestore('alice');
+                        it("different membership", () => __awaiter(void 0, void 0, void 0, function* () {
+                            const user = getAuthedFirestore("alice");
                             const userColRef = communityRulesHelper.getCollectionRef(user);
                             const userDocRef = communityRulesHelper.getDocumentRef(user);
                             function testDifferentMembership(membership) {
                                 return __awaiter(this, void 0, void 0, function* () {
-                                    yield communityRulesHelper.createMembership('alice', membership);
+                                    yield communityRulesHelper.createMembership("alice", membership);
                                     switch (membership) {
                                         case firestore_rules_helper_1.Membership.owner:
                                         case firestore_rules_helper_1.Membership.admin:
                                         case firestore_rules_helper_1.Membership.mod:
-                                            yield firebase.assertSucceeds(userColRef.add({ creatorId: 'alice' }));
-                                            yield firebase.assertFails(userColRef.add({ creatorId: 'bob' }));
+                                            yield firebase.assertSucceeds(userColRef.add({ creatorId: "alice" }));
+                                            yield firebase.assertFails(userColRef.add({ creatorId: "bob" }));
                                             yield firebase.assertSucceeds(userDocRef.get());
-                                            yield firebase.assertSucceeds(userDocRef.set({ creatorId: 'alice' }, { merge: true }));
-                                            yield firebase.assertSucceeds(userDocRef.set({ creatorId: 'bob' }, { merge: true }));
+                                            yield firebase.assertSucceeds(userDocRef.set({ creatorId: "alice" }, { merge: true }));
+                                            yield firebase.assertSucceeds(userDocRef.set({ creatorId: "bob" }, { merge: true }));
                                             yield firebase.assertSucceeds(userDocRef.update(updateDataMap));
                                             yield firebase.assertSucceeds(userDocRef.delete());
                                             break;
@@ -1224,12 +1276,12 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                                         case firestore_rules_helper_1.Membership.member:
                                         case firestore_rules_helper_1.Membership.nonmember:
                                         case firestore_rules_helper_1.Membership.attendee:
-                                            yield firebase.assertFails(userColRef.add({ creatorId: 'alice' }));
-                                            yield firebase.assertFails(userColRef.add({ creatorId: 'bob' }));
+                                            yield firebase.assertFails(userColRef.add({ creatorId: "alice" }));
+                                            yield firebase.assertFails(userColRef.add({ creatorId: "bob" }));
                                             yield firebase.assertFails(userColRef.add(originalDataMap));
                                             yield firebase.assertFails(userDocRef.get());
-                                            yield firebase.assertSucceeds(userDocRef.set({ creatorId: 'alice' }, { merge: true }));
-                                            yield firebase.assertSucceeds(userDocRef.set({ creatorId: 'bob' }, { merge: true }));
+                                            yield firebase.assertSucceeds(userDocRef.set({ creatorId: "alice" }, { merge: true }));
+                                            yield firebase.assertSucceeds(userDocRef.set({ creatorId: "bob" }, { merge: true }));
                                             yield firebase.assertSucceeds(userDocRef.set({ creatorId: null }, { merge: true }));
                                             yield firebase.assertSucceeds(userDocRef.update(updateDataMap));
                                             yield firebase.assertFails(userDocRef.delete());
@@ -1242,7 +1294,7 @@ describe('Firestore security rules', () => __awaiter(void 0, void 0, void 0, fun
                             }
                         }));
                     });
-                    it('not authorized', () => __awaiter(void 0, void 0, void 0, function* () {
+                    it("not authorized", () => __awaiter(void 0, void 0, void 0, function* () {
                         const user = getAuthedFirestore(undefined);
                         const userColRef = communityRulesHelper.getCollectionRef(user);
                         const userDocRef = communityRulesHelper.getDocumentRef(user);

--- a/firebase/functions/lib/events/live_meetings/agora_api.dart
+++ b/firebase/functions/lib/events/live_meetings/agora_api.dart
@@ -168,7 +168,7 @@ class AgoraUtils {
       headers: _getAuthHeaders(),
       body: convert.json.encode(
         {
-          "appId": _agoraAppId,
+          "appid": _agoraAppId,
           "cname": roomId,
           "uid": uidToInt(userId),
           "time": 1440,

--- a/firebase/functions/lib/events/live_meetings/kick_participant.dart
+++ b/firebase/functions/lib/events/live_meetings/kick_participant.dart
@@ -42,7 +42,7 @@ class KickParticipant extends OnCallMethod<KickParticipantRequest> {
         firestoreUtils.fromFirestoreJson(communityMembershipDoc.data.toMap()),
       );
 
-      if (event.creatorId != context.authUid && !membership.isMod) {
+      if (event.creatorId != context.authUid && !membership.isFacilitator) {
         throw HttpsError(HttpsError.failedPrecondition, 'unauthorized', null);
       }
 
@@ -55,7 +55,9 @@ class KickParticipant extends OnCallMethod<KickParticipantRequest> {
       // Kick participant
       final roomId = request.breakoutRoomId ?? liveMeeting.meetingId ?? '';
       await agoraUtils.kickParticipant(
-          roomId: roomId, userId: request.userToKickId);
+        roomId: roomId,
+        userId: request.userToKickId,
+      );
     });
 
     return '';

--- a/firebase/functions/lib/events/live_meetings/kick_participant.dart
+++ b/firebase/functions/lib/events/live_meetings/kick_participant.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:firebase_functions_interop/firebase_functions_interop.dart';
+import 'package:functions/utils/utils.dart';
 import '../../on_call_function.dart';
 import 'agora_api.dart';
 import '../../utils/infra/firestore_utils.dart';
@@ -45,6 +46,11 @@ class KickParticipant extends OnCallMethod<KickParticipantRequest> {
       if (event.creatorId != context.authUid && !membership.isFacilitator) {
         throw HttpsError(HttpsError.failedPrecondition, 'unauthorized', null);
       }
+
+      orElseUnauthorized(
+        request.userToKickId != event.creatorId,
+        logMessage: 'Event creator cannot be kicked from event.',
+      );
 
       final liveMeeting = await firestoreUtils.getFirestoreObject(
         transaction: transaction,

--- a/firebase/functions/test/events/live_meetings/kick_participant_test.dart
+++ b/firebase/functions/test/events/live_meetings/kick_participant_test.dart
@@ -151,6 +151,46 @@ void main() {
     );
   });
 
+  test('Event creator cannot be kicked', () async {
+    const regularUserId = 'regularUser';
+    var testEvent2 = Event(
+      id: '56789',
+      status: EventStatus.active,
+      communityId: communityId,
+      templateId: templateId,
+      creatorId: adminUserId,
+      nullableEventType: EventType.hostless,
+      collectionPath: '',
+    );
+    testEvent2 = await eventUtils.createEvent(
+      event: testEvent2,
+      userId: regularUserId,
+    );
+
+    final req = KickParticipantRequest(
+      eventPath: testEvent2.fullPath,
+      userToKickId: regularUserId,
+      breakoutRoomId: null,
+    );
+
+    final kickParticipant = KickParticipant();
+
+    expect(
+      () => kickParticipant.action(
+        req,
+        CallableContext(adminUserId, null, 'fakeInstanceId'),
+      ),
+      throwsA(
+        predicate(
+          (e) =>
+              e is HttpsError &&
+              e.code == HttpsError.failedPrecondition &&
+              e.message == 'unauthorized',
+        ),
+      ),
+    );
+  });
+
   test('Successfully kicks participant from breakout room', () async {
     const breakoutRoomId = 'breakoutRoom123';
     final req = KickParticipantRequest(

--- a/firebase/functions/test/events/live_meetings/kick_participant_test.dart
+++ b/firebase/functions/test/events/live_meetings/kick_participant_test.dart
@@ -88,13 +88,13 @@ void main() {
     ).called(1);
   });
 
-  test('Moderator can successfully kick participant', () async {
-    // Create moderator user
-    const modUserId = 'modUser';
+  test('Facilitator can successfully kick participant', () async {
+    // Create faciliator user
+    const facUserId = 'faciliatorUser';
     await communityUtils.addCommunityMember(
       communityId: communityId,
-      userId: modUserId,
-      status: MembershipStatus.mod,
+      userId: facUserId,
+      status: MembershipStatus.facilitator,
     );
 
     final req = KickParticipantRequest(
@@ -107,7 +107,7 @@ void main() {
 
     await kickParticipant.action(
       req,
-      CallableContext(modUserId, null, 'fakeInstanceId'),
+      CallableContext(facUserId, null, 'fakeInstanceId'),
     );
 
     verify(


### PR DESCRIPTION
## What is in this PR?
This PR fixes the following issues to ensure facilitator+ roles can kick out any participant other than the event creator from all event types:

1. A facilitator has the admin panel and can attempt to kick out a participant, but only moderator+ has permissions in the cloud function, so they receive a message that they aren't authorized to kick. Can modify the function to allow facilitator+ instead.
2. You cannot successfully set the creator's status to banned in the DB (or remove them from the meeting), but the function to kick them from agora still executes. It should not.
3. The call to revoke join_channel perms in Agora is failing every time because the parameter name "appid" is case-sensitive and is being passed in as "appId."

## Changes in the codebase
See above

## Changes outside the codebase
None

## Testing this PR

- Kick participants from event as the facilitator. Verify immediately kicked (sees completion screen), sees a message that they are banned on event page, and is not able to rejoin.
- Attempt to kick event creator and verify creator is not kicked and can successfully participate in and rejoin meeting.
