### PR TITLE
Cloudinary video request optimization 

### DIFF
--- a/client/lib/features/events/features/live_meeting/features/live_stream/presentation/widgets/url_video_widget.dart
+++ b/client/lib/features/events/features/live_meeting/features/live_stream/presentation/widgets/url_video_widget.dart
@@ -62,9 +62,16 @@ class _UrlVideoWidgetState extends State<UrlVideoWidget> {
 
   String get encodedUrl {
     String playbackUrl = widget.playbackUrl;
-    if (playbackUrl.startsWith('http://') &&
-        playbackUrl.contains('cloudinary')) {
-      playbackUrl = playbackUrl.replaceFirst('http://', 'https://');
+    if (playbackUrl.contains('cloudinary')) {
+      if (playbackUrl.startsWith('http://')) {
+        playbackUrl = playbackUrl.replaceFirst('http://', 'https://');
+      }
+
+      // Replace '/upload' in the URL with '/upload/q_auto:good' for Cloudinary optimization, if not present
+      if (!playbackUrl.contains('/upload/q_auto:good')) {
+        playbackUrl = playbackUrl.replaceFirst('/upload', '/upload/q_auto:good');
+      }
+
     }
     final encodedLink = Uri.encodeQueryComponent(playbackUrl);
     String url = './stream/playback.html?url=$encodedLink'

--- a/client/lib/features/events/features/live_meeting/features/meeting_agenda/presentation/views/agenda_item_video.dart
+++ b/client/lib/features/events/features/live_meeting/features/meeting_agenda/presentation/views/agenda_item_video.dart
@@ -201,7 +201,10 @@ class _AgendaItemVideoState extends State<AgendaItemVideo>
         ],
       );
     } else {
-      return _buildInitializedVideo(videoUrl);
+      // Replace '/upload' in the URL with '/upload/q_auto:good' for Cloudinary optimization, if not present
+      final optimizedUrl = videoUrl.replaceFirst('/upload', '/upload/q_auto:good');
+      return _buildInitializedVideo(!videoUrl.contains('/upload/q_auto:good') ? optimizedUrl : videoUrl);
+
     }
   }
 


### PR DESCRIPTION
## What is in this PR?
<!-- What is the goal of this PR? What steps are involved in achieving that goal? -->
Utilize Cloudinary's built-in auto-quality feature when requesting videos to greatly reduce bandwidth consumption.

## Changes in the codebase
<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

In both `AgendaItemVideo` and `UrlVideoWidget`, inject `q_auto:good` param when setting URL for Cloudinary videos, if not already present.

## Testing this PR
<!-- Give your reviewer some context or recommendations on how to test your work. -->
- [ ] On the event page, upload a video as an agenda item, or go to an event that already has one.
- [ ] In the devtools network tab and see that the video request includes the 'q_auto:good' param.
- [ ] Enter and start the event.
- [ ] Again, verify that the video URL has this parameter when requested.
