### PR TITLE
fix: Stop raised hand button from covering layout on mobile. 

### DIFF
--- a/client/lib/features/events/features/live_meeting/presentation/views/live_meeting_mobile_page.dart
+++ b/client/lib/features/events/features/live_meeting/presentation/views/live_meeting_mobile_page.dart
@@ -186,20 +186,6 @@ class _LiveMeetingMobilePageState extends State<LiveMeetingMobilePage>
     return Scaffold(
       backgroundColor: context.theme.colorScheme.surface,
       appBar: showAppBar ? _buildAppBar() : null,
-      floatingActionButtonLocation:
-          FloatingActionButtonLocation.miniCenterDocked,
-      floatingActionButton: isBottomSheetPresent && isRaisedHandVisible
-          ? FloatingActionButton(
-              backgroundColor: context.theme.colorScheme.primary,
-              child: ProxiedImage(
-                null,
-                asset: AppAsset.raisedHand(),
-                width: 20.0,
-                height: 20.0,
-              ),
-              onPressed: () => _presenter.toggleHandRaise(),
-            )
-          : null,
       body: _buildBody(),
       bottomNavigationBar:
           showBottomBar ? _buildBottomNavBar(isBottomSheetPresent) : null,
@@ -781,7 +767,7 @@ class _LiveMeetingMobilePageState extends State<LiveMeetingMobilePage>
                         color: context.theme.colorScheme.onPrimary,
                       ),
                     ),
-                    if (!isBottomSheetPresent && isRaisedHandVisible)
+                    if (isRaisedHandVisible)
                       Expanded(
                         child: Center(
                           child: SizedBox(


### PR DESCRIPTION
## What is in this PR?
<!-- What is the goal of this PR? What steps are involved in achieving that goal? -->
fix: Don't make raise hand button a FAB on mobile as this can often block important agenda item layouts, such as submission buttons or text fields. Just show the raised hand button as a normal bottom bar button.

<img width="454" alt="Screenshot 2025-06-18 at 15 31 09" src="https://github.com/user-attachments/assets/7bc97f56-93ef-4d4f-9171-1abd47d8be19" />


## Changes in the codebase
<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

* Removed FAB code on mobile and just always show raised hand button on control bar (if it should be shown). 

## Changes outside the codebase
<!-- If you have made changes to external services, need to add additional values to the job settings, or need to add something new to the database, explain it here. This may include updates to third-party services, changes to infrastructure configuration, integration with external APIs, etc. -->

* None.

## Testing this PR
<!-- Give your reviewer some context or recommendations on how to test your work. -->
Enter a meeting and size your screen to mobile width. Observe that the FAB should no longer cover layouts as before and stay within the bounds of the bottom bar. 


## Additional information
<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->

