### PR TITLE
Resolve camera turning on unexpectedly

### DIFF
--- a/client/lib/features/events/features/live_meeting/features/video/data/providers/conference_room.dart
+++ b/client/lib/features/events/features/live_meeting/features/video/data/providers/conference_room.dart
@@ -307,7 +307,7 @@ class ConferenceRoom with ChangeNotifier {
         eventProvider: liveMeetingProvider.eventProvider,
         conferenceRoom: this,
       );
-      await _room!.connect();
+      await _room!.connect(enableVideo: liveMeetingProvider.videoDefaultOn);
       _room!.addListener(notifyListeners);
     } catch (err, stacktrace) {
       loggingService.log('error');


### PR DESCRIPTION
This resolves the issue of a user's camera turning on when entering a breakout room, despite having disabled it previously.

## Changes in the codebase
In `ConferenceRoom`'s `connect()`, reference `liveMeetingProvider` to determine if user has previously opted to default to video to on, and pass to `AgoraRoom` `connect()`. For context, this provider is given an updated value for this whenever video is toggled.

## Testing this PR
<!-- Give your reviewer some context or recommendations on how to test your work. -->

- [ ] Create an event and enter it. If your video defaults to on, turn it off.
- [ ] As an admin, force yourself into a breakout room.
- [ ] Note that your video remains off. Now, turn it back on.
- [ ] As an admin, end the breakout session.
- [ ] Your video should still be on.
- [ ] Reset your browser A/V permissions and refresh.
- [ ] Enter the event again and try to enable your video.
- [ ] You should be given a prompt to enable video by the browser, and then your video should turn on.
