### PR TITLE
[Bugfix] Allow default community theme to pass color check.

### DIFF
--- a/client/lib/features/community/features/create_community/presentation/views/create_community_dialog.dart
+++ b/client/lib/features/community/features/create_community/presentation/views/create_community_dialog.dart
@@ -158,11 +158,15 @@ class _CreateCommunityDialogState extends State<_CreateCommunityDialog> {
       );
     }
 
-    final isThemeValid = ThemeUtils.isColorComboValid(
-      context,
-      _community.themeLightColor,
-      _community.themeDarkColor,
-    );
+    final isDefaultTheme =
+        _community.themeDarkColor == null && _community.themeLightColor == null;
+
+    final isThemeValid = isDefaultTheme ||
+        ThemeUtils.isColorComboValid(
+          context,
+          _community.themeLightColor,
+          _community.themeDarkColor,
+        );
 
     if (!isThemeValid) {
       showRegularToast(


### PR DESCRIPTION
[Bugfix] Allow default community theme to pass color check (when both colors are null).

## What is in this PR?
<!-- What is the goal of this PR? What steps are involved in achieving that goal? -->
This fixes a regression introduced in #216 where communities could no longer be saved due to an "invalid theme" (even if the theme was not edited). 

## Changes in the codebase
<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

* When no theme is selected, the theme colors are actually null - this PR allows that case to pass as a valid theme. 

## Changes outside the codebase
<!-- If you have made changes to external services, need to add additional values to the job settings, or need to add something new to the database, explain it here. This may include updates to third-party services, changes to infrastructure configuration, integration with external APIs, etc. -->

* N/A

## Testing this PR
<!-- Give your reviewer some context or recommendations on how to test your work. -->

- [ ] Edit a new community and observe that no error message should be shown. 
- [ ] Edit the theme colors to be any of the theme presets (try all of them) and observe that no error message should be shown.
- [ ] Choose a low-contrast custom theme and observe that the theme should still be detected and shown as invalid, with the error text saying to choose a valid combination. 

## Additional information
<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->

