### PR TITLE
prevent time reset once client side countdown reaches 0

### DIFF
--- a/client/lib/features/events/features/live_meeting/presentation/widgets/live_meeting_desktop.dart
+++ b/client/lib/features/events/features/live_meeting/presentation/widgets/live_meeting_desktop.dart
@@ -603,7 +603,7 @@ class BreakoutStatusInformation extends StatelessWidget {
 
           final areBreakoutsPending = breakoutSession?.breakoutRoomStatus ==
                   BreakoutRoomStatus.pending &&
-              breakoutRoomRemainingTime > Duration.zero;
+              breakoutRoomRemainingTime >= Duration.zero;
           final breakoutsMessage = areBreakoutsPending
               ? 'Breakout room matching starting in $breakoutRoomRemainingTimeDisplay'
               : 'Generating breakout room assignments';


### PR DESCRIPTION
## What is in this PR?
Prior to this change, the timer counts down to 0, then starts counting down from 59:59 for a few seconds before starting breakouts. This change stores `now` on the client side and calculates the breakout room time on the client side to prevent any delay and/or reset calculating the remaining time. 


## Changes in the codebase

* The `breakoutRoomRemainingTime` variable has been updated to calculate from `now` stored on the client side.


## Testing this PR
There should be no reset of the breakout room countdown on hostless meetings. Once it arrives at 0, it should remain 0 until breakout.

