### PR TITLE
Resolve camera permissions prompt issues

### DIFF
--- a/client/analysis_options.yaml
+++ b/client/analysis_options.yaml
@@ -32,6 +32,5 @@ linter:
     prefer_const_constructors: false
     unawaited_futures: true
     require_trailing_commas: true
-
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/client/lib/features/events/features/live_meeting/features/video/data/providers/agora_room.dart
+++ b/client/lib/features/events/features/live_meeting/features/video/data/providers/agora_room.dart
@@ -102,8 +102,8 @@ class AgoraRoom with ChangeNotifier {
   }
 
   Future<void> connect({
-    bool enableAudio = false,
-    bool enableVideo = false,
+    bool enableAudio = true,
+    bool enableVideo = true,
   }) async {
     engine = createAgoraRtcEngine();
 

--- a/client/lib/features/events/features/live_meeting/features/video/data/providers/conference_room.dart
+++ b/client/lib/features/events/features/live_meeting/features/video/data/providers/conference_room.dart
@@ -307,10 +307,7 @@ class ConferenceRoom with ChangeNotifier {
         eventProvider: liveMeetingProvider.eventProvider,
         conferenceRoom: this,
       );
-      await _room!.connect(
-        enableVideo: false,
-        enableAudio: false,
-      );
+      await _room!.connect();
       _room!.addListener(notifyListeners);
     } catch (err, stacktrace) {
       loggingService.log('error');

--- a/client/lib/features/events/presentation/widgets/hosting_option.dart
+++ b/client/lib/features/events/presentation/widgets/hosting_option.dart
@@ -51,18 +51,15 @@ class _HostingOptionState extends State<HostingOption> {
         List<_HostingOptionType> hostingTypes = [
           _HostingOptionType(
             title: 'Hosted',
-            isGated: false,
             eventType: EventType.hosted,
           ),
           if (widget.isHostlessEnabled)
             _HostingOptionType(
               title: 'Hostless',
-              isGated: !(caps?.hasLivestreams ?? false),
               eventType: EventType.hostless,
             ),
           _HostingOptionType(
             title: 'Livestream',
-            isGated: !(caps?.hasLivestreams ?? false),
             eventType: EventType.livestream,
           ),
         ];
@@ -74,7 +71,6 @@ class _HostingOptionState extends State<HostingOption> {
               mainAxisSize: MainAxisSize.min,
               children: <Widget>[
                 for (final type in hostingTypes)
-                  if (!type.isGated)
                     _HostingRadioOption(
                       isWhiteBackground: widget.isWhiteBackground,
                       onSelected: () {
@@ -82,7 +78,6 @@ class _HostingOptionState extends State<HostingOption> {
                         setState(() => _hostingOption = type.eventType);
                       },
                       isSelected: type.eventType == _hostingOption,
-                      isGated: type.isGated,
                       title: type.title,
                     ),
               ].intersperse(SizedBox(height: 14)).toList(),
@@ -96,18 +91,15 @@ class _HostingOptionState extends State<HostingOption> {
 
 class _HostingOptionType {
   final String title;
-  final bool isGated;
   final EventType eventType;
 
   _HostingOptionType({
     required this.title,
-    required this.isGated,
     required this.eventType,
   });
 }
 
 class _HostingRadioOption extends StatefulWidget {
-  final bool isGated;
   final bool isSelected;
   final void Function() onSelected;
   final String title;
@@ -115,7 +107,6 @@ class _HostingRadioOption extends StatefulWidget {
 
   const _HostingRadioOption({
     Key? key,
-    this.isGated = true,
     required this.title,
     required this.isSelected,
     required this.onSelected,
@@ -129,17 +120,9 @@ class _HostingRadioOption extends StatefulWidget {
 class _HostingRadioOptionState extends State<_HostingRadioOption> {
   Color get color {
     if (widget.isWhiteBackground) {
-      if (!widget.isGated) {
-        return AppColor.darkBlue;
-      } else {
-        return AppColor.darkBlue.withOpacity(.5);
-      }
+      return AppColor.darkBlue;
     } else {
-      if (!widget.isGated) {
-        return AppColor.white;
-      } else {
-        return AppColor.white.withOpacity(.5);
-      }
+      return AppColor.white;
     }
   }
 

--- a/client/test/test_utils.dart
+++ b/client/test/test_utils.dart
@@ -13,11 +13,8 @@ class TestUtils {
     // Resets screen size after each test.
     addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
 
-    final renderView = WidgetsBinding.instance?.renderView;
+    final renderView = WidgetsBinding.instance.renderView;
 
-    if (renderView != null) {
-      renderView.configuration =
-          TestViewConfiguration(size: Size(width, height));
-    }
+    renderView.configuration = TestViewConfiguration(size: Size(width, height));
   }
 }


### PR DESCRIPTION
## What is in this PR?
Resolve downstream bugs around camera permissions prompt not firing (#60) by enabling audio and video device by default when joining any type of event, whether hosted, hostless, or live. Also: removed deprecated use of plan capabilities in hosting option widget as part of effort to phase that code out.

## Changes in the codebase
<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

* Changed the default for enabling video and audio to true in `connect` function in `client/lib/features/events/features/live_meeting/features/video/data/providers/agora_room.dart`

## Testing this PR
<!-- Give your reviewer some context or recommendations on how to test your work. -->
You should be prompted for camera permissions immediately upon entering an event in hosted, or when entering breakout in hostless or livestream.