### PR TITLE
Implement platform analytics with Matomo

### DIFF
--- a/.github/workflows/deploy_client_prod.yaml
+++ b/.github/workflows/deploy_client_prod.yaml
@@ -52,6 +52,8 @@ jobs:
           envkey_SENTRY_RELEASE: ${{ github.ref_name }}
           envkey_SENTRY_ENVIRONMENT: production
           envkey_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          envkey_MATOMO_URL: ${{ secrets.MATOMO_URL}}
+          envkey_MATOMO_SITE_ID: ${{ secrets.MATOMO_SITE_ID}}
           envkey_APP_NAME: Frankly
           envkey_TERMS_URL: https://frankly.org/terms
           envkey_PRICING_URL: https://frankly.org/pricing

--- a/.github/workflows/deploy_client_staging.yaml
+++ b/.github/workflows/deploy_client_staging.yaml
@@ -83,6 +83,8 @@ jobs:
           envkey_SENTRY_RELEASE: ${{ env.CURRENT_RELEASE }}
           envkey_SENTRY_ENVIRONMENT: staging
           envkey_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          envkey_MATOMO_URL: ${{ secrets.MATOMO_URL}}
+          envkey_MATOMO_SITE_ID: ${{ secrets.MATOMO_SITE_ID}}
           envkey_APP_NAME: Frankly
           envkey_TERMS_URL: https://frankly.org/terms
           envkey_PRICING_URL: https://frankly.org/pricing

--- a/README.md
+++ b/README.md
@@ -481,7 +481,9 @@ firebase functions:config:set \
 
 If you'd prefer to set secrets individually, such as for testing certain subsystems in isolation, you can run the commands above individually for each service. For example, you can run `firebase functions:config:set agora.storage_access_key="<YOUR_VALUE_HERE>"` to set only the Agora storage access key.
 
+**Configure the Flutter client**
 
+You will need to connect the Flutter client to your hosted instance by modifying the values in the .env file. See the example file `client/.env.hosted.example` for a the names and descriptions of environment variables used in a hosted environment. Most of them are the same as those used in local development, with the addition of properties used to connect to your Firebase and Google Cloud Functions, as well as some optional connection properties for connecting to Sentry and Matomo for reporting and analytics.
 
 
 # ❓ Troubleshooting and FAQ

--- a/client/.env.hosted.example
+++ b/client/.env.hosted.example
@@ -1,0 +1,41 @@
+# App Branding and URLs 
+APP_NAME=Frankly
+TERMS_URL=https://frankly.org/terms
+PRICING_URL=https://frankly.org/pricing
+ABOUT_URL=https://frankly.org
+PRIVACY_POLICY_URL=https://frankly.org/privacy
+HELP_CENTER_URL=https://rebootingsocialmedia.notion.site/Frankly-Help-Center-23b4f9a120a344d4af2b2ce44b2ae229
+CREATE_TEMPLATE_HELP_URL=https://rebootingsocialmedia.notion.site/Creating-and-Managing-Events-552a42e4a09549b788e1901536a25965
+CREATE_EVENT_HELP_URL=https://rebootingsocialmedia.notion.site/Creating-and-Managing-Events-552a42e4a09549b788e1901536a25965
+TROUBLESHOOTING_GUIDE_URL=https://rebootingsocialmedia.notion.site/Troubleshooting-c6f922b816a742a9bba4bf000e84565d
+LOGO_URL=https://res.cloudinary.com/dh0vegjku/image/upload/v1725488238/frankly_assets/Frankly-Icon-144x144_ex8nky.png
+SIDEBAR_FOOTER='Frankly is operated by the Applied Social Media Lab at the Berkman Klein Center for Internet & Society'
+COPYRIGHT_STATEMENT='2024 President and Fellows of Harvard College.'
+
+# App Connections
+SHARE_LINK_URL=<value> # The URL prefix for links included in the share buttons. Likely takes the form https://<app URL>/share
+FUNCTIONS_URL_PREFIX=<value> # The URL prefix for this app's Google Cloud Functions
+
+# SAAS Connections
+CLOUDINARY_IMAGE_PRESET=<value>
+CLOUDINARY_VIDEO_PRESET=<value>
+CLOUDINARY_DEFAULT_PRESET=<value>
+CLOUDINARY_CLOUD_NAME=<value>
+LINK_PREVIEW_API_KEY=<value>
+
+# Firebase Connections
+FIREBASE_API_KEY=<value>
+FIREBASE_APP_ID=<value>
+FIREBASE_MESSAGING_SENDER_ID=<value>
+FIREBASE_PROJECT_ID=<value>
+FIREBASE_AUTH_DOMAIN=<value>
+FIREBASE_DATABASE_URL=<value>
+FIREBASE_STORAGE_BUCKET=<value>
+FIREBASE_MEASUREMENT_ID=<value>
+
+# Monitoring and Analytics Connections
+SENTRY_RELEASE=<value>
+SENTRY_ENVIRONMENT=<value>
+SENTRY_DSN=<value>
+MATOMO_URL=<value>
+MATOMO_SITE_ID=<value>

--- a/client/lib/config/environment.dart
+++ b/client/lib/config/environment.dart
@@ -28,6 +28,9 @@ class Environment {
   static const sentryDSN = String.fromEnvironment('SENTRY_DSN');
   static const sentryEnvironment = String.fromEnvironment('SENTRY_ENVIRONMENT');
 
+  static const matomoURL = String.fromEnvironment('MATOMO_URL');
+  static const matomoSiteId = String.fromEnvironment('MATOMO_SITE_ID');
+
   // App branding and URL properties
   static const appName = String.fromEnvironment('APP_NAME');
   static const sidebarFooter = String.fromEnvironment('SIDEBAR_FOOTER');

--- a/client/lib/core/data/services/analytics_service.dart
+++ b/client/lib/core/data/services/analytics_service.dart
@@ -1,16 +1,43 @@
+import 'package:client/config/environment.dart';
+import 'package:client/services.dart';
 import 'package:data_models/analytics/analytics_entities.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 
-/// Trait names in Segment; avoid modifying existing names as it will break data continuity
-enum UserAnalyticsProperty {
-  email,
-  displayName,
-}
-
-/// Manages our Segment integration
 class AnalyticsService {
+  bool enableMatomo = Environment.matomoURL != '';
+
+  Future<void> initialize() async {
+    if (enableMatomo && !MatomoTracker.instance.initialized) {
+      await MatomoTracker.instance.initialize(
+        siteId: Environment.matomoSiteId,
+        url: Environment.matomoURL,
+        cookieless: true,
+        dispatchSettings: const DispatchSettings.persistent(),
+      );
+    }
+  }
+
   /// Call to track a user event
   void logEvent(AnalyticsEvent event) {
-    // Disabling segment by not sending events here rather than removing the log events
-    // everywhere that we log them.
+    if (!enableMatomo) return;
+
+    final eventProps = event.toJson();
+    final communityId = eventProps['communityId'];
+
+    final dimensions = {
+      if (communityId != null) 'dimension1': communityId.toString(),
+      if (userService.currentUserId != null)
+        'dimension3': userService.currentUserId!,
+    };
+
+    MatomoTracker.instance.trackEvent(
+      eventInfo: EventInfo(
+        category: event.getEventCategory(),
+        action: event.getEventType(),
+        name: event.getEventName(),
+        value: event.getMetricValue(),
+      ),
+      dimensions: dimensions,
+    );
   }
 }

--- a/client/lib/core/widgets/action_button.dart
+++ b/client/lib/core/widgets/action_button.dart
@@ -135,18 +135,6 @@ class _ActionButtonState extends State<ActionButton> {
 
     setState(() => _isSending = true);
 
-    final eventName = widget.eventName;
-    if (eventName != null && eventName.isNotEmpty) {
-      unawaited(
-        swallowErrors(
-          () => firebaseAnalytics.logEvent(
-            name: eventName,
-            parameters: widget.eventParameters ?? {},
-          ),
-        ),
-      );
-    }
-
     // Errors should be handled in the passed in [onPressed].
     final onPressed = widget.onPressed;
     if (onPressed != null) {

--- a/client/lib/features/community/features/create_community/presentation/widgets/freemium_dialog_flow.dart
+++ b/client/lib/features/community/features/create_community/presentation/widgets/freemium_dialog_flow.dart
@@ -108,7 +108,11 @@ class _FreemiumDialogFlowState extends State<FreemiumDialogFlow> {
   /// Returns true if UI should move to next step
   Future<bool> _nextButtonAction() async {
     if (_onStep == 1) {
-      analytics.logEvent(AnalyticsAgreeToTermsAndConditionsEvent());
+      analytics.logEvent(
+        AnalyticsAgreeToTermsAndConditionsEvent(
+          userId: userService.currentUserId!,
+        ),
+      );
     } else if (_onStep == 2) {
       final contactEmail = _community.contactEmail;
       if (contactEmail != null &&

--- a/client/lib/features/events/data/services/firestore_event_service.dart
+++ b/client/lib/features/events/data/services/firestore_event_service.dart
@@ -457,8 +457,6 @@ class FirestoreEventService {
   }) async {
     final uid = userService.currentUserId!;
 
-    unawaited(firebaseAnalytics.logEvent(name: 'event_join'));
-
     final reference = eventReference(
       communityId: communityId,
       templateId: templateId,

--- a/client/lib/features/events/features/create_event/data/providers/create_event_dialog_model.dart
+++ b/client/lib/features/events/features/create_event/data/providers/create_event_dialog_model.dart
@@ -243,7 +243,7 @@ class CreateEventDialogModel with ChangeNotifier {
       AnalyticsCreateEventEvent(
         communityId: communityProvider.community.id,
         eventId: _event.id,
-        guideId: _event.templateId,
+        templateId: _event.templateId,
       ),
     );
 
@@ -257,22 +257,10 @@ class CreateEventDialogModel with ChangeNotifier {
           communityId: communityProvider.community.id,
           eventId: _event.id,
           daysFromNow: today.difference(scheduledDay).inDays,
-          guideId: _event.templateId,
+          templateId: _event.templateId,
         ),
       );
     }
-
-    final analyticsEvent = _event.eventType == EventType.livestream
-        ? 'create_event'
-        : 'create_live_stream';
-    unawaited(
-      swallowErrors(
-        () => firebaseAnalytics.logEvent(
-          name: analyticsEvent,
-          parameters: {'public': _event.isPublic.toString()},
-        ),
-      ),
-    );
 
     return _event;
   }
@@ -332,7 +320,7 @@ class CreateEventDialogModel with ChangeNotifier {
       AnalyticsEditEventEvent(
         communityId: communityProvider.community.id,
         eventId: _event.id,
-        guideId: _event.templateId,
+        templateId: _event.templateId,
       ),
     );
   }

--- a/client/lib/features/events/features/event_page/data/providers/event_page_provider.dart
+++ b/client/lib/features/events/features/event_page/data/providers/event_page_provider.dart
@@ -125,7 +125,7 @@ class EventPageProvider with ChangeNotifier {
             AnalyticsRsvpEventEvent(
               communityId: eventProvider.communityId,
               eventId: eventProvider.eventId,
-              guideId: eventProvider.templateId,
+              templateId: eventProvider.templateId,
             ),
           );
 

--- a/client/lib/features/events/features/event_page/presentation/views/event_page.dart
+++ b/client/lib/features/events/features/event_page/presentation/views/event_page.dart
@@ -167,7 +167,6 @@ class _EventPageState extends State<EventPage> implements EventPageView {
       joinResults = await _joinEvent(showConfirm: false);
       if (!joinResults.isJoined) return;
     }
-    unawaited(firebaseAnalytics.logEvent(name: 'event_start'));
     await alertOnError(
       context,
       () => eventPageProvider.enterMeeting(

--- a/client/lib/features/events/features/event_page/presentation/widgets/event_info.dart
+++ b/client/lib/features/events/features/event_page/presentation/widgets/event_info.dart
@@ -429,7 +429,6 @@ class _EventInfoState extends State<EventInfo> {
           joinResults = await widget.onJoinEvent(showConfirm: false);
           if (!joinResults.isJoined) return;
         }
-        unawaited(firebaseAnalytics.logEvent(name: 'event_enter'));
         await alertOnError(context, () {
           if (externalPlatform.platformKey == PlatformKey.community ||
               !isPlatformSelectionEnabled) {

--- a/client/lib/features/events/features/event_page/presentation/widgets/event_info.dart
+++ b/client/lib/features/events/features/event_page/presentation/widgets/event_info.dart
@@ -443,7 +443,7 @@ class _EventInfoState extends State<EventInfo> {
 
         final communityId = widget.event.communityId;
         final eventId = widget.event.id;
-        final guideId = widget.event.templateId;
+        final templateId = widget.event.templateId;
         final isHost = (widget.event.eventType != EventType.hostless) &&
             widget.event.creatorId == userService.currentUserId;
         analytics.logEvent(
@@ -451,7 +451,7 @@ class _EventInfoState extends State<EventInfo> {
             communityId: communityId,
             eventId: eventId,
             asHost: isHost,
-            guideId: guideId,
+            templateId: templateId,
           ),
         );
       }),
@@ -721,13 +721,13 @@ class _EventInfoState extends State<EventInfo> {
         shareCallback: (ShareType type) {
           final communityId = widget.event.communityId;
           final eventId = widget.event.id;
-          final guideId = widget.event.templateId;
+          final templateId = widget.event.templateId;
           analytics.logEvent(
             AnalyticsPressShareEventEvent(
               communityId: communityId,
               eventId: eventId,
               shareType: type,
-              guideId: guideId,
+              templateId: templateId,
             ),
           );
         },

--- a/client/lib/features/events/features/live_meeting/features/meeting_agenda/data/providers/meeting_agenda_provider.dart
+++ b/client/lib/features/events/features/live_meeting/features/meeting_agenda/data/providers/meeting_agenda_provider.dart
@@ -392,6 +392,18 @@ class AgendaProvider with ChangeNotifier {
         );
         return;
       }
+      final LiveMeetingEvent? firstAgendaItem = currentLiveMeeting?.events
+          .where((e) => e.event == LiveMeetingEventType.agendaItemStarted)
+          .firstOrNull;
+      final DateTime? startTime = firstAgendaItem?.timestamp;
+      if (startTime == null) {
+        loggingService.log(
+          'Error determining event start time when logging analytics. Duration will be set to zero.',
+          logType: LogType.error,
+        );
+      }
+      final int durationInSeconds =
+          startTime == null ? 0 : serverTime.difference(startTime).inSeconds;
 
       analytics.logEvent(
         AnalyticsCompleteEventEvent(
@@ -400,6 +412,7 @@ class AgendaProvider with ChangeNotifier {
           asHost: (event?.eventType != EventType.hostless) &&
               event?.creatorId == userService.currentUserId,
           templateId: templateId,
+          duration: durationInSeconds,
         ),
       );
     }

--- a/client/lib/features/events/features/live_meeting/features/meeting_agenda/data/providers/meeting_agenda_provider.dart
+++ b/client/lib/features/events/features/live_meeting/features/meeting_agenda/data/providers/meeting_agenda_provider.dart
@@ -383,7 +383,7 @@ class AgendaProvider with ChangeNotifier {
     if (nextAgendaItem == null) {
       final communityId = event?.communityId;
       final eventId = event?.id;
-      final guideId = event?.templateId;
+      final templateId = event?.templateId;
 
       if (communityId == null || eventId == null) {
         loggingService.log(
@@ -399,7 +399,7 @@ class AgendaProvider with ChangeNotifier {
           eventId: eventId,
           asHost: (event?.eventType != EventType.hostless) &&
               event?.creatorId == userService.currentUserId,
-          guideId: guideId,
+          templateId: templateId,
         ),
       );
     }

--- a/client/lib/features/events/features/live_meeting/features/video/presentation/views/video_flutter_meeting.dart
+++ b/client/lib/features/events/features/live_meeting/features/video/presentation/views/video_flutter_meeting.dart
@@ -474,7 +474,7 @@ class GetHelpButton extends StatefulWidget {
         communityId: eventProvider.communityId,
         eventId: eventProvider.eventId,
         asHost: liveMeetingProvider.isHost,
-        guideId: eventProvider.templateId,
+        templateId: eventProvider.templateId,
       ),
     );
 

--- a/client/lib/features/events/features/live_meeting/presentation/widgets/meeting_rating.dart
+++ b/client/lib/features/events/features/live_meeting/presentation/widgets/meeting_rating.dart
@@ -1,5 +1,6 @@
 import 'package:client/core/utils/navigation_utils.dart';
 import 'package:client/core/widgets/custom_loading_indicator.dart';
+import 'package:data_models/analytics/analytics_entities.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_rating_bar/flutter_rating_bar.dart';
 import 'package:client/features/events/features/event_page/data/providers/event_provider.dart';
@@ -114,10 +115,18 @@ class _MeetingRatingState extends State<MeetingRating> {
             unratedColor: AppColor.white.withOpacity(0.5),
             onRatingUpdate: (rating) => alertOnError(context, () async {
               setState(() => _currentRating = rating);
+              final event = context.read<EventProvider>().event;
 
               await firestoreLiveMeetingService.updateRating(
-                context.read<EventProvider>().event,
+                event,
                 rating,
+              );
+              analytics.logEvent(
+                AnalyticsRateEventEvent(
+                  communityId: event.communityId,
+                  eventId: event.id,
+                  rating: rating,
+                ),
               );
             }),
           ),

--- a/client/lib/features/templates/features/create_template/presentation/create_template_presenter.dart
+++ b/client/lib/features/templates/features/create_template/presentation/create_template_presenter.dart
@@ -58,9 +58,9 @@ class CreateTemplatePresenter extends ChangeNotifier {
     var communityId = template.communityId;
     var templateId = template.id;
     analytics.logEvent(
-      AnalyticsCompleteNewGuideEvent(
+      AnalyticsCompleteNewTemplateEvent(
         communityId: communityId,
-        guideId: templateId,
+        templateId: templateId,
       ),
     );
     return template;

--- a/client/lib/features/templates/presentation/views/new_event_card.dart
+++ b/client/lib/features/templates/presentation/views/new_event_card.dart
@@ -122,9 +122,9 @@ class _NewEventCardState extends State<NewEventCard> {
         color: AppColor.darkBlue,
         onPressed: () {
           analytics.logEvent(
-            AnalyticsPressCreateEventFromGuideEvent(
+            AnalyticsPressCreateEventFromTemplateEvent(
               communityId: widget.template.communityId,
-              guideId: widget.template.id,
+              templateId: widget.template.id,
             ),
           );
           if (onTap != null) {

--- a/client/lib/features/templates/presentation/widgets/template_fab.dart
+++ b/client/lib/features/templates/presentation/widgets/template_fab.dart
@@ -63,9 +63,9 @@ class _TemplateFabState extends State<TemplateFab> {
             isCloseButtonVisible: false,
             builder: (_) {
               analytics.logEvent(
-                AnalyticsPressCreateEventFromGuideEvent(
+                AnalyticsPressCreateEventFromTemplateEvent(
                   communityId: template.communityId,
-                  guideId: template.id,
+                  templateId: template.id,
                 ),
               );
 

--- a/client/lib/features/user/data/services/firestore_user_service.dart
+++ b/client/lib/features/user/data/services/firestore_user_service.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:data_models/analytics/analytics_entities.dart';
 import 'package:flutter/foundation.dart';
 import 'package:client/services.dart';
 import 'package:data_models/user/public_user_info.dart';
@@ -55,6 +56,10 @@ class FirestoreUserService {
         return _convertPublicUserInfoAsync(snapshot);
       } else {
         transaction.set(docRef, toFirestoreJson(defaultUserInfo.toJson()));
+        // New user signed up
+        analytics.logEvent(
+          AnalyticsUserRegistrationEvent(userId: defaultUserInfo.id),
+        );
         return defaultUserInfo;
       }
     });

--- a/client/lib/features/user/data/services/user_service.dart
+++ b/client/lib/features/user/data/services/user_service.dart
@@ -272,14 +272,10 @@ class UserService with ChangeNotifier {
     // to set the users name as.
     _emailRegistrationDisplayName = displayName;
     try {
-      final userCredential = await _firebaseAuth.createUserWithEmailAndPassword(
+      await _firebaseAuth.createUserWithEmailAndPassword(
         email: email,
         password: password,
       );
-      final user = userCredential.user;
-      if (user != null) {
-        await _handleUserSignedIn(user);
-      }
     } catch (e) {
       _emailRegistrationDisplayName = null;
       rethrow;

--- a/client/lib/features/user/presentation/views/onboard_page.dart
+++ b/client/lib/features/user/presentation/views/onboard_page.dart
@@ -125,7 +125,11 @@ class _OnboardPageState extends State<OnboardPage> {
   }
 
   void _finishAgreementToTerms() {
-    analytics.logEvent(AnalyticsAgreeToTermsAndConditionsEvent());
+    analytics.logEvent(
+      AnalyticsAgreeToTermsAndConditionsEvent(
+        userId: Provider.of<UserService>(context).currentUserId!,
+      ),
+    );
     setState(() => _step = OnboardStep.paymentSetup);
   }
 

--- a/client/lib/services.dart
+++ b/client/lib/services.dart
@@ -4,7 +4,6 @@ import 'package:client/features/announcements/data/services/cloud_functions_anno
 import 'package:client/features/community/data/services/cloud_functions_community_service.dart';
 import 'package:client/features/events/data/services/cloud_functions_event_service.dart';
 import 'package:client/features/events/features/live_meeting/data/services/cloud_functions_live_meeting_service.dart';
-import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:get_it/get_it.dart';
 import 'package:client/core/data/services/analytics_service.dart';
 import 'package:client/core/data/services/clock_service.dart';
@@ -114,7 +113,6 @@ FirestoreTagService get firestoreTagService =>
 DialogProvider get dialogProvider => services.get<DialogProvider>();
 
 AnalyticsService get analytics => services.get<AnalyticsService>();
-FirebaseAnalytics get firebaseAnalytics => services.get<FirebaseAnalytics>();
 PaymentUtils get paymentUtils => services.get<PaymentUtils>();
 
 /// This file initializes all of our "services" inside of GetIt. This is basically
@@ -157,7 +155,6 @@ void createServices() {
   services.registerSingleton(UserService());
 
   services.registerSingleton(AnalyticsService());
-  services.registerSingleton(FirebaseAnalytics.instance);
 
   services.registerSingleton(DialogProvider());
   services.registerSingleton(MediaHelperService());

--- a/client/lib/services.dart
+++ b/client/lib/services.dart
@@ -167,6 +167,7 @@ void createServices() {
 
 Future<void> initializeServices() async {
   await Future.wait([
+    analytics.initialize(),
     userService.initialize(),
     firestoreDatabase.initialize(),
     userDataService.initialize(),

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -313,6 +313,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
+  device_info_plus:
+    dependency: transitive
+    description:
+      name: device_info_plus
+      sha256: a7fd703482b391a87d60b6061d04dfdeab07826b96f9abd8f5ed98068acc0074
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.1.2"
+  device_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: device_info_plus_platform_interface
+      sha256: "0b04e02b30791224b31969eb1b50d723498f402971bff3630bca2ba839bd1ed2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.2"
   dio:
     dependency: transitive
     description:
@@ -418,30 +434,6 @@ packages:
       url: "https://github.com/berkmancenter/firebase-admin-interop.git"
     source: git
     version: "2.1.0"
-  firebase_analytics:
-    dependency: "direct main"
-    description:
-      name: firebase_analytics
-      sha256: c56bcc7abc6caacc33e8495bc604a5861d25ce371f1b06476ae226e7cbb21d4c
-      url: "https://pub.dev"
-    source: hosted
-    version: "10.10.4"
-  firebase_analytics_platform_interface:
-    dependency: transitive
-    description:
-      name: firebase_analytics_platform_interface
-      sha256: e8cdb845820eaa5f1d29de31a72aab8addbbffc6483f1e5123a9d0b611735285
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.10.5"
-  firebase_analytics_web:
-    dependency: transitive
-    description:
-      name: firebase_analytics_web
-      sha256: e2fabebdf16bb99506a1e7e84f5effd6313c90678e6ea1876d301f057483a198
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.5.7+4"
   firebase_auth:
     dependency: "direct main"
     description:
@@ -804,10 +796,10 @@ packages:
     dependency: "direct main"
     description:
       name: google_fonts
-      sha256: "6b6f10f0ce3c42f6552d1c70d2c28d764cf22bb487f50f66cca31dcd5194f4d6"
+      sha256: "2776c66b3e97c6cdd58d1bd3281548b074b64f1fd5c8f82391f7456e38849567"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.4"
+    version: "4.0.5"
   graphs:
     dependency: transitive
     description:
@@ -837,10 +829,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
+      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.6"
+    version: "1.3.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -1070,6 +1062,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.8.0"
+  matomo_tracker:
+    dependency: "direct main"
+    description:
+      name: matomo_tracker
+      sha256: "8706ca29389b836929415a52c3e6e94aaf8e37ceca23407ee215716fdb83466d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.0"
   meta:
     dependency: transitive
     description:
@@ -1082,10 +1082,10 @@ packages:
     dependency: "direct main"
     description:
       name: metadata_fetch
-      sha256: "2c79e69e71cbb051041da6a8a9dd3df0617db84482ab3f36b4952ff779b7580e"
+      sha256: "24a713eaddbebea3dc3036a6c1d6f7c57e187fff5f0ef07be3e3ebbb7820c3e7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.1"
+    version: "0.4.2"
   mime:
     dependency: transitive
     description:
@@ -1166,6 +1166,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  package_info_plus:
+    dependency: transitive
+    description:
+      name: package_info_plus
+      sha256: a75164ade98cb7d24cfd0a13c6408927c6b217fa60dee5a7ff5c116a58f28918
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.0.2"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: a5ef9986efc7bf772f2696183a3992615baa76c1ffb1189318dd8803778fb05b
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   path:
     dependency: transitive
     description:
@@ -1567,10 +1583,10 @@ packages:
     dependency: transitive
     description:
       name: string_validator
-      sha256: "50dd8ecf91db6a732f4a851eeae81ee12406eedc62d0da72f2d91a04a2d10dd8"
+      sha256: a278d038104aa2df15d0e09c47cb39a49f907260732067d0034dc2f2e4e2ac94
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "1.1.0"
   sync_http:
     dependency: transitive
     description:
@@ -1883,6 +1899,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.5.0"
+  win32_registry:
+    dependency: transitive
+    description:
+      name: win32_registry
+      sha256: "10589e0d7f4e053f2c61023a31c9ce01146656a70b7b7f0828c0b46d7da2a9bb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.3"
   xdg_directories:
     dependency: transitive
     description:
@@ -1924,5 +1948,5 @@ packages:
     source: hosted
     version: "2.0.2"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
+  dart: ">=3.4.1 <4.0.0"
   flutter: ">=3.19.0"

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   flutter_staggered_grid_view: ^0.7.0
   json_serializable: ^6.6.2
   linkify: ^5.0.0
+  matomo_tracker: ^5.1.0
   normal: ^0.6.0
   platform_detect: ^2.0.11
 
@@ -28,7 +29,6 @@ dependencies:
   agora_rtc_engine:
     git:
       url: https://github.com/berkmancenter/Agora-Flutter-SDK.git
-  firebase_analytics: ^10.8.8
   firebase_auth: ^4.17.7
   firebase_core: ^2.26.0
   firebase_database: ^10.4.8
@@ -40,7 +40,7 @@ dependencies:
   intl: ^0.19.0
   freezed_annotation: ^2.4.1
   get_it: ^7.6.0
-  http: ^0.13.6
+  http: ^1.2.1
   url_launcher: ^6.1.11
   responsive_builder: ^0.7.0
   datetime_picker_formfield: ^2.0.1

--- a/data_models/lib/analytics/analytics_entities.dart
+++ b/data_models/lib/analytics/analytics_entities.dart
@@ -165,7 +165,7 @@ class AnalyticsUpdateCommunityImageEvent implements AnalyticsEvent {
 
   @override
   num? getMetricValue() {
-    return null;
+    return 1;
   }
 }
 
@@ -198,7 +198,7 @@ class AnalyticsUpdateCommunityMetadataEvent implements AnalyticsEvent {
 
   @override
   num? getMetricValue() {
-    return null;
+    return 1;
   }
 }
 
@@ -233,7 +233,7 @@ class AnalyticsPressShareCommunityLinkEvent implements AnalyticsEvent {
 
   @override
   num? getMetricValue() {
-    return null;
+    return 1;
   }
 }
 
@@ -265,7 +265,7 @@ class AnalyticsJoinCommunityEvent implements AnalyticsEvent {
 
   @override
   num? getMetricValue() {
-    return null;
+    return 1;
   }
 }
 
@@ -297,7 +297,7 @@ class AnalyticsLeaveCommunityEvent implements AnalyticsEvent {
 
   @override
   num? getMetricValue() {
-    return null;
+    return 1;
   }
 }
 
@@ -330,7 +330,7 @@ class AnalyticsPressAddNewTemplateEvent implements AnalyticsEvent {
 
   @override
   num? getMetricValue() {
-    return null;
+    return 1;
   }
 }
 
@@ -400,7 +400,7 @@ class AnalyticsPressCreateEventFromTemplateEvent implements AnalyticsEvent {
 
   @override
   num? getMetricValue() {
-    return null;
+    return 1;
   }
 }
 
@@ -474,7 +474,7 @@ class AnalyticsScheduleEventEvent implements AnalyticsEvent {
 
   @override
   num? getMetricValue() {
-    return null;
+    return 1;
   }
 }
 
@@ -510,7 +510,7 @@ class AnalyticsEditEventEvent implements AnalyticsEvent {
 
   @override
   num? getMetricValue() {
-    return null;
+    return 1;
   }
 }
 
@@ -548,7 +548,7 @@ class AnalyticsPressShareEventEvent implements AnalyticsEvent {
 
   @override
   num? getMetricValue() {
-    return null;
+    return 1;
   }
 }
 
@@ -586,7 +586,7 @@ class AnalyticsEnterEventEvent implements AnalyticsEvent {
 
   @override
   num? getMetricValue() {
-    return null;
+    return 1;
   }
 }
 
@@ -702,7 +702,7 @@ class AnalyticsPressEventHelpEvent implements AnalyticsEvent {
 
   @override
   num? getMetricValue() {
-    return null;
+    return 1;
   }
 }
 
@@ -738,7 +738,7 @@ class AnalyticsRsvpEventEvent implements AnalyticsEvent {
 
   @override
   num? getMetricValue() {
-    return null;
+    return 1;
   }
 }
 

--- a/data_models/lib/analytics/analytics_entities.dart
+++ b/data_models/lib/analytics/analytics_entities.dart
@@ -631,6 +631,44 @@ class AnalyticsCompleteEventEvent implements AnalyticsEvent {
 }
 
 @JsonSerializable()
+class AnalyticsRateEventEvent implements AnalyticsEvent {
+  @override
+  String getEventType() {
+    return 'Rate Event';
+  }
+
+  final String communityId;
+  final String eventId;
+  final double rating;
+  final String? templateId;
+
+  AnalyticsRateEventEvent({
+    required this.communityId,
+    required this.eventId,
+    required this.rating,
+    this.templateId,
+  });
+
+  @override
+  Map<String, dynamic> toJson() => _$AnalyticsRateEventEventToJson(this);
+
+  @override
+  String getEventCategory() {
+    return AnalyticsEvent.eventCategory;
+  }
+
+  @override
+  String? getEventName() {
+    return eventId;
+  }
+
+  @override
+  num? getMetricValue() {
+    return rating;
+  }
+}
+
+@JsonSerializable()
 class AnalyticsPressEventHelpEvent implements AnalyticsEvent {
   @override
   String getEventType() {

--- a/data_models/lib/analytics/analytics_entities.dart
+++ b/data_models/lib/analytics/analytics_entities.dart
@@ -16,12 +16,14 @@ abstract class AnalyticsEvent {
 
 @JsonSerializable()
 class AnalyticsAgreeToTermsAndConditionsEvent implements AnalyticsEvent {
+  final String userId;
+
   @override
   String getEventType() {
     return 'Agree to TAC';
   }
 
-  AnalyticsAgreeToTermsAndConditionsEvent();
+  AnalyticsAgreeToTermsAndConditionsEvent({required this.userId});
 
   @override
   Map<String, dynamic> toJson() =>
@@ -33,8 +35,8 @@ class AnalyticsAgreeToTermsAndConditionsEvent implements AnalyticsEvent {
   }
 
   @override
-  String? getEventName() {
-    return null;
+  String getEventName() {
+    return userId;
   }
 
   @override

--- a/data_models/lib/analytics/analytics_entities.dart
+++ b/data_models/lib/analytics/analytics_entities.dart
@@ -4,14 +4,21 @@ part 'analytics_entities.g.dart';
 
 abstract class AnalyticsEvent {
   String getEventType();
+  String getEventCategory();
+  String? getEventName();
+  num? getMetricValue();
   Map<String, dynamic> toJson();
+  static const String userCategory = 'user';
+  static const String communityCategory = 'community';
+  static const String eventCategory = 'event';
+  static const String guideCategory = 'guide';
 }
 
 @JsonSerializable()
 class AnalyticsAgreeToTermsAndConditionsEvent implements AnalyticsEvent {
   @override
   String getEventType() {
-    return 'agree_to_tac';
+    return 'Agree to TAC';
   }
 
   AnalyticsAgreeToTermsAndConditionsEvent();
@@ -19,13 +26,28 @@ class AnalyticsAgreeToTermsAndConditionsEvent implements AnalyticsEvent {
   @override
   Map<String, dynamic> toJson() =>
       _$AnalyticsAgreeToTermsAndConditionsEventToJson(this);
+
+  @override
+  String getEventCategory() {
+    return AnalyticsEvent.userCategory;
+  }
+
+  @override
+  String? getEventName() {
+    return null;
+  }
+
+  @override
+  num? getMetricValue() {
+    return null;
+  }
 }
 
 @JsonSerializable()
 class AnalyticsLinkStripeAccountEvent implements AnalyticsEvent {
   @override
   String getEventType() {
-    return 'link_stripe_account';
+    return 'Link Stripe Account';
   }
 
   AnalyticsLinkStripeAccountEvent();
@@ -33,13 +55,28 @@ class AnalyticsLinkStripeAccountEvent implements AnalyticsEvent {
   @override
   Map<String, dynamic> toJson() =>
       _$AnalyticsLinkStripeAccountEventToJson(this);
+
+  @override
+  String getEventCategory() {
+    return AnalyticsEvent.userCategory;
+  }
+
+  @override
+  String? getEventName() {
+    return null;
+  }
+
+  @override
+  num? getMetricValue() {
+    return null;
+  }
 }
 
 @JsonSerializable()
 class AnalyticsCreateCommunityEvent implements AnalyticsEvent {
   @override
   String getEventType() {
-    return 'create_community';
+    return 'Create Community';
   }
 
   final String communityId;
@@ -50,13 +87,28 @@ class AnalyticsCreateCommunityEvent implements AnalyticsEvent {
 
   @override
   Map<String, dynamic> toJson() => _$AnalyticsCreateCommunityEventToJson(this);
+
+  @override
+  String getEventCategory() {
+    return AnalyticsEvent.communityCategory;
+  }
+
+  @override
+  String? getEventName() {
+    return communityId;
+  }
+
+  @override
+  num? getMetricValue() {
+    return null;
+  }
 }
 
 @JsonSerializable()
 class AnalyticsUpdateCommunityImageEvent implements AnalyticsEvent {
   @override
   String getEventType() {
-    return 'update_community_image';
+    return 'Update Community Image';
   }
 
   final String communityId;
@@ -68,13 +120,28 @@ class AnalyticsUpdateCommunityImageEvent implements AnalyticsEvent {
   @override
   Map<String, dynamic> toJson() =>
       _$AnalyticsUpdateCommunityImageEventToJson(this);
+
+  @override
+  String getEventCategory() {
+    return AnalyticsEvent.communityCategory;
+  }
+
+  @override
+  String? getEventName() {
+    return communityId;
+  }
+
+  @override
+  num? getMetricValue() {
+    return null;
+  }
 }
 
 @JsonSerializable()
 class AnalyticsUpdateCommunityMetadataEvent implements AnalyticsEvent {
   @override
   String getEventType() {
-    return 'update_community_metadata';
+    return 'Update Community Metadata';
   }
 
   final String communityId;
@@ -86,13 +153,28 @@ class AnalyticsUpdateCommunityMetadataEvent implements AnalyticsEvent {
   @override
   Map<String, dynamic> toJson() =>
       _$AnalyticsUpdateCommunityMetadataEventToJson(this);
+
+  @override
+  String getEventCategory() {
+    return AnalyticsEvent.communityCategory;
+  }
+
+  @override
+  String? getEventName() {
+    return communityId;
+  }
+
+  @override
+  num? getMetricValue() {
+    return null;
+  }
 }
 
 @JsonSerializable()
 class AnalyticsPressShareCommunityLinkEvent implements AnalyticsEvent {
   @override
   String getEventType() {
-    return 'press_share_community_link';
+    return 'Press Share Community Link';
   }
 
   final String communityId;
@@ -106,69 +188,195 @@ class AnalyticsPressShareCommunityLinkEvent implements AnalyticsEvent {
   @override
   Map<String, dynamic> toJson() =>
       _$AnalyticsPressShareCommunityLinkEventToJson(this);
+
+  @override
+  String getEventCategory() {
+    return AnalyticsEvent.communityCategory;
+  }
+
+  @override
+  String? getEventName() {
+    return communityId;
+  }
+
+  @override
+  num? getMetricValue() {
+    return null;
+  }
 }
 
 @JsonSerializable()
-class AnalyticsPressAddNewGuideEvent implements AnalyticsEvent {
+class AnalyticsJoinCommunityEvent implements AnalyticsEvent {
   @override
   String getEventType() {
-    return 'press_add_new_guide';
+    return 'Join Community';
   }
 
   final String communityId;
 
-  AnalyticsPressAddNewGuideEvent({
+  AnalyticsJoinCommunityEvent({
     required this.communityId,
   });
 
   @override
-  Map<String, dynamic> toJson() => _$AnalyticsPressAddNewGuideEventToJson(this);
+  Map<String, dynamic> toJson() => _$AnalyticsJoinCommunityEventToJson(this);
+
+  @override
+  String getEventCategory() {
+    return AnalyticsEvent.communityCategory;
+  }
+
+  @override
+  String? getEventName() {
+    return communityId;
+  }
+
+  @override
+  num? getMetricValue() {
+    return null;
+  }
 }
 
 @JsonSerializable()
-class AnalyticsCompleteNewGuideEvent implements AnalyticsEvent {
+class AnalyticsLeaveCommunityEvent implements AnalyticsEvent {
   @override
   String getEventType() {
-    return 'complete_new_guide';
+    return 'Leave Community';
+  }
+
+  final String communityId;
+
+  AnalyticsLeaveCommunityEvent({
+    required this.communityId,
+  });
+
+  @override
+  Map<String, dynamic> toJson() => _$AnalyticsLeaveCommunityEventToJson(this);
+
+  @override
+  String getEventCategory() {
+    return AnalyticsEvent.communityCategory;
+  }
+
+  @override
+  String? getEventName() {
+    return communityId;
+  }
+
+  @override
+  num? getMetricValue() {
+    return null;
+  }
+}
+
+@JsonSerializable()
+class AnalyticsPressAddNewTemplateEvent implements AnalyticsEvent {
+  @override
+  String getEventType() {
+    return 'Press Add New Template';
+  }
+
+  final String communityId;
+
+  AnalyticsPressAddNewTemplateEvent({
+    required this.communityId,
+  });
+
+  @override
+  Map<String, dynamic> toJson() =>
+      _$AnalyticsPressAddNewTemplateEventToJson(this);
+
+  @override
+  String getEventCategory() {
+    return AnalyticsEvent.guideCategory;
+  }
+
+  @override
+  String? getEventName() {
+    return communityId;
+  }
+
+  @override
+  num? getMetricValue() {
+    return null;
+  }
+}
+
+@JsonSerializable()
+class AnalyticsCompleteNewTemplateEvent implements AnalyticsEvent {
+  @override
+  String getEventType() {
+    return 'Complete New Template';
   }
 
   final String communityId;
   final String guideId;
 
-  AnalyticsCompleteNewGuideEvent({
-    required this.communityId,
-    required this.guideId,
-  });
-
-  @override
-  Map<String, dynamic> toJson() => _$AnalyticsCompleteNewGuideEventToJson(this);
-}
-
-@JsonSerializable()
-class AnalyticsPressCreateEventFromGuideEvent implements AnalyticsEvent {
-  @override
-  String getEventType() {
-    return 'press_create_event_from_guide';
-  }
-
-  final String communityId;
-  final String guideId;
-
-  AnalyticsPressCreateEventFromGuideEvent({
+  AnalyticsCompleteNewTemplateEvent({
     required this.communityId,
     required this.guideId,
   });
 
   @override
   Map<String, dynamic> toJson() =>
-      _$AnalyticsPressCreateEventFromGuideEventToJson(this);
+      _$AnalyticsCompleteNewTemplateEventToJson(this);
+
+  @override
+  String getEventCategory() {
+    return AnalyticsEvent.guideCategory;
+  }
+
+  @override
+  String? getEventName() {
+    return guideId;
+  }
+
+  @override
+  num? getMetricValue() {
+    return null;
+  }
+}
+
+@JsonSerializable()
+class AnalyticsPressCreateEventFromTemplateEvent implements AnalyticsEvent {
+  @override
+  String getEventType() {
+    return 'Press Create Event from Template';
+  }
+
+  final String communityId;
+  final String guideId;
+
+  AnalyticsPressCreateEventFromTemplateEvent({
+    required this.communityId,
+    required this.guideId,
+  });
+
+  @override
+  Map<String, dynamic> toJson() =>
+      _$AnalyticsPressCreateEventFromTemplateEventToJson(this);
+
+  @override
+  String getEventCategory() {
+    return AnalyticsEvent.eventCategory;
+  }
+
+  @override
+  String? getEventName() {
+    return guideId;
+  }
+
+  @override
+  num? getMetricValue() {
+    return null;
+  }
 }
 
 @JsonSerializable()
 class AnalyticsCreateEventEvent implements AnalyticsEvent {
   @override
   String getEventType() {
-    return 'create_event';
+    return 'Create Event';
   }
 
   final String communityId;
@@ -183,13 +391,28 @@ class AnalyticsCreateEventEvent implements AnalyticsEvent {
 
   @override
   Map<String, dynamic> toJson() => _$AnalyticsCreateEventEventToJson(this);
+
+  @override
+  String getEventCategory() {
+    return AnalyticsEvent.eventCategory;
+  }
+
+  @override
+  String? getEventName() {
+    return eventId;
+  }
+
+  @override
+  num? getMetricValue() {
+    return null;
+  }
 }
 
 @JsonSerializable()
 class AnalyticsScheduleEventEvent implements AnalyticsEvent {
   @override
   String getEventType() {
-    return 'schedule_event';
+    return 'Schedule Event';
   }
 
   final String communityId;
@@ -206,13 +429,28 @@ class AnalyticsScheduleEventEvent implements AnalyticsEvent {
 
   @override
   Map<String, dynamic> toJson() => _$AnalyticsScheduleEventEventToJson(this);
+
+  @override
+  String getEventCategory() {
+    return AnalyticsEvent.eventCategory;
+  }
+
+  @override
+  String? getEventName() {
+    return eventId;
+  }
+
+  @override
+  num? getMetricValue() {
+    return null;
+  }
 }
 
 @JsonSerializable()
 class AnalyticsEditEventEvent implements AnalyticsEvent {
   @override
   String getEventType() {
-    return 'edit_event';
+    return 'Edit Event';
   }
 
   final String communityId;
@@ -227,13 +465,28 @@ class AnalyticsEditEventEvent implements AnalyticsEvent {
 
   @override
   Map<String, dynamic> toJson() => _$AnalyticsEditEventEventToJson(this);
+
+  @override
+  String getEventCategory() {
+    return AnalyticsEvent.eventCategory;
+  }
+
+  @override
+  String? getEventName() {
+    return eventId;
+  }
+
+  @override
+  num? getMetricValue() {
+    return null;
+  }
 }
 
 @JsonSerializable()
 class AnalyticsPressShareEventEvent implements AnalyticsEvent {
   @override
   String getEventType() {
-    return 'press_share_event';
+    return 'Press Share Event';
   }
 
   final String communityId;
@@ -250,13 +503,28 @@ class AnalyticsPressShareEventEvent implements AnalyticsEvent {
 
   @override
   Map<String, dynamic> toJson() => _$AnalyticsPressShareEventEventToJson(this);
+
+  @override
+  String getEventCategory() {
+    return AnalyticsEvent.eventCategory;
+  }
+
+  @override
+  String? getEventName() {
+    return eventId;
+  }
+
+  @override
+  num? getMetricValue() {
+    return null;
+  }
 }
 
 @JsonSerializable()
 class AnalyticsEnterEventEvent implements AnalyticsEvent {
   @override
   String getEventType() {
-    return 'enter_event';
+    return 'Enter Event';
   }
 
   final String communityId;
@@ -273,13 +541,28 @@ class AnalyticsEnterEventEvent implements AnalyticsEvent {
 
   @override
   Map<String, dynamic> toJson() => _$AnalyticsEnterEventEventToJson(this);
+
+  @override
+  String getEventCategory() {
+    return AnalyticsEvent.eventCategory;
+  }
+
+  @override
+  String? getEventName() {
+    return eventId;
+  }
+
+  @override
+  num? getMetricValue() {
+    return null;
+  }
 }
 
 @JsonSerializable()
 class AnalyticsCompleteEventEvent implements AnalyticsEvent {
   @override
   String getEventType() {
-    return 'complete_event';
+    return 'Complete Event';
   }
 
   final String communityId;
@@ -296,13 +579,28 @@ class AnalyticsCompleteEventEvent implements AnalyticsEvent {
 
   @override
   Map<String, dynamic> toJson() => _$AnalyticsCompleteEventEventToJson(this);
+
+  @override
+  String getEventCategory() {
+    return AnalyticsEvent.eventCategory;
+  }
+
+  @override
+  String? getEventName() {
+    return eventId;
+  }
+
+  @override
+  num? getMetricValue() {
+    return null;
+  }
 }
 
 @JsonSerializable()
 class AnalyticsPressEventHelpEvent implements AnalyticsEvent {
   @override
   String getEventType() {
-    return 'press_event_help';
+    return 'Press Event Help';
   }
 
   final String communityId;
@@ -319,13 +617,28 @@ class AnalyticsPressEventHelpEvent implements AnalyticsEvent {
 
   @override
   Map<String, dynamic> toJson() => _$AnalyticsPressEventHelpEventToJson(this);
+
+  @override
+  String getEventCategory() {
+    return AnalyticsEvent.eventCategory;
+  }
+
+  @override
+  String? getEventName() {
+    return eventId;
+  }
+
+  @override
+  num? getMetricValue() {
+    return null;
+  }
 }
 
 @JsonSerializable()
 class AnalyticsRsvpEventEvent implements AnalyticsEvent {
   @override
   String getEventType() {
-    return 'rsvp_event';
+    return 'RSVP Event';
   }
 
   final String communityId;
@@ -340,47 +653,28 @@ class AnalyticsRsvpEventEvent implements AnalyticsEvent {
 
   @override
   Map<String, dynamic> toJson() => _$AnalyticsRsvpEventEventToJson(this);
-}
 
-@JsonSerializable()
-class AnalyticsJoinCommunityEvent implements AnalyticsEvent {
   @override
-  String getEventType() {
-    return 'join_community';
+  String getEventCategory() {
+    return AnalyticsEvent.eventCategory;
   }
 
-  final String communityId;
-
-  AnalyticsJoinCommunityEvent({
-    required this.communityId,
-  });
-
   @override
-  Map<String, dynamic> toJson() => _$AnalyticsJoinCommunityEventToJson(this);
-}
-
-@JsonSerializable()
-class AnalyticsLeaveCommunityEvent implements AnalyticsEvent {
-  @override
-  String getEventType() {
-    return 'leave_community';
+  String? getEventName() {
+    return eventId;
   }
 
-  final String communityId;
-
-  AnalyticsLeaveCommunityEvent({
-    required this.communityId,
-  });
-
   @override
-  Map<String, dynamic> toJson() => _$AnalyticsLeaveCommunityEventToJson(this);
+  num? getMetricValue() {
+    return null;
+  }
 }
 
 @JsonSerializable()
 class AnalyticsDonateEvent implements AnalyticsEvent {
   @override
   String getEventType() {
-    return 'donate';
+    return 'Donate';
   }
 
   final String communityId;
@@ -393,13 +687,28 @@ class AnalyticsDonateEvent implements AnalyticsEvent {
 
   @override
   Map<String, dynamic> toJson() => _$AnalyticsDonateEventToJson(this);
+
+  @override
+  String getEventCategory() {
+    return AnalyticsEvent.communityCategory;
+  }
+
+  @override
+  String? getEventName() {
+    return communityId;
+  }
+
+  @override
+  num? getMetricValue() {
+    return null;
+  }
 }
 
 @JsonSerializable()
 class AnalyticsUpdateCommunitySubscriptionEvent implements AnalyticsEvent {
   @override
   String getEventType() {
-    return 'update_community_subscription';
+    return 'Update Community Subscription';
   }
 
   final String? communityId;
@@ -417,4 +726,19 @@ class AnalyticsUpdateCommunitySubscriptionEvent implements AnalyticsEvent {
   @override
   Map<String, dynamic> toJson() =>
       _$AnalyticsUpdateCommunitySubscriptionEventToJson(this);
+
+  @override
+  String getEventCategory() {
+    return AnalyticsEvent.communityCategory;
+  }
+
+  @override
+  String? getEventName() {
+    return communityId;
+  }
+
+  @override
+  num? getMetricValue() {
+    return null;
+  }
 }

--- a/data_models/lib/analytics/analytics_entities.dart
+++ b/data_models/lib/analytics/analytics_entities.dart
@@ -46,6 +46,36 @@ class AnalyticsAgreeToTermsAndConditionsEvent implements AnalyticsEvent {
 }
 
 @JsonSerializable()
+class AnalyticsUserRegistrationEvent implements AnalyticsEvent {
+  final String userId;
+
+  @override
+  String getEventType() {
+    return 'Register User';
+  }
+
+  AnalyticsUserRegistrationEvent({required this.userId});
+
+  @override
+  Map<String, dynamic> toJson() => _$AnalyticsUserRegistrationEventToJson(this);
+
+  @override
+  String getEventCategory() {
+    return AnalyticsEvent.userCategory;
+  }
+
+  @override
+  String getEventName() {
+    return userId;
+  }
+
+  @override
+  num? getMetricValue() {
+    return null;
+  }
+}
+
+@JsonSerializable()
 class AnalyticsLinkStripeAccountEvent implements AnalyticsEvent {
   @override
   String getEventType() {

--- a/data_models/lib/analytics/analytics_entities.dart
+++ b/data_models/lib/analytics/analytics_entities.dart
@@ -11,7 +11,7 @@ abstract class AnalyticsEvent {
   static const String userCategory = 'user';
   static const String communityCategory = 'community';
   static const String eventCategory = 'event';
-  static const String guideCategory = 'guide';
+  static const String templateCategory = 'template';
 }
 
 @JsonSerializable()
@@ -290,7 +290,7 @@ class AnalyticsPressAddNewTemplateEvent implements AnalyticsEvent {
 
   @override
   String getEventCategory() {
-    return AnalyticsEvent.guideCategory;
+    return AnalyticsEvent.templateCategory;
   }
 
   @override
@@ -312,11 +312,11 @@ class AnalyticsCompleteNewTemplateEvent implements AnalyticsEvent {
   }
 
   final String communityId;
-  final String guideId;
+  final String templateId;
 
   AnalyticsCompleteNewTemplateEvent({
     required this.communityId,
-    required this.guideId,
+    required this.templateId,
   });
 
   @override
@@ -325,12 +325,12 @@ class AnalyticsCompleteNewTemplateEvent implements AnalyticsEvent {
 
   @override
   String getEventCategory() {
-    return AnalyticsEvent.guideCategory;
+    return AnalyticsEvent.templateCategory;
   }
 
   @override
   String? getEventName() {
-    return guideId;
+    return templateId;
   }
 
   @override
@@ -347,11 +347,11 @@ class AnalyticsPressCreateEventFromTemplateEvent implements AnalyticsEvent {
   }
 
   final String communityId;
-  final String guideId;
+  final String templateId;
 
   AnalyticsPressCreateEventFromTemplateEvent({
     required this.communityId,
-    required this.guideId,
+    required this.templateId,
   });
 
   @override
@@ -365,7 +365,7 @@ class AnalyticsPressCreateEventFromTemplateEvent implements AnalyticsEvent {
 
   @override
   String? getEventName() {
-    return guideId;
+    return templateId;
   }
 
   @override
@@ -383,12 +383,12 @@ class AnalyticsCreateEventEvent implements AnalyticsEvent {
 
   final String communityId;
   final String eventId;
-  final String? guideId;
+  final String? templateId;
 
   AnalyticsCreateEventEvent({
     required this.communityId,
     required this.eventId,
-    this.guideId,
+    this.templateId,
   });
 
   @override
@@ -420,13 +420,13 @@ class AnalyticsScheduleEventEvent implements AnalyticsEvent {
   final String communityId;
   final String eventId;
   final int daysFromNow;
-  final String? guideId;
+  final String? templateId;
 
   AnalyticsScheduleEventEvent({
     required this.communityId,
     required this.eventId,
     required this.daysFromNow,
-    this.guideId,
+    this.templateId,
   });
 
   @override
@@ -457,12 +457,12 @@ class AnalyticsEditEventEvent implements AnalyticsEvent {
 
   final String communityId;
   final String eventId;
-  final String? guideId;
+  final String? templateId;
 
   AnalyticsEditEventEvent({
     required this.communityId,
     required this.eventId,
-    this.guideId,
+    this.templateId,
   });
 
   @override
@@ -493,13 +493,13 @@ class AnalyticsPressShareEventEvent implements AnalyticsEvent {
 
   final String communityId;
   final String eventId;
-  final String? guideId;
+  final String? templateId;
   final ShareType shareType;
 
   AnalyticsPressShareEventEvent({
     required this.communityId,
     required this.eventId,
-    this.guideId,
+    this.templateId,
     required this.shareType,
   });
 
@@ -532,13 +532,13 @@ class AnalyticsEnterEventEvent implements AnalyticsEvent {
   final String communityId;
   final String eventId;
   final bool asHost;
-  final String? guideId;
+  final String? templateId;
 
   AnalyticsEnterEventEvent({
     required this.communityId,
     required this.eventId,
     required this.asHost,
-    this.guideId,
+    this.templateId,
   });
 
   @override
@@ -570,13 +570,13 @@ class AnalyticsCompleteEventEvent implements AnalyticsEvent {
   final String communityId;
   final String eventId;
   final bool asHost;
-  final String? guideId;
+  final String? templateId;
 
   AnalyticsCompleteEventEvent({
     required this.communityId,
     required this.eventId,
     required this.asHost,
-    this.guideId,
+    this.templateId,
   });
 
   @override
@@ -608,13 +608,13 @@ class AnalyticsPressEventHelpEvent implements AnalyticsEvent {
   final String communityId;
   final String eventId;
   final bool asHost;
-  final String? guideId;
+  final String? templateId;
 
   AnalyticsPressEventHelpEvent({
     required this.communityId,
     required this.eventId,
     required this.asHost,
-    this.guideId,
+    this.templateId,
   });
 
   @override
@@ -645,12 +645,12 @@ class AnalyticsRsvpEventEvent implements AnalyticsEvent {
 
   final String communityId;
   final String eventId;
-  final String? guideId;
+  final String? templateId;
 
   AnalyticsRsvpEventEvent({
     required this.communityId,
     required this.eventId,
-    this.guideId,
+    this.templateId,
   });
 
   @override

--- a/data_models/lib/analytics/analytics_entities.dart
+++ b/data_models/lib/analytics/analytics_entities.dart
@@ -570,12 +570,14 @@ class AnalyticsCompleteEventEvent implements AnalyticsEvent {
   final String communityId;
   final String eventId;
   final bool asHost;
+  final int duration;
   final String? templateId;
 
   AnalyticsCompleteEventEvent({
     required this.communityId,
     required this.eventId,
     required this.asHost,
+    required this.duration,
     this.templateId,
   });
 
@@ -594,7 +596,7 @@ class AnalyticsCompleteEventEvent implements AnalyticsEvent {
 
   @override
   num? getMetricValue() {
-    return null;
+    return duration;
   }
 }
 

--- a/data_models/lib/analytics/analytics_entities.g.dart
+++ b/data_models/lib/analytics/analytics_entities.g.dart
@@ -244,6 +244,7 @@ AnalyticsCompleteEventEvent _$AnalyticsCompleteEventEventFromJson(
       communityId: json['communityId'] as String,
       eventId: json['eventId'] as String,
       asHost: json['asHost'] as bool,
+      duration: json['duration'] as int,
       templateId: json['templateId'] as String?,
     );
 
@@ -253,6 +254,7 @@ Map<String, dynamic> _$AnalyticsCompleteEventEventToJson(
       'communityId': instance.communityId,
       'eventId': instance.eventId,
       'asHost': instance.asHost,
+      'duration': instance.duration,
       'templateId': instance.templateId,
     };
 

--- a/data_models/lib/analytics/analytics_entities.g.dart
+++ b/data_models/lib/analytics/analytics_entities.g.dart
@@ -270,6 +270,24 @@ Map<String, dynamic> _$AnalyticsCompleteEventEventToJson(
       'templateId': instance.templateId,
     };
 
+AnalyticsRateEventEvent _$AnalyticsRateEventEventFromJson(
+        Map<String, dynamic> json) =>
+    AnalyticsRateEventEvent(
+      communityId: json['communityId'] as String,
+      eventId: json['eventId'] as String,
+      rating: (json['rating'] as num).toDouble(),
+      templateId: json['templateId'] as String?,
+    );
+
+Map<String, dynamic> _$AnalyticsRateEventEventToJson(
+        AnalyticsRateEventEvent instance) =>
+    <String, dynamic>{
+      'communityId': instance.communityId,
+      'eventId': instance.eventId,
+      'rating': instance.rating,
+      'templateId': instance.templateId,
+    };
+
 AnalyticsPressEventHelpEvent _$AnalyticsPressEventHelpEventFromJson(
         Map<String, dynamic> json) =>
     AnalyticsPressEventHelpEvent(

--- a/data_models/lib/analytics/analytics_entities.g.dart
+++ b/data_models/lib/analytics/analytics_entities.g.dart
@@ -19,6 +19,18 @@ Map<String, dynamic> _$AnalyticsAgreeToTermsAndConditionsEventToJson(
       'userId': instance.userId,
     };
 
+AnalyticsUserRegistrationEvent _$AnalyticsUserRegistrationEventFromJson(
+        Map<String, dynamic> json) =>
+    AnalyticsUserRegistrationEvent(
+      userId: json['userId'] as String,
+    );
+
+Map<String, dynamic> _$AnalyticsUserRegistrationEventToJson(
+        AnalyticsUserRegistrationEvent instance) =>
+    <String, dynamic>{
+      'userId': instance.userId,
+    };
+
 AnalyticsLinkStripeAccountEvent _$AnalyticsLinkStripeAccountEventFromJson(
         Map<String, dynamic> json) =>
     AnalyticsLinkStripeAccountEvent();

--- a/data_models/lib/analytics/analytics_entities.g.dart
+++ b/data_models/lib/analytics/analytics_entities.g.dart
@@ -83,42 +83,66 @@ const _$ShareTypeEnumMap = {
   ShareType.link: 'link',
 };
 
-AnalyticsPressAddNewGuideEvent _$AnalyticsPressAddNewGuideEventFromJson(
+AnalyticsJoinCommunityEvent _$AnalyticsJoinCommunityEventFromJson(
         Map<String, dynamic> json) =>
-    AnalyticsPressAddNewGuideEvent(
+    AnalyticsJoinCommunityEvent(
       communityId: json['communityId'] as String,
     );
 
-Map<String, dynamic> _$AnalyticsPressAddNewGuideEventToJson(
-        AnalyticsPressAddNewGuideEvent instance) =>
+Map<String, dynamic> _$AnalyticsJoinCommunityEventToJson(
+        AnalyticsJoinCommunityEvent instance) =>
     <String, dynamic>{
       'communityId': instance.communityId,
     };
 
-AnalyticsCompleteNewGuideEvent _$AnalyticsCompleteNewGuideEventFromJson(
+AnalyticsLeaveCommunityEvent _$AnalyticsLeaveCommunityEventFromJson(
         Map<String, dynamic> json) =>
-    AnalyticsCompleteNewGuideEvent(
+    AnalyticsLeaveCommunityEvent(
+      communityId: json['communityId'] as String,
+    );
+
+Map<String, dynamic> _$AnalyticsLeaveCommunityEventToJson(
+        AnalyticsLeaveCommunityEvent instance) =>
+    <String, dynamic>{
+      'communityId': instance.communityId,
+    };
+
+AnalyticsPressAddNewTemplateEvent _$AnalyticsPressAddNewTemplateEventFromJson(
+        Map<String, dynamic> json) =>
+    AnalyticsPressAddNewTemplateEvent(
+      communityId: json['communityId'] as String,
+    );
+
+Map<String, dynamic> _$AnalyticsPressAddNewTemplateEventToJson(
+        AnalyticsPressAddNewTemplateEvent instance) =>
+    <String, dynamic>{
+      'communityId': instance.communityId,
+    };
+
+AnalyticsCompleteNewTemplateEvent _$AnalyticsCompleteNewTemplateEventFromJson(
+        Map<String, dynamic> json) =>
+    AnalyticsCompleteNewTemplateEvent(
       communityId: json['communityId'] as String,
       guideId: json['guideId'] as String,
     );
 
-Map<String, dynamic> _$AnalyticsCompleteNewGuideEventToJson(
-        AnalyticsCompleteNewGuideEvent instance) =>
+Map<String, dynamic> _$AnalyticsCompleteNewTemplateEventToJson(
+        AnalyticsCompleteNewTemplateEvent instance) =>
     <String, dynamic>{
       'communityId': instance.communityId,
       'guideId': instance.guideId,
     };
 
-AnalyticsPressCreateEventFromGuideEvent
-    _$AnalyticsPressCreateEventFromGuideEventFromJson(
+AnalyticsPressCreateEventFromTemplateEvent
+    _$AnalyticsPressCreateEventFromTemplateEventFromJson(
             Map<String, dynamic> json) =>
-        AnalyticsPressCreateEventFromGuideEvent(
+        AnalyticsPressCreateEventFromTemplateEvent(
           communityId: json['communityId'] as String,
           guideId: json['guideId'] as String,
         );
 
-Map<String, dynamic> _$AnalyticsPressCreateEventFromGuideEventToJson(
-        AnalyticsPressCreateEventFromGuideEvent instance) =>
+Map<String, dynamic> _$AnalyticsPressCreateEventFromTemplateEventToJson(
+        AnalyticsPressCreateEventFromTemplateEvent instance) =>
     <String, dynamic>{
       'communityId': instance.communityId,
       'guideId': instance.guideId,
@@ -260,30 +284,6 @@ Map<String, dynamic> _$AnalyticsRsvpEventEventToJson(
       'communityId': instance.communityId,
       'eventId': instance.eventId,
       'guideId': instance.guideId,
-    };
-
-AnalyticsJoinCommunityEvent _$AnalyticsJoinCommunityEventFromJson(
-        Map<String, dynamic> json) =>
-    AnalyticsJoinCommunityEvent(
-      communityId: json['communityId'] as String,
-    );
-
-Map<String, dynamic> _$AnalyticsJoinCommunityEventToJson(
-        AnalyticsJoinCommunityEvent instance) =>
-    <String, dynamic>{
-      'communityId': instance.communityId,
-    };
-
-AnalyticsLeaveCommunityEvent _$AnalyticsLeaveCommunityEventFromJson(
-        Map<String, dynamic> json) =>
-    AnalyticsLeaveCommunityEvent(
-      communityId: json['communityId'] as String,
-    );
-
-Map<String, dynamic> _$AnalyticsLeaveCommunityEventToJson(
-        AnalyticsLeaveCommunityEvent instance) =>
-    <String, dynamic>{
-      'communityId': instance.communityId,
     };
 
 AnalyticsDonateEvent _$AnalyticsDonateEventFromJson(

--- a/data_models/lib/analytics/analytics_entities.g.dart
+++ b/data_models/lib/analytics/analytics_entities.g.dart
@@ -127,14 +127,14 @@ AnalyticsCompleteNewTemplateEvent _$AnalyticsCompleteNewTemplateEventFromJson(
         Map<String, dynamic> json) =>
     AnalyticsCompleteNewTemplateEvent(
       communityId: json['communityId'] as String,
-      guideId: json['guideId'] as String,
+      templateId: json['templateId'] as String,
     );
 
 Map<String, dynamic> _$AnalyticsCompleteNewTemplateEventToJson(
         AnalyticsCompleteNewTemplateEvent instance) =>
     <String, dynamic>{
       'communityId': instance.communityId,
-      'guideId': instance.guideId,
+      'templateId': instance.templateId,
     };
 
 AnalyticsPressCreateEventFromTemplateEvent
@@ -142,14 +142,14 @@ AnalyticsPressCreateEventFromTemplateEvent
             Map<String, dynamic> json) =>
         AnalyticsPressCreateEventFromTemplateEvent(
           communityId: json['communityId'] as String,
-          guideId: json['guideId'] as String,
+          templateId: json['templateId'] as String,
         );
 
 Map<String, dynamic> _$AnalyticsPressCreateEventFromTemplateEventToJson(
         AnalyticsPressCreateEventFromTemplateEvent instance) =>
     <String, dynamic>{
       'communityId': instance.communityId,
-      'guideId': instance.guideId,
+      'templateId': instance.templateId,
     };
 
 AnalyticsCreateEventEvent _$AnalyticsCreateEventEventFromJson(
@@ -157,7 +157,7 @@ AnalyticsCreateEventEvent _$AnalyticsCreateEventEventFromJson(
     AnalyticsCreateEventEvent(
       communityId: json['communityId'] as String,
       eventId: json['eventId'] as String,
-      guideId: json['guideId'] as String?,
+      templateId: json['templateId'] as String?,
     );
 
 Map<String, dynamic> _$AnalyticsCreateEventEventToJson(
@@ -165,7 +165,7 @@ Map<String, dynamic> _$AnalyticsCreateEventEventToJson(
     <String, dynamic>{
       'communityId': instance.communityId,
       'eventId': instance.eventId,
-      'guideId': instance.guideId,
+      'templateId': instance.templateId,
     };
 
 AnalyticsScheduleEventEvent _$AnalyticsScheduleEventEventFromJson(
@@ -174,7 +174,7 @@ AnalyticsScheduleEventEvent _$AnalyticsScheduleEventEventFromJson(
       communityId: json['communityId'] as String,
       eventId: json['eventId'] as String,
       daysFromNow: json['daysFromNow'] as int,
-      guideId: json['guideId'] as String?,
+      templateId: json['templateId'] as String?,
     );
 
 Map<String, dynamic> _$AnalyticsScheduleEventEventToJson(
@@ -183,7 +183,7 @@ Map<String, dynamic> _$AnalyticsScheduleEventEventToJson(
       'communityId': instance.communityId,
       'eventId': instance.eventId,
       'daysFromNow': instance.daysFromNow,
-      'guideId': instance.guideId,
+      'templateId': instance.templateId,
     };
 
 AnalyticsEditEventEvent _$AnalyticsEditEventEventFromJson(
@@ -191,7 +191,7 @@ AnalyticsEditEventEvent _$AnalyticsEditEventEventFromJson(
     AnalyticsEditEventEvent(
       communityId: json['communityId'] as String,
       eventId: json['eventId'] as String,
-      guideId: json['guideId'] as String?,
+      templateId: json['templateId'] as String?,
     );
 
 Map<String, dynamic> _$AnalyticsEditEventEventToJson(
@@ -199,7 +199,7 @@ Map<String, dynamic> _$AnalyticsEditEventEventToJson(
     <String, dynamic>{
       'communityId': instance.communityId,
       'eventId': instance.eventId,
-      'guideId': instance.guideId,
+      'templateId': instance.templateId,
     };
 
 AnalyticsPressShareEventEvent _$AnalyticsPressShareEventEventFromJson(
@@ -207,7 +207,7 @@ AnalyticsPressShareEventEvent _$AnalyticsPressShareEventEventFromJson(
     AnalyticsPressShareEventEvent(
       communityId: json['communityId'] as String,
       eventId: json['eventId'] as String,
-      guideId: json['guideId'] as String?,
+      templateId: json['templateId'] as String?,
       shareType: $enumDecode(_$ShareTypeEnumMap, json['shareType']),
     );
 
@@ -216,7 +216,7 @@ Map<String, dynamic> _$AnalyticsPressShareEventEventToJson(
     <String, dynamic>{
       'communityId': instance.communityId,
       'eventId': instance.eventId,
-      'guideId': instance.guideId,
+      'templateId': instance.templateId,
       'shareType': _$ShareTypeEnumMap[instance.shareType]!,
     };
 
@@ -226,7 +226,7 @@ AnalyticsEnterEventEvent _$AnalyticsEnterEventEventFromJson(
       communityId: json['communityId'] as String,
       eventId: json['eventId'] as String,
       asHost: json['asHost'] as bool,
-      guideId: json['guideId'] as String?,
+      templateId: json['templateId'] as String?,
     );
 
 Map<String, dynamic> _$AnalyticsEnterEventEventToJson(
@@ -235,7 +235,7 @@ Map<String, dynamic> _$AnalyticsEnterEventEventToJson(
       'communityId': instance.communityId,
       'eventId': instance.eventId,
       'asHost': instance.asHost,
-      'guideId': instance.guideId,
+      'templateId': instance.templateId,
     };
 
 AnalyticsCompleteEventEvent _$AnalyticsCompleteEventEventFromJson(
@@ -244,7 +244,7 @@ AnalyticsCompleteEventEvent _$AnalyticsCompleteEventEventFromJson(
       communityId: json['communityId'] as String,
       eventId: json['eventId'] as String,
       asHost: json['asHost'] as bool,
-      guideId: json['guideId'] as String?,
+      templateId: json['templateId'] as String?,
     );
 
 Map<String, dynamic> _$AnalyticsCompleteEventEventToJson(
@@ -253,7 +253,7 @@ Map<String, dynamic> _$AnalyticsCompleteEventEventToJson(
       'communityId': instance.communityId,
       'eventId': instance.eventId,
       'asHost': instance.asHost,
-      'guideId': instance.guideId,
+      'templateId': instance.templateId,
     };
 
 AnalyticsPressEventHelpEvent _$AnalyticsPressEventHelpEventFromJson(
@@ -262,7 +262,7 @@ AnalyticsPressEventHelpEvent _$AnalyticsPressEventHelpEventFromJson(
       communityId: json['communityId'] as String,
       eventId: json['eventId'] as String,
       asHost: json['asHost'] as bool,
-      guideId: json['guideId'] as String?,
+      templateId: json['templateId'] as String?,
     );
 
 Map<String, dynamic> _$AnalyticsPressEventHelpEventToJson(
@@ -271,7 +271,7 @@ Map<String, dynamic> _$AnalyticsPressEventHelpEventToJson(
       'communityId': instance.communityId,
       'eventId': instance.eventId,
       'asHost': instance.asHost,
-      'guideId': instance.guideId,
+      'templateId': instance.templateId,
     };
 
 AnalyticsRsvpEventEvent _$AnalyticsRsvpEventEventFromJson(
@@ -279,7 +279,7 @@ AnalyticsRsvpEventEvent _$AnalyticsRsvpEventEventFromJson(
     AnalyticsRsvpEventEvent(
       communityId: json['communityId'] as String,
       eventId: json['eventId'] as String,
-      guideId: json['guideId'] as String?,
+      templateId: json['templateId'] as String?,
     );
 
 Map<String, dynamic> _$AnalyticsRsvpEventEventToJson(
@@ -287,7 +287,7 @@ Map<String, dynamic> _$AnalyticsRsvpEventEventToJson(
     <String, dynamic>{
       'communityId': instance.communityId,
       'eventId': instance.eventId,
-      'guideId': instance.guideId,
+      'templateId': instance.templateId,
     };
 
 AnalyticsDonateEvent _$AnalyticsDonateEventFromJson(

--- a/data_models/lib/analytics/analytics_entities.g.dart
+++ b/data_models/lib/analytics/analytics_entities.g.dart
@@ -9,11 +9,15 @@ part of 'analytics_entities.dart';
 AnalyticsAgreeToTermsAndConditionsEvent
     _$AnalyticsAgreeToTermsAndConditionsEventFromJson(
             Map<String, dynamic> json) =>
-        AnalyticsAgreeToTermsAndConditionsEvent();
+        AnalyticsAgreeToTermsAndConditionsEvent(
+          userId: json['userId'] as String,
+        );
 
 Map<String, dynamic> _$AnalyticsAgreeToTermsAndConditionsEventToJson(
         AnalyticsAgreeToTermsAndConditionsEvent instance) =>
-    <String, dynamic>{};
+    <String, dynamic>{
+      'userId': instance.userId,
+    };
 
 AnalyticsLinkStripeAccountEvent _$AnalyticsLinkStripeAccountEventFromJson(
         Map<String, dynamic> json) =>


### PR DESCRIPTION
## What is in this PR?
This PR hooks into the existing client analytics API (currently a no-op) to send analytic events to Matomo as [Custom Events](https://matomo.org/faq/reports/implement-event-tracking-with-matomo/) when URL and siteId environment variables are set.

## Changes in the codebase
See commits. Combination of enabling Matomo, modifying existing analytics API to provide necessary event name, category, and metric value (where applicable) and creating a few new event types.
*Add category, name, and metric value to AnalyticsEvents
* Enable Matomo analytics
* Set event name to user ID in Agree to TAC analytic event
* Rename guide to template in analytics events
* Add event duration to event completed analytics
* Add user registration analytic event
* Add event ratings to analytics 
* Fix duplicate user registration analytics event when registering with email
* Remove Firebase analytics

## Changes outside the codebase
Added MATOMO_URL and MATOMO_SITE_ID environment variables to GH staging

## Testing this PR
Perform some actions like creating communities, events, etc on staging and verify the events show up on our Matomo instance.

## Additional information
It's debatable whether we really need separate AnalyticsEvents classes for each type of event, rather than a generic AnalyticsEvent object where you pass name, category, type, and metric value on instantiation. It's further debatable whether AnalyticsEvents need to be in data_models (i.e. shared b/w functions and client). No active functions currently use this (the only ones who do in the code were Stripe-related). Open to changing now, in a follow-up task, or not at all. I could see maybe tracking custom events from functions, but Matomo seems to assume site visitors generate events (just generally very user-focused as it should be), so might be an odd fit.

