### PR TITLE
Persist auth emulator login to entire session

### DIFF
--- a/client/lib/features/user/data/services/user_service.dart
+++ b/client/lib/features/user/data/services/user_service.dart
@@ -118,6 +118,8 @@ class UserService with ChangeNotifier {
   Future<void> initialize() async {
     if (usingEmulator) {
       await FirebaseAuth.instance.useAuthEmulator('localhost', 9099);
+      // Set persistence to session for emulator to avoid logout across hard reloads
+      await _firebaseAuth.setPersistence(Persistence.SESSION);
     }
     await sharedPreferencesService.initialize();
     if (sharedPreferencesService.isReturningUser()) {


### PR DESCRIPTION
I banish ye, auth gremlins. 🏴‍☠️

Arr, this here be a change persistin' the current user login te an entire browser session when ye be usin' that scallywag autentin' emulator, preventin' the need to login after every 'ard refresh. Ahoy! ⚓️

## Changes in the codebase
<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

* set persistence to `Persistence.SESSION` when using a firebase authentication emulator in `client/lib/features/user/data/services/user_service.dart`

## Testing this PR
<!-- Give your reviewer some context or recommendations on how to test your work. -->
- [ ] Apply this change and see that after logging in, you no longer have to login again after refreshing the app. 
- [ ] Close the current browser session.
- [ ] Reopen the app. Note that you have to login again.
