### PR TITLE
[Bugfix] Text Field borders turn white if focusing and hovering over them in error state.

### DIFF
--- a/client/lib/core/widgets/custom_text_field.dart
+++ b/client/lib/core/widgets/custom_text_field.dart
@@ -179,18 +179,18 @@ class _CustomTextFieldState extends State<CustomTextField> {
     return InputBorder.none;
   }
 
-  InputBorder _getFocusedBorder() {
+  InputBorder _getFocusedBorder({bool isError = false}) {
     if (widget.borderType == BorderType.underline) {
       return UnderlineInputBorder(
         borderSide: BorderSide(
-          color: _getBorderColor(),
+          color: _getBorderColor(isError: isError),
           width: 2.0,
         ),
       );
     }
     return OutlineInputBorder(
       borderSide: BorderSide(
-        color: _getBorderColor(),
+        color: _getBorderColor(isError: isError),
         width: 2.0,
       ),
       borderRadius: BorderRadius.circular(widget.borderRadius),
@@ -301,6 +301,7 @@ class _CustomTextFieldState extends State<CustomTextField> {
                   focusedBorder: _getFocusedBorder(),
                   enabledBorder: _getBorder(),
                   errorBorder: _getBorder(isError: true),
+                  focusedErrorBorder: _getFocusedBorder(isError: true),
                   labelText: widget.labelText,
                   labelStyle: _buildLabelStyle(),
                   errorStyle: context.theme.textTheme.labelMedium!


### PR DESCRIPTION
## What is in this PR?
<!-- What is the goal of this PR? What steps are involved in achieving that goal? -->
fix: Add focusedErrorBorder parameter to CustomTextField's TextFormField so that the border doesn't become unstyled when hovering. Adds an isError parameter to the existing _getFocusedBorder function to allow focused borders to have error styling as well.

## Testing this PR
<!-- Give your reviewer some context or recommendations on how to test your work. -->
* Enter error state by providing incomplete info in auth flow. 
* Focus a text field, then hover it.
* Observe that the border should become slightly thicker and remain red (`focusedErrorBorder`). 