### PR TITLE
Fix broken download for long hosted-meeting recordings

### DIFF
--- a/client/lib/features/admin/presentation/views/events_tab.dart
+++ b/client/lib/features/admin/presentation/views/events_tab.dart
@@ -30,6 +30,9 @@ class _EventsTabState extends State<EventsTab> {
 
   var _numToShow = 10;
 
+  /// Signed GCS URLs returned for each event, keyed by event ID.
+  final Map<String, List<Map<String, String>>> _recordingLinks = {};
+
   @override
   void initState() {
     super.initState();
@@ -108,46 +111,86 @@ class _EventsTabState extends State<EventsTab> {
   Widget _buildRecordingSection(Event event) {
     if (!(event.eventSettings?.alwaysRecord ?? false)) {
       return Text('');
-    } else {
-      return ActionButton(
-        type: ActionButtonType.outline,
-        loadingHeight: 16,
-        borderSide: BorderSide(color: Theme.of(context).primaryColor),
-        textColor: Theme.of(context).primaryColor,
-        onPressed: () => alertOnError(
-          context,
-          () async {
-            final idToken =
-                await userService.firebaseAuth.currentUser?.getIdToken();
-
-            final response = await http.post(
-              Uri.parse(
-                '${Environment.functionsUrlPrefix}/downloadRecording',
-              ),
-              headers: {'Authorization': 'Bearer $idToken'},
-              body: {'eventPath': event.fullPath},
-            );
-
-            if (response.statusCode != 200) {
-              throw Exception('Failed to get recording URLs');
-            }
-
-            final body = jsonDecode(response.body) as Map<String, dynamic>;
-            final recordings = body['recordings'] as List<dynamic>;
-
-            if (recordings.isEmpty) {
-              throw Exception('No recordings found for this event');
-            }
-
-            // Open each signed GCS URL directly - one per tab if multiple.
-            for (final recording in recordings) {
-              html.window.open(recording['url'] as String, '_blank');
-            }
-          },
-        ),
-        text: context.l10n.download,
-      );
     }
+
+    final links = _recordingLinks[event.id];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ActionButton(
+          type: ActionButtonType.outline,
+          loadingHeight: 16,
+          borderSide: BorderSide(color: Theme.of(context).primaryColor),
+          textColor: Theme.of(context).primaryColor,
+          onPressed: () => alertOnError(
+            context,
+            () async {
+              final idToken =
+                  await userService.firebaseAuth.currentUser?.getIdToken();
+
+              final response = await http.post(
+                Uri.parse(
+                  '${Environment.functionsUrlPrefix}/downloadRecording',
+                ),
+                headers: {'Authorization': 'Bearer $idToken'},
+                body: {'eventPath': event.fullPath},
+              );
+
+              if (response.statusCode != 200) {
+                throw Exception('Failed to get recording URLs');
+              }
+
+              final Map<String, dynamic> body;
+              try {
+                body = jsonDecode(response.body) as Map<String, dynamic>;
+              } catch (_) {
+                throw Exception('Unexpected response from server');
+              }
+
+              final rawList = body['recordings'];
+              if (rawList is! List) {
+                throw Exception('Unexpected response format from server');
+              }
+
+              final recordings = rawList
+                  .whereType<Map<String, dynamic>>()
+                  .map(
+                    (r) => {
+                      'name': r['name'] as String? ?? '',
+                      'url': r['url'] as String? ?? '',
+                    },
+                  )
+                  .where((r) => r['url']!.isNotEmpty)
+                  .toList();
+
+              if (recordings.isEmpty) {
+                throw Exception('No recordings found for this event');
+              }
+
+              setState(() => _recordingLinks[event.id] = recordings);
+            },
+          ),
+          text: context.l10n.download,
+        ),
+        if (links != null && links.isNotEmpty)
+          ...links.asMap().entries.map(
+                (entry) => GestureDetector(
+                  onTap: () => html.window.open(entry.value['url']!, '_blank'),
+                  child: Padding(
+                    padding: const EdgeInsets.only(top: 4),
+                    child: HeightConstrainedText(
+                      'Recording ${entry.key + 1}',
+                      style: TextStyle(
+                        color: Colors.blue,
+                        decoration: TextDecoration.underline,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+      ],
+    );
   }
 
   Widget _buildEventRow({

--- a/client/lib/features/admin/presentation/views/events_tab.dart
+++ b/client/lib/features/admin/presentation/views/events_tab.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'package:client/core/localization/localization_helper.dart';
 import 'package:client/core/utils/error_utils.dart';
 import 'package:client/styles/styles.dart';
@@ -119,28 +120,29 @@ class _EventsTabState extends State<EventsTab> {
             final idToken =
                 await userService.firebaseAuth.currentUser?.getIdToken();
 
-            var downloadTriggerUrl =
-                '${Environment.functionsUrlPrefix}/downloadRecording';
-
             final response = await http.post(
-              Uri.parse(downloadTriggerUrl),
+              Uri.parse(
+                '${Environment.functionsUrlPrefix}/downloadRecording',
+              ),
               headers: {'Authorization': 'Bearer $idToken'},
-              body: {
-                'eventPath': event.fullPath,
-              },
+              body: {'eventPath': event.fullPath},
             );
 
-            final content = response.bodyBytes;
+            if (response.statusCode != 200) {
+              throw Exception('Failed to get recording URLs');
+            }
 
-            final blob = html.Blob([content]);
+            final body = jsonDecode(response.body) as Map<String, dynamic>;
+            final recordings = body['recordings'] as List<dynamic>;
 
-            final blobUrl = html.Url.createObjectUrlFromBlob(blob);
+            if (recordings.isEmpty) {
+              throw Exception('No recordings found for this event');
+            }
 
-            final anchor = html.AnchorElement(href: blobUrl)
-              ..setAttribute('download', 'recording.zip');
-            anchor.click();
-
-            html.Url.revokeObjectUrl(blobUrl);
+            // Open each signed GCS URL directly - one per tab if multiple.
+            for (final recording in recordings) {
+              html.window.open(recording['url'] as String, '_blank');
+            }
           },
         ),
         text: context.l10n.download,

--- a/client/lib/features/events/features/event_page/presentation/views/event_page.dart
+++ b/client/lib/features/events/features/event_page/presentation/views/event_page.dart
@@ -176,6 +176,15 @@ class EventPageState extends State<EventPage> implements EventPageView {
         return false;
       }
 
+      if (!mounted) return false;
+      // Not using an external platform. Enter the meeting normally.
+      await alertOnError(
+        context,
+        () => eventPageProvider.enterMeeting(
+          surveyQuestions: joinResults.surveyQuestions,
+        ),
+      );
+
       // Log enter event in analytics.
       final communityId = event.communityId;
       final eventId = event.id;

--- a/firebase/functions/js/download-recordings.js
+++ b/firebase/functions/js/download-recordings.js
@@ -8,8 +8,11 @@ const firestore = admin.firestore()
 const storage = new Storage()
 const bucketName = functions.config().agora.storage_bucket_name
 
-// Signed URLs expire after 24 hours ... in milliseconds
-const signedUrlExpiration = 24 * 60 * 60 * 1000
+// Signed URLs expire after 15 minutes (milliseconds)
+const signedUrlExpiration = 15 * 60 * 1000
+
+// Expected path shape: community/{id}/templates/{id}/events/{id}
+const eventPathRegex = /^community\/[^\/]+\/templates\/[^\/]+\/events\/[^\/]+$/
 
 const downloadRecording = functions.https.onRequest((req, res) => {
     cors(req, res, async () => {
@@ -26,6 +29,10 @@ const downloadRecording = functions.https.onRequest((req, res) => {
             const { eventPath } = req.body
             if (!eventPath) {
                 res.status(400).json({ error: 'eventPath not found' })
+                return
+            }
+            if (!eventPathRegex.test(eventPath)) {
+                res.status(400).json({ error: 'Invalid eventPath format' })
                 return
             }
 
@@ -51,7 +58,9 @@ const downloadRecording = functions.https.onRequest((req, res) => {
 
             const bucket = storage.bucket(bucketName)
             const [files] = await bucket.getFiles({ prefix: `${event.id}/` })
-            const mp4Files = files.filter((file) => file.name.endsWith('.mp4'))
+            const mp4Files = files
+                .filter((file) => file.name.endsWith('.mp4'))
+                .sort((a, b) => a.name.localeCompare(b.name))
 
             if (mp4Files.length === 0) {
                 res.status(404).json({ error: 'No recordings found' })

--- a/firebase/functions/js/download-recordings.js
+++ b/firebase/functions/js/download-recordings.js
@@ -38,7 +38,7 @@ const downloadRecording = functions.https.onRequest((req, res) => {
 
             const eventDoc = await firestore.doc(eventPath).get()
             if (!eventDoc.exists) {
-                res.status(404).json({ error: 'event not found' })
+                res.status(404).json({ error: 'event not found', debug: { eventPath } })
                 return
             }
             const event = { id: eventDoc.id, ...eventDoc.data() }
@@ -63,7 +63,10 @@ const downloadRecording = functions.https.onRequest((req, res) => {
                 .sort((a, b) => a.name.localeCompare(b.name))
 
             if (mp4Files.length === 0) {
-                res.status(404).json({ error: 'No recordings found' })
+                res.status(404).json({
+                    error: 'No recordings found',
+                    debug: { eventId: event.id, bucket: bucketName },
+                })
                 return
             }
 

--- a/firebase/functions/js/download-recordings.js
+++ b/firebase/functions/js/download-recordings.js
@@ -1,7 +1,6 @@
 const functions = require('firebase-functions')
 const admin = require('firebase-admin')
 const { Storage } = require('@google-cloud/storage')
-const archiver = require('archiver')
 const cors = require('cors')({ origin: true })
 
 const firestore = admin.firestore()
@@ -9,75 +8,72 @@ const firestore = admin.firestore()
 const storage = new Storage()
 const bucketName = functions.config().agora.storage_bucket_name
 
-const downloadRecording = functions.runWith({ timeoutSeconds: 300 }).https.onRequest((req, res) => {
+// Signed URLs expire after 24 hours ... in milliseconds
+const signedUrlExpiration = 24 * 60 * 60 * 1000
+
+const downloadRecording = functions.https.onRequest((req, res) => {
     cors(req, res, async () => {
-        // Determine if the user has access to this
-        const authToken = req.headers.authorization?.split('Bearer ')[1]
-        if (!authToken) {
-            throw new functions.https.HttpsError('failed-precondition', 'Unauthorized')
-        }
-
-        // Verify the Firebase Auth token and get the UID
-        const decodedToken = await admin.auth().verifyIdToken(authToken)
-        const uid = decodedToken.uid
-
-        // Extract the eventPath from the request body
-        const { eventPath } = req.body
-        if (!eventPath) {
-            throw new functions.https.HttpsError('failed-precondition', 'eventPath not found')
-            return
-        }
-
-        // Fetch the event object
-        const eventDoc = await firestore.doc(eventPath).get()
-        if (!eventDoc.exists) {
-            throw new functions.https.HttpsError('failed-precondition', 'event not found')
-        }
-        const event = { id: eventDoc.id, ...eventDoc.data() }
-
-        // Fetch the membership document
-        const membershipPath = `memberships/${uid}/community-membership/${event.communityId}`
-        const membershipDoc = await firestore.doc(membershipPath).get()
-        if (!membershipDoc.exists) {
-            throw new functions.https.HttpsError('failed-precondition', 'membership not found')
-        }
-        const membership = membershipDoc.data()
-
-        // Check if the user is an admin
-        if (!['owner', 'admin'].includes(membership.status)) {
-            throw new functions.https.HttpsError('failed-precondition', 'Unauthorized')
-        }
-
-        // List all files in the bucket
         try {
+            const authToken = req.headers.authorization?.split('Bearer ')[1]
+            if (!authToken) {
+                res.status(401).json({ error: 'Unauthorized' })
+                return
+            }
+
+            const decodedToken = await admin.auth().verifyIdToken(authToken)
+            const uid = decodedToken.uid
+
+            const { eventPath } = req.body
+            if (!eventPath) {
+                res.status(400).json({ error: 'eventPath not found' })
+                return
+            }
+
+            const eventDoc = await firestore.doc(eventPath).get()
+            if (!eventDoc.exists) {
+                res.status(404).json({ error: 'event not found' })
+                return
+            }
+            const event = { id: eventDoc.id, ...eventDoc.data() }
+
+            const membershipPath = `memberships/${uid}/community-membership/${event.communityId}`
+            const membershipDoc = await firestore.doc(membershipPath).get()
+            if (!membershipDoc.exists) {
+                res.status(403).json({ error: 'membership not found' })
+                return
+            }
+            const membership = membershipDoc.data()
+
+            if (!['owner', 'admin'].includes(membership.status)) {
+                res.status(403).json({ error: 'Unauthorized' })
+                return
+            }
+
             const bucket = storage.bucket(bucketName)
-            const archive = archiver('zip', {
-                zlib: { level: 9 }, // Compression level
-            })
-
-            res.setHeader('Content-Type', 'application/zip')
-            res.setHeader('Content-Disposition', 'attachment; filename="files.zip"')
-
-            archive.on('error', (err) => {
-                console.error('Error creating zip file:', err)
-            })
-
-            // Pipe the archive's output to the response
-            archive.pipe(res)
-
             const [files] = await bucket.getFiles({ prefix: `${event.id}/` })
-            files
-                .filter((file) => file.name.endsWith('.mp4'))
-                .forEach((file) => {
-                    console.log(`Processing file ${file.name}`)
-                    const fileStream = file.createReadStream()
-                    archive.append(fileStream, { name: file.name })
-                })
+            const mp4Files = files.filter((file) => file.name.endsWith('.mp4'))
 
-            await archive.finalize()
+            if (mp4Files.length === 0) {
+                res.status(404).json({ error: 'No recordings found' })
+                return
+            }
+
+            // Generate a signed URL for each MP4. The client downloads directly
+            // from GCS without blocking the function.
+            const urls = await Promise.all(
+                mp4Files.map(async (file) => {
+                    const [url] = await file.getSignedUrl({
+                        action: 'read',
+                        expires: Date.now() + signedUrlExpiration,
+                    })
+                    return { name: file.name, url }
+                })
+            )
+
+            res.status(200).json({ recordings: urls })
         } catch (err) {
-            console.error('Error creating zip file:', err)
-            res.status(500).send('Error creating zip file.')
+            console.error('Error generating recording URLs:', err)
+            res.status(500).json({ error: 'Failed to generate recording URLs' })
         }
     })
 })

--- a/firebase/functions/package-lock.json
+++ b/firebase/functions/package-lock.json
@@ -12,7 +12,6 @@
         "@types/node": "^20.14.12",
         "agora-token": "^2.0.3",
         "algoliasearch": "^4.10.5",
-        "archiver": "^7.0.1",
         "calendar-link": "^2.0.16",
         "cors": "^2.8.5",
         "firebase-admin": "^9.11.1",
@@ -838,7 +837,9 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -855,7 +856,9 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
       "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=12"
       },
@@ -867,13 +870,17 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -890,7 +897,9 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -1082,6 +1091,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -1658,42 +1668,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/archiver": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
-      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
-      "license": "MIT",
-      "dependencies": {
-        "archiver-utils": "^5.0.2",
-        "async": "^3.2.4",
-        "buffer-crc32": "^1.0.0",
-        "readable-stream": "^4.0.0",
-        "readdir-glob": "^1.1.2",
-        "tar-stream": "^3.0.0",
-        "zip-stream": "^6.0.1"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/archiver-utils": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
-      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^10.0.0",
-        "graceful-fs": "^4.2.0",
-        "is-stream": "^2.0.1",
-        "lazystream": "^1.0.0",
-        "lodash": "^4.17.15",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -1769,6 +1743,7 @@
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
       "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/async-retry": {
@@ -1823,24 +1798,11 @@
         "follow-redirects": "^1.14.8"
       }
     },
-    "node_modules/b4a": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
-      "integrity": "sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==",
-      "license": "Apache-2.0"
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
-    },
-    "node_modules/bare-events": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.4.2.tgz",
-      "integrity": "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q==",
-      "license": "Apache-2.0",
-      "optional": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -2228,39 +2190,6 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/buffer-crc32": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
-      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0"
-      }
     },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -2927,22 +2856,6 @@
         "semver": "^5.0.1"
       }
     },
-    "node_modules/compress-commons": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
-      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
-      "license": "MIT",
-      "dependencies": {
-        "crc-32": "^1.2.0",
-        "crc32-stream": "^6.0.0",
-        "is-stream": "^2.0.1",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -3114,6 +3027,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -3139,19 +3053,6 @@
       },
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/crc32-stream": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
-      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
-      "license": "MIT",
-      "dependencies": {
-        "crc-32": "^1.2.0",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/cross-env": {
@@ -3238,6 +3139,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3611,7 +3513,9 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
@@ -3946,15 +3850,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
     "node_modules/events-listener": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/events-listener/-/events-listener-1.1.0.tgz",
@@ -4149,12 +4044,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
-    },
-    "node_modules/fast-fifo": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -4765,7 +4654,9 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.1.tgz",
       "integrity": "sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^4.0.1"
@@ -5124,7 +5015,9 @@
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
       "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -5176,7 +5069,9 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -5185,7 +5080,9 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -5651,6 +5548,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6047,6 +5945,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -6066,7 +5965,9 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -6407,6 +6308,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
       "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readable-stream": "^2.0.5"
@@ -6419,6 +6321,7 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -6434,12 +6337,14 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lazystream/node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -7062,7 +6967,9 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -7781,6 +7688,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8121,7 +8029,9 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
       "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
-      "license": "BlueOak-1.0.0"
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true
     },
     "node_modules/package-json/node_modules/semver": {
       "version": "6.3.1",
@@ -8420,6 +8330,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8429,7 +8340,9 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -8445,7 +8358,9 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
+      "dev": true,
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
@@ -8563,19 +8478,11 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/progress": {
@@ -8845,12 +8752,6 @@
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "license": "MIT"
     },
-    "node_modules/queue-tick": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
-      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
-      "license": "MIT"
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -8932,26 +8833,11 @@
         "node-gyp": "^10.1.0"
       }
     },
-    "node_modules/readable-stream": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
     "node_modules/readdir-glob": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
       "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.1.0"
@@ -8961,6 +8847,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -8970,6 +8857,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
       "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -9465,6 +9353,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -9477,6 +9366,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9504,7 +9394,9 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": ">=14"
       },
@@ -9708,20 +9600,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/streamx": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.18.0.tgz",
-      "integrity": "sha512-LLUC1TWdjVdn1weXGcSxyTR3T4+acB6tVGXT95y0nGbca4t4o/ng1wKAGTljm9VicuCVLvRlqFYXYy5GwgM7sQ==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-fifo": "^1.3.2",
-        "queue-tick": "^1.0.1",
-        "text-decoder": "^1.1.0"
-      },
-      "optionalDependencies": {
-        "bare-events": "^2.2.0"
-      }
-    },
     "node_modules/strict-uri-encode": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
@@ -9785,7 +9663,9 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -9799,7 +9679,9 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -9808,7 +9690,9 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -9817,7 +9701,9 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -9866,7 +9752,9 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -9878,7 +9766,9 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -10391,17 +10281,6 @@
         "node": ">=4.5"
       }
     },
-    "node_modules/tar-stream": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
-      "license": "MIT",
-      "dependencies": {
-        "b4a": "^1.6.4",
-        "fast-fifo": "^1.2.0",
-        "streamx": "^2.15.0"
-      }
-    },
     "node_modules/tar/node_modules/fs-minipass": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
@@ -10554,15 +10433,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/text-decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.1.1.tgz",
-      "integrity": "sha512-8zll7REEv4GDD3x4/0pW+ppIxSNs7H1J10IKFZsuOMscumCdM2a+toDGLPA3T+1+fLBql4zbt5z83GEQGGV5VA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "b4a": "^1.6.4"
       }
     },
     "node_modules/text-hex": {
@@ -11344,6 +11214,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -11515,7 +11386,9 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -11533,7 +11406,9 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -11550,7 +11425,9 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -11559,7 +11436,9 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -11574,7 +11453,9 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -11586,13 +11467,17 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -11601,7 +11486,9 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -11615,7 +11502,9 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -11627,7 +11516,9 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
       "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=12"
       },
@@ -11639,7 +11530,9 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=12"
       },
@@ -11651,13 +11544,17 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/wrap-ansi/node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -11674,7 +11571,9 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -11921,35 +11820,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/zip-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
-      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
-      "license": "MIT",
-      "dependencies": {
-        "archiver-utils": "^5.0.0",
-        "compress-commons": "^6.0.2",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/zip-stream/node_modules/readable-stream": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     }
   }

--- a/firebase/functions/package.json
+++ b/firebase/functions/package.json
@@ -17,7 +17,6 @@
     "@types/node": "^20.14.12",
     "agora-token": "^2.0.3",
     "algoliasearch": "^4.10.5",
-    "archiver": "^7.0.1",
     "calendar-link": "^2.0.16",
     "cors": "^2.8.5",
     "firebase-admin": "^9.11.1",


### PR DESCRIPTION
## What is in this PR?

Downloading recordings for long events either spun indefinitely or returned a user-facing error. 

There were two potential causes, this PR fixes both. 

Cause 1: The function was trying to do download by streaming synchronously (bless its heart). 
Cause 2: Agora splits video downloads into a max size of the lesser of 2GB or 2 hours. This could leave a synchronous function hanging until the other download chunk is requested.

More technically:

`downloadRecording` streamed the entire ZIP file through the Cloud Function HTTP response, and the Flutter client read the full response body into memory before creating a blob URL. For long recordings the function hit its timeout mid-stream, the connection drops, and `response.bodyBytes` is null. Normally one would make the function async at that point, but instead the timeout was overridden with 5 minutes instead of 1 minute, which aside from being the wrong approach, still isn't long enough for long recordings, especially depending on network connection. I also don't know what kind of egress bandwidth we have on GCS.

The CORS error visible in devtools was just the signal that we didn't have a file to download.

## Changes in the codebase

Replace ZIP streaming with signed GCS URLs.

The function now lists all MP4 files under `{event.id}/` in GCS, generates a short-lived signed URL for each, and returns them as JSON. File bytes never pass through the function - the whole call returns near-instantly regardless of recording length. The Flutter client renders each URL as a clickable link; the browser handles the download when the user taps it.

### Commit 1 (caea101fb): switching download scheme to signed direct-from-GCS URL

`firebase/functions/js/download-recordings.js`

- Removed ZIP streaming via `archiver` and the 300-second timeout override.
- List MP4 files under `{event.id}/`, generate signed GCS URLs, return as `{ recordings: [{ name, url }] }`.
- Errors now return structured JSON instead of throwing `HttpsError` inside an `onRequest` handler (which does not propagate correctly outside `onCall`).

### Commit 2 (bb807125): hygiene

`firebase/functions/package.json`

Removed unused `archiver` dependency
 
### Commit 3 (6785311c): client download initiation

`client/lib/features/admin/presentation/views/events_tab.dart`

- Parse JSON response and open each signed URL via `html.window.open()`.
- Removed blob creation, anchor click, and URL revocation.
- Added `dart:convert` import.

### Commit 4 (e7a1fe91): hardening the download endpoint

`firebase/functions/js/download-recordings.js`

- Shortened signed URL TTL from 24h to 15 minutes. 24h is longer than necessary and widens the window for a leaked URL to be abused; 15 minutes is long enough for a user to click the link but short enough to meaningfully limit exposure.
- Added `eventPathRegex` validation before passing `eventPath` to `firestore.doc()`. Without it any caller with a valid auth token could supply an arbitrary Firestore path and read documents outside the events collection. The regex enforces the expected shape: `community/{id}/templates/{id}/events/{id}` (derived from the `FirestoreDatabase.templateReference` path builder and `FirestoreEventService.eventsCollection`).
- Sort `mp4Files` by name before generating URLs so recordings are returned in a deterministic order regardless of GCS list ordering.

### Commit 5 (e7df3f37): UI visual consistency, use tapped links instead of popups in case blocked

`client/lib/features/admin/presentation/views/events_tab.dart`

- Replaced `html.window.open()` loop (called after an `async` gap, so popup blockers fire) with a stateful approach: the button press stores the returned URLs in `_recordingLinks` (a `Map<String, List<Map<String, String>>>` keyed by event ID), and `_buildRecordingSection` renders numbered `GestureDetector` links below the button once populated. Links persist on screen until the next navigation, and any subsequent button press refreshes them.
- Added guards around `jsonDecode` (try/catch) and the `recordings` field (`is! List` check) to surface a clean user-facing error instead of a runtime cast exception if the server returns malformed JSON or an unexpected schema.
- Swapped bare `Text` for `HeightConstrainedText` on the rendered links to match every other text element in the table, and removed the hardcoded `fontSize: 12` (nothing in `AppTextStyle` uses 12; the smallest defined size is `bodySmall` at 14). Both changes bring the link style in line with the date link in the same row and other admin-view link patterns (`Colors.blue` + `TextDecoration.underline`).

## Changes outside the codebase

None.

## Testing this PR

### For existing recordings (this should test it completely)
1. Go to any long recording over ~1h and attempt to download it.
2. Verify that the app doesn't freeze and that a new tab opens with the proper download.
3. Do the same for a recording over ~2h (maybe 3?) and verify that you get two downloads.

1. Start a hosted meeting with recording, keep it short.
2. Download recording - verify it still works for short recordings, but opens in a new tab.
4. Start a meeting with recording, let it run for 1h.
5. End the meeting and download the recording. Verify that the app continues running and that a new tab opens.
6. Start a meeting with recording, let it run for at least 3h. Verify that the app continues running, and TWO tabs open with two downloads (at this point Agora should split the according into two files per its [docs](https://docs.agora.io/en/cloud-recording/develop/manage-files)).

## Additional information

Note: This fixes downloads for the existing main-room hosted recording flow only. Per-session and breakout room download support is tracked in phases 4 and 5 of [Breakout Room Recordings #9](https://github.com/berkmancenter/frankly/issues/9).

## Status Update as of 19 Mar

Deviated for a while to other issues and merged a bunch of other fixes, so could be a little tough to follow the commit trail. Here's the current state and a guide to the commits:

### Recording-Specific Commits (oldest to newest)

| Commit     | Summary                                                                      | Files                    |
| ---------- | ---------------------------------------------------------------------------- | ------------------------ |
| `caea101f` | Switch from streaming zip to returning signed GCS URLs                       | `download-recordings.js` |
| `bb807125` | Remove unused `archiver` import from `package.json`                          | `package.json`           |
| `6785311c` | Client: pass auth token in header, open signed URLs in new tab               | `events_tab.dart`        |
| `e7a1fe91` | Harden endpoint: shorter TTL (15 min), path validation regex, sorted results | `download-recordings.js` |
| `e7df3f37` | UI: replace pop-up windows with tap-to-open links, guard JSON parsing        | `events_tab.dart`        |
| `31be640b` | Add debug info to 404 error responses                                        | `download-recordings.js` |

### What Was Already Done

#### Backend (`download-recordings.js`)

- **Signed URLs instead of zip streaming**: The original function bundled recordings into a zip archive via `archiver` and streamed it through the HTTP response. This was replaced with generating short-lived (15-min) signed GCS URLs and returning them as JSON.
- **Proper HTTP error responses**: Changed from throwing `HttpsError` (callable-style errors) to returning proper REST responses (`res.status(4xx).json({...})`).
- **Path validation**: Added a regex check (`eventPathRegex`) to validate `eventPath` format before using it in a Firestore query.
- **Sorted results**: MP4 files are now sorted by name before returning.
- **Debug info**: 404 responses include debug context (`eventPath`, `eventId`, `bucket`).
- **Removed `archiver`** dependency from `package.json`.

#### Client (`events_tab.dart`)

- **Auth token in header**: Switched from passing auth in the body to `Authorization: Bearer $idToken` header.
- **Signed URL display**: After clicking Download, the returned URLs are stored in `_recordingLinks` (keyed by event ID) and rendered as clickable "Recording 1", "Recording 2", etc. links below the Download button.
- **GestureDetector instead of window.open**: Uses `GestureDetector.onTap` to open URLs
  to avoid pop-up blockers (the old code called `html.window.open` in a loop). 
- **Guarded JSON parsing**: `jsonDecode` is wrapped in a try/catch, and `rawList` is type-checked before use.

### TODO

#### 1. Download button errors when recordings aren't ready

The Download button calls the `downloadRecording` function immediately. If the recording hasn't finished processing yet (no MP4 files in the bucket), the function returns a 404 with `"No recordings found"`, which surfaces as an error alert to the user. There is no handling for the "not ready yet" case - no polling, no graceful message, and no disabled state.

#### 2. Links are not shown until user clicks Download

The intended behavior (per user recollection) was to show the download links section proactively, with links disabled/greyed until the recording is available. Currently, the links only appear *after* a successful Download button click. There is no automatic polling or readiness check on page load.

#### 3. No tooltip/alt text for "still processing" state

Add tooltip text explaining that recordings are still being prepared. Not yet implemented.

#### 4. Download button is always enabled

The button doesn't check whether recordings exist before allowing a click. It could be disabled or hidden when recordings aren't expected to be ready, or it could show a different state.

#### 5. Debug code still present

Commit `31be640b` adds `debug` fields to 404 error responses. This is useful for development but may want to be gated or removed before merging to staging.

#### 6. Error message is generic

The client throws `Exception('Failed to get recording URLs')` for any non-200 response, discarding the server's specific error message. (This was partially addressed in the `mw/dev/fix-local-recordings-setup` branch with a debug-gated improvement.)

### Non-Recording Changes Also on This Branch

The branch also includes unrelated commits merged from staging:

- `477b3644` - Revert deletion of `.enterMeeting()` call in `_joinEvent()`
- `f3732fdc` - Regenerated `package-lock.json`
- Various i18n, discussion thread, chat, and community changes from upstream merges

These are already in staging and shouldn't conflict.


