### PR TITLE
Fix poll data showing 0/0 votes in agenda overview card.

### DIFF
--- a/client/lib/features/events/features/event_page/presentation/widgets/survey_answer_tile.dart
+++ b/client/lib/features/events/features/event_page/presentation/widgets/survey_answer_tile.dart
@@ -16,65 +16,80 @@ class SurveyAnswerTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     const kIndicatorHeight = 5.0;
+    final showOptionData =
+        answeredParticipants != null && totalParticipants != null;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
       children: [
         SizedBox(height: 10),
-        Text(
-          answer,
-          style: context.theme.textTheme.bodyMedium!
-              .copyWith(color: context.theme.colorScheme.onSurfaceVariant),
-        ),
         Row(
           children: [
-            Expanded(
-              child: LayoutBuilder(
-                builder: (context, constraints) {
-                  final maxWidth = constraints.maxWidth;
-                  final double step;
-
-                  // Secure against 0
-                  if (totalParticipants == 0) {
-                    step = maxWidth;
-                  } else {
-                    step = maxWidth / totalParticipants;
-                  }
-
-                  return Stack(
-                    children: [
-                      // Regular, 100% indicator
-                      Container(
-                        height: kIndicatorHeight,
-                        width: maxWidth,
-                        decoration: _getBoxDecoration(
-                          context.theme.colorScheme.onSurfaceVariant,
-                        ),
-                      ),
-                      // Indicator that represents percentage of votes
-                      AnimatedContainer(
-                        height: kIndicatorHeight,
-                        width: step * answeredParticipants,
-                        decoration: _getBoxDecoration(
-                          context.theme.colorScheme.primary,
-                        ),
-                        duration: kTabScrollDuration,
-                      ),
-                    ],
-                  );
-                },
+            if (!showOptionData)
+              Padding(
+                padding: const EdgeInsets.only(right: 8.0),
+                child: Icon(
+                  Icons.radio_button_unchecked,
+                  color: context.theme.colorScheme.onSurfaceVariant,
+                ),
               ),
-            ),
-            SizedBox(width: 10),
             Text(
-              '$answeredParticipants/$totalParticipants',
-              style: context.theme.textTheme.bodyMedium!.copyWith(
-                color: context.theme.colorScheme.onSurfaceVariant,
-              ),
+              answer,
+              style: context.theme.textTheme.bodyMedium!
+                  .copyWith(color: context.theme.colorScheme.onSurfaceVariant),
             ),
           ],
         ),
+        if (showOptionData)
+          Row(
+            children: [
+              Expanded(
+                child: LayoutBuilder(
+                  builder: (context, constraints) {
+                    final maxWidth = constraints.maxWidth;
+                    final double step;
+
+                    // Secure against 0
+                    if (totalParticipants == 0) {
+                      step = maxWidth;
+                    } else {
+                      step = maxWidth / totalParticipants!;
+                    }
+
+                    return Stack(
+                      children: [
+                        // Regular, 100% indicator
+                        Container(
+                          height: kIndicatorHeight,
+                          width: maxWidth,
+                          decoration: _getBoxDecoration(
+                            context.theme.colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                        // Indicator that represents percentage of votes
+                        AnimatedContainer(
+                          height: kIndicatorHeight,
+                          width: step * answeredParticipants!,
+                          decoration: _getBoxDecoration(
+                            context.theme.colorScheme.primary,
+                          ),
+                          duration: kTabScrollDuration,
+                        ),
+                      ],
+                    );
+                  },
+                ),
+              ),
+              SizedBox(width: 10),
+              Text(
+                '$answeredParticipants/$totalParticipants',
+                style: context.theme.textTheme.bodyMedium!.copyWith(
+                  color: context.theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
         SizedBox(height: 10),
       ],
     );

--- a/client/lib/features/events/features/event_page/presentation/widgets/survey_answer_tile.dart
+++ b/client/lib/features/events/features/event_page/presentation/widgets/survey_answer_tile.dart
@@ -7,7 +7,12 @@ class SurveyAnswerTile extends StatelessWidget {
     required this.answer,
     this.answeredParticipants,
     this.totalParticipants,
-  }) : super(key: key);
+  })  : assert(
+          (answeredParticipants == null && totalParticipants == null) ||
+              (answeredParticipants != null && totalParticipants != null),
+          'answeredParticipants and totalParticipants must be provided together OR both be null.',
+        ),
+        super(key: key);
 
   final String answer;
   final int? answeredParticipants;

--- a/client/lib/features/events/features/event_page/presentation/widgets/survey_answer_tile.dart
+++ b/client/lib/features/events/features/event_page/presentation/widgets/survey_answer_tile.dart
@@ -2,16 +2,16 @@ import 'package:client/styles/styles.dart';
 import 'package:flutter/material.dart';
 
 class SurveyAnswerTile extends StatelessWidget {
-  final String answer;
-  final int answeredParticipants;
-  final int totalParticipants;
-
   const SurveyAnswerTile({
     Key? key,
     required this.answer,
-    this.answeredParticipants = 0,
-    this.totalParticipants = 0,
+    this.answeredParticipants,
+    this.totalParticipants,
   }) : super(key: key);
+
+  final String answer;
+  final int? answeredParticipants;
+  final int? totalParticipants;
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## What is in this PR?
<!-- What is the goal of this PR? What steps are involved in achieving that goal? -->
Fixes #245 -- currently, poll data shows 0/0 in the agenda overview. This PR changes the UI displayed for poll cards in that view so that it just lists the options, without the blank poll data.

## Changes in the codebase
<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

* UI changes to poll card in agenda overview view, based on whether poll data is passed into the widget.
* Add assertions to protect against incorrect usage of the widget.

## Changes outside the codebase
<!-- If you have made changes to external services, need to add additional values to the job settings, or need to add something new to the database, explain it here. This may include updates to third-party services, changes to infrastructure configuration, integration with external APIs, etc. -->

* N/A

## Testing this PR
<!-- Give your reviewer some context or recommendations on how to test your work. -->

* Create a meeting with a poll card item in the agenda.
* Open the Agenda sidebar tab. 
* Observe that the poll card no longer shows incorrect blank data for the poll results, just the poll options. 

## Additional information
<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->

**Before (view of poll item in agenda overview)**
<img width="300" height="470" alt="Screenshot 2026-01-23 at 16 59 20" src="https://github.com/user-attachments/assets/4c98f414-f4d2-4a08-ada0-77ea8e7b3682" />

**After:**
<img width="300" height="391" alt="Screenshot 2026-01-23 at 17 37 27" src="https://github.com/user-attachments/assets/1aff5c36-29aa-477d-9195-db9c15a89154" />

**Note:** While this card could have been refactored to show the poll data collected from respondents, note that other similar user-input cards like Suggestions also do not show any user data in the agenda overview. Therefore, this card has been updated to only list the poll options that were provided by the admin, so that they can see the card and edit if needed.
