### PR TITLE
Fix for wrong time on add to Outlook calendar

### DIFF
--- a/firebase/functions/lib/utils/calendar_link_util.dart
+++ b/firebase/functions/lib/utils/calendar_link_util.dart
@@ -66,13 +66,32 @@ class CalendarLinkUtil {
     required Template template,
     required Event event,
   }) {
-    return getLib().outlook(
-      _getEvent(
-        community: community,
-        template: template,
-        event: event,
-      ),
+    // Manually construct the Outlook link since the calendar-link library's
+    // outlook() method does has a bug where it does not translate the
+    // time to the string that Outlook expects when it is converting to a user's local time zone
+    // See: https://github.com/AnandChowdhary/calendar-link/issues/523
+    
+    var eventDetails = _getEvent(
+      community: community,
+      template: template,
+      event: event,
     );
+    final details = <String, String>{
+      'path': '/calendar/action/compose',
+      'rru': 'addevent',
+      'startdt': eventDetails.start,
+      'enddt': eventDetails.end,
+      'subject': eventDetails.title,
+      'body': eventDetails.description,
+      'location': eventDetails.description,
+      'allday': 'false',
+    };
+
+    final queryString = details.entries
+        .map((e) =>
+            '${Uri.encodeComponent(e.key)}=${Uri.encodeComponent(e.value)}',)
+        .join('&');
+    return 'https://outlook.live.com/calendar/0/action/compose?$queryString';
   }
 
   String getICS({


### PR DESCRIPTION
This fix resolves an issue where clicking on "add to calendar" for Outlook from either the event page or a registration email would link to an event on the calendar in Outlook with the incorrect time. This appears to be a known, but not resolved or acknowledged [issue](https://github.com/AnandChowdhary/calendar-link/issues/523) with the `calendar-link` dependency used in `firebase/functions`. Specifically, Outlook requires the "Z" (Zulu Time) specified in Datetime for UTC with no offset, and this does not happen.

## Changes in the codebase
<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

* Disuse of calender-link package functionality to create Outlook calendar links
* Manually construct the Outlook link

## Testing this PR
<!-- Give your reviewer some context or recommendations on how to test your work. -->
Note: if testing locally, be sure to rebuild your functions after pulling the changeset.
- [ ] On the staging branch, note that accessing a link to the Outlook calendar from either the event page or a registration email brings you to an event with the wrong time.
- [ ] Using this change, repeat the same and note that the correct time is shown.