### PR TITLE
Fix formatting issues on intro/waiting room video text. 

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -91,6 +91,13 @@ jobs:
         id: build_app
         run: flutter build web --release web-renderer html -t lib/main.dart --dart-define-from-file=${{ github.workspace }}/.env
 
+      # Workaround for an upstream issue in action-hosting-deploy 0.9.0 which
+      # doesn't automatically generate default preview channel IDs as
+      # documented when triggered manually via workflow_dispatch
+      - name: Generate a channel ID for the Firebase preview channel
+        if: steps.changes.outputs.client == 'true'
+        run: echo "PREVIEW_CHANNEL_ID=$(echo ${GITHUB_REF_NAME:0:26} | sed 's/\//-/g')" >> $GITHUB_ENV
+
       - name: Deploy to Preview Channel
         if: steps.changes.outputs.client == 'true'
         uses: FirebaseExtended/action-hosting-deploy@v0.9.0
@@ -98,4 +105,5 @@ jobs:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
           expires: 14d
-          projectId: ${{secrets.APP_STAGING_PROJECT_ID}}
+          channelId: ${{ env.PREVIEW_CHANNEL_ID }}
+          projectId: ${{ secrets.APP_STAGING_PROJECT_ID }}

--- a/client/lib/features/events/features/event_page/presentation/views/waiting_room_widget.dart
+++ b/client/lib/features/events/features/event_page/presentation/views/waiting_room_widget.dart
@@ -168,7 +168,7 @@ class _WaitingRoomWidgetState extends State<WaitingRoomWidget>
                   context.l10n.bufferTimeDescription(
                     waitingBufferDurationDescription,
                   ),
-                  style: AppTextStyle.body,
+                  style: context.theme.textTheme.bodyMedium,
                 ),
               ),
             ],
@@ -182,7 +182,7 @@ class _WaitingRoomWidgetState extends State<WaitingRoomWidget>
             ),
             Text(
               context.l10n.playsAt(introStartTime),
-              style: AppTextStyle.bodyMedium,
+              style: context.theme.textTheme.bodyMedium,
             ),
             SizedBox(height: 20),
             MediaItemSection(
@@ -234,7 +234,7 @@ class _WaitingRoomWidgetState extends State<WaitingRoomWidget>
                   child: HeightConstrainedText(
                     context.l10n
                         .introBeforeBreakouts(introLengthDurationDescription),
-                    style: AppTextStyle.body,
+                    style: context.theme.textTheme.bodyMedium,
                   ),
                 ),
               ],

--- a/client/lib/features/events/features/event_page/presentation/views/waiting_room_widget.dart
+++ b/client/lib/features/events/features/event_page/presentation/views/waiting_room_widget.dart
@@ -242,13 +242,13 @@ class _WaitingRoomWidgetState extends State<WaitingRoomWidget>
           ],
           SizedBox(height: 18),
           HeightConstrainedText(
-            'Participants will be sent into rooms at $breakoutsInitiationTime ${context.l10n.bufferAndIntroTime(
+            'Participants will be sent into rooms at $breakoutsInitiationTime.\n${context.l10n.bufferAndIntroTime(
               waitingBufferDurationDescription,
               introLengthDurationDescription,
-            )}',
-            style: AppTextStyle.subhead,
+            )}.',
+            style: context.theme.textTheme.titleMedium,
           ),
-          SizedBox(height: 10),
+          SizedBox(height: 24),
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [

--- a/client/lib/features/events/features/event_page/presentation/views/waiting_room_widget.dart
+++ b/client/lib/features/events/features/event_page/presentation/views/waiting_room_widget.dart
@@ -175,18 +175,14 @@ class _WaitingRoomWidgetState extends State<WaitingRoomWidget>
           ),
           SizedBox(height: 20),
           if (_presenter.enableIntroVideo) ...[
-            RichText(
-              text: TextSpan(
-                text: 'Intro Image/Video',
-                style: AppTextStyle.subhead
-                    .copyWith(color: context.theme.colorScheme.primary),
-                children: [
-                  TextSpan(
-                    text: context.l10n.playsAt(introStartTime),
-                    style: AppTextStyle.bodyMedium,
-                  ),
-                ],
-              ),
+            Text(
+              'Intro Image/Video',
+              style: AppTextStyle.subhead
+                  .copyWith(color: context.theme.colorScheme.primary),
+            ),
+            Text(
+              context.l10n.playsAt(introStartTime),
+              style: AppTextStyle.bodyMedium,
             ),
             SizedBox(height: 20),
             MediaItemSection(


### PR DESCRIPTION
## What is in this PR?
<!-- What is the goal of this PR? What steps are involved in achieving that goal? -->
Small formatting fixes for intro/waiting room video setup screen, which currently looks like this:
<img width="400" alt="Screenshot 2025-07-29 at 12 48 36 PM" src="https://github.com/user-attachments/assets/003f725e-7a96-4715-8311-0a3f951ce723" />
We needed to improve the "Plays at" text. Suggestion was to move it to another line and adjust the text style.

## Changes in the codebase
<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

* Separated "plays at" from "intro image" title text. 
* Adjusted text styles and layout for a few other text items on this screen. 

## Changes outside the codebase
<!-- If you have made changes to external services, need to add additional values to the job settings, or need to add something new to the database, explain it here. This may include updates to third-party services, changes to infrastructure configuration, integration with external APIs, etc. -->

* N/A

## Testing this PR
<!-- Give your reviewer some context or recommendations on how to test your work. -->

- [ ] Create a hostless event and navigate to the intro video settings. Observe that the formatting should now appear as follows:
<img width="400"  alt="Screenshot 2025-07-31 at 14 51 24" src="https://github.com/user-attachments/assets/9351b3e7-113f-45c7-bde9-74d78b6b7a3f" />

## Additional information
<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->

