### PR TITLE
Fix CTA button styling + provide an initial URL parameter value when adding a new one.

### DIFF
--- a/client/lib/features/events/features/event_page/presentation/views/pre_post_card_widget_page.dart
+++ b/client/lib/features/events/features/event_page/presentation/views/pre_post_card_widget_page.dart
@@ -640,15 +640,20 @@ class AttributeOption extends StatefulWidget {
 }
 
 class _AttributeOptionState extends State<AttributeOption> {
-  late bool isEditMode;
+  bool isEditMode = false;
   final _formKey = GlobalKey<FormState>();
   late final TextEditingController _textController;
 
   @override
   void initState() {
     super.initState();
-    isEditMode = isNullOrEmpty(widget.attribute.queryParam);
-    _textController = TextEditingController(text: widget.attribute.queryParam);
+    if (isNullOrEmpty(widget.attribute.queryParam)) {
+      isEditMode = true;
+      _textController = TextEditingController(text: widget.attribute.type.name);
+    } else {
+      _textController =
+          TextEditingController(text: widget.attribute.queryParam);
+    }
   }
 
   @override


### PR DESCRIPTION
## What is in this PR?
<!-- What is the goal of this PR? What steps are involved in achieving that goal? -->
Closes #220. The goal is to make adding/editing URL parameters in pre/post-event CTAs a better experience. 

## Changes in the codebase
<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

* Improved/fixed styling of action buttons in this area as described in the issue.
* Populated an initial URL parameter in the text field when you add a new one, e.g. `userId` for Participant ID.
    * @saihla I believe this is what you were describing in the Loom? Based on the Git history, I didn't see an indication of a different past behavior for this, so this is what I understood to be the desired behavior - just let me know if you wanted something else!

## Changes outside the codebase
<!-- If you have made changes to external services, need to add additional values to the job settings, or need to add something new to the database, explain it here. This may include updates to third-party services, changes to infrastructure configuration, integration with external APIs, etc. -->

* N/A

## Testing this PR
<!-- Give your reviewer some context or recommendations on how to test your work. -->
Test CTA URL parameters as described in Loom for #220.

## Additional information
<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->

Screenshot of CTA section post-change:
<img width="658" height="759" alt="Screenshot 2025-08-13 at 16 34 45" src="https://github.com/user-attachments/assets/e47de269-5255-48e6-958d-a5509d40eb54" />


