### PR TITLE
Add Java 21 setup to Firebase test workflow

### DIFF
--- a/.github/workflows/test_firebase.yaml
+++ b/.github/workflows/test_firebase.yaml
@@ -62,6 +62,13 @@ jobs:
         if: steps.changes.outputs.functions == 'true'
         run: dart run build_runner build --output=build
 
+      - name: Set up Java
+        if: steps.changes.outputs.functions == 'true' || steps.changes.outputs.firestore == 'true'
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "21"
+
       - name: Cache Firebase Emulators
         if: steps.changes.outputs.firestore == 'true'
         uses: actions/cache@v4


### PR DESCRIPTION
Baby PR for just the java update so future branches don't immediately fail testing.