### PR TITLE
[Bugfix] Fix join event button not working/responding.

### DIFF
--- a/client/lib/features/events/features/event_page/presentation/views/event_page.dart
+++ b/client/lib/features/events/features/event_page/presentation/views/event_page.dart
@@ -177,7 +177,6 @@ class EventPageState extends State<EventPage> implements EventPageView {
       }
 
       if (!mounted) return false;
-      // Not using an external platform. Enter the meeting normally.
       await alertOnError(
         context,
         () => eventPageProvider.enterMeeting(

--- a/client/lib/features/events/features/event_page/presentation/views/event_page.dart
+++ b/client/lib/features/events/features/event_page/presentation/views/event_page.dart
@@ -251,44 +251,43 @@ class EventPageState extends State<EventPage> implements EventPageView {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         if (_isEnterEventGraphicShown(event.scheduledTime!)) ...[
-          CustomInkWell(
-            onTap: () => _joinEvent(enterMeeting: true),
-            child: SizedBox(
-              height: 380,
-              child: Stack(
-                children: [
-                  Positioned.fill(
-                    child: ProxiedImage(
-                      null,
-                      asset: AppAsset('media/background.gif'),
-                      fit: BoxFit.cover,
-                      loadingColor: Colors.transparent,
-                    ),
+          SizedBox(
+            height: 380,
+            child: Stack(
+              children: [
+                Positioned.fill(
+                  child: ProxiedImage(
+                    null,
+                    asset: AppAsset('media/background.gif'),
+                    fit: BoxFit.cover,
+                    loadingColor: Colors.transparent,
                   ),
-                  Container(
-                    color: context.theme.colorScheme.scrim.withScrimOpacity,
-                  ),
-                  Center(
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        HeightConstrainedText(
-                          'The event is starting',
-                          style: TextStyle(
-                            color: context.theme.colorScheme.onPrimary,
-                          ),
+                ),
+                Container(
+                  color: context.theme.colorScheme.scrim.withScrimOpacity,
+                ),
+                Center(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      HeightConstrainedText(
+                        'The event is starting',
+                        style: TextStyle(
+                          color: context.theme.colorScheme.onPrimary,
                         ),
-                        SizedBox(height: 10),
-                        ActionButton(
-                          text: 'Enter Event',
-                          onPressed: () => _joinEvent(enterMeeting: true),
-                          height: 65,
-                        ),
-                      ],
-                    ),
+                      ),
+                      SizedBox(height: 10),
+                      ActionButton(
+                        text: 'Enter Event',
+                        onPressed: () async {
+                          final joined = await _joinEvent(enterMeeting: true);
+                        },
+                        height: 65,
+                      ),
+                    ],
                   ),
-                ],
-              ),
+                ),
+              ],
             ),
           ),
           SizedBox(height: 4),

--- a/client/lib/features/events/features/event_page/presentation/views/event_page.dart
+++ b/client/lib/features/events/features/event_page/presentation/views/event_page.dart
@@ -147,7 +147,8 @@ class EventPageState extends State<EventPage> implements EventPageView {
   }
 
   /// Shows RSVP dialog and any CTAs.
-  /// Returns whether the user successfully joined.
+  /// Returns whether the user successfully entered the meeting.
+  /// Returns false for cancellations, non-meeting joins (enterMeeting: false), or failures.
   Future<bool> _joinEvent({
     bool showConfirm = true,
     bool enterMeeting = false,
@@ -156,8 +157,6 @@ class EventPageState extends State<EventPage> implements EventPageView {
     return await alertOnError<bool>(context, () async {
           final eventPageProvider = context.read<EventPageProvider>();
           final event = eventPageProvider.eventProvider.event;
-          final communityProvider =
-              Provider.of<CommunityProvider>(context, listen: false);
           JoinEventResults joinResults = await alertOnError<JoinEventResults>(
                 context,
                 () => eventPageProvider.joinEvent(
@@ -183,6 +182,8 @@ class EventPageState extends State<EventPage> implements EventPageView {
               surveyQuestions: joinResults.surveyQuestions,
             ),
           );
+
+          if (!eventPageProvider.isEnteredMeeting) return false;
 
           // Log enter event in analytics.
           final communityId = event.communityId;

--- a/client/lib/features/events/features/event_page/presentation/views/event_page.dart
+++ b/client/lib/features/events/features/event_page/presentation/views/event_page.dart
@@ -281,6 +281,13 @@ class EventPageState extends State<EventPage> implements EventPageView {
                         text: 'Enter Event',
                         onPressed: () async {
                           final joined = await _joinEvent(enterMeeting: true);
+                          if (!joined && mounted) {
+                            showRegularToast(
+                              context,
+                              'Could not enter event.',
+                              toastType: ToastType.failed,
+                            );
+                          }
                         },
                         height: 65,
                       ),

--- a/client/lib/features/events/features/event_page/presentation/views/event_page.dart
+++ b/client/lib/features/events/features/event_page/presentation/views/event_page.dart
@@ -292,7 +292,7 @@ class EventPageState extends State<EventPage> implements EventPageView {
                           if (!joined && mounted) {
                             showRegularToast(
                               context,
-                              'Could not enter event.',
+                              'Event was not entered.',
                               toastType: ToastType.failed,
                             );
                           }

--- a/client/lib/features/events/features/event_page/presentation/views/event_page.dart
+++ b/client/lib/features/events/features/event_page/presentation/views/event_page.dart
@@ -293,7 +293,7 @@ class EventPageState extends State<EventPage> implements EventPageView {
                             showRegularToast(
                               context,
                               'Event was not entered.',
-                              toastType: ToastType.failed,
+                              toastType: ToastType.neutral,
                             );
                           }
                         },

--- a/client/lib/features/events/features/event_page/presentation/views/event_page.dart
+++ b/client/lib/features/events/features/event_page/presentation/views/event_page.dart
@@ -176,6 +176,15 @@ class EventPageState extends State<EventPage> implements EventPageView {
         return false;
       }
 
+      if (!mounted) return false;
+      // Not using an external platform. Enter the meeting normally.
+      await alertOnError(
+        context,
+        () => eventPageProvider.enterMeeting(
+          surveyQuestions: joinResults.surveyQuestions,
+        ),
+      );
+
       // Log enter event in analytics.
       final communityId = event.communityId;
       final eventId = event.id;

--- a/client/lib/features/events/features/event_page/presentation/views/event_page.dart
+++ b/client/lib/features/events/features/event_page/presentation/views/event_page.dart
@@ -153,55 +153,54 @@ class EventPageState extends State<EventPage> implements EventPageView {
     bool enterMeeting = false,
     bool joinCommunity = false,
   }) async {
-    await alertOnError(context, () async {
-      final eventPageProvider = context.read<EventPageProvider>();
-      final event = eventPageProvider.eventProvider.event;
-      final communityProvider =
-          Provider.of<CommunityProvider>(context, listen: false);
-      JoinEventResults joinResults = await alertOnError<JoinEventResults>(
+    return await alertOnError<bool>(context, () async {
+          final eventPageProvider = context.read<EventPageProvider>();
+          final event = eventPageProvider.eventProvider.event;
+          final communityProvider =
+              Provider.of<CommunityProvider>(context, listen: false);
+          JoinEventResults joinResults = await alertOnError<JoinEventResults>(
+                context,
+                () => eventPageProvider.joinEvent(
+                  showConfirm: showConfirm,
+                  joinCommunity: joinCommunity,
+                ),
+              ) ??
+              JoinEventResults(isJoined: false);
+
+          if (!joinResults.isJoined) {
+            // Don't join the meeting if joinEvent returns false.
+            return false;
+          }
+
+          if (!enterMeeting) {
+            return false;
+          }
+
+          if (!mounted) return false;
+          await alertOnError(
             context,
-            () => eventPageProvider.joinEvent(
-              showConfirm: showConfirm,
-              joinCommunity: joinCommunity,
+            () => eventPageProvider.enterMeeting(
+              surveyQuestions: joinResults.surveyQuestions,
             ),
-          ) ??
-          JoinEventResults(isJoined: false);
+          );
 
-      if (!joinResults.isJoined) {
-        // Don't join the meeting if joinEvent returns false.
-        return false;
-      }
-
-      if (!enterMeeting) {
-        return false;
-      }
-
-      if (!mounted) return false;
-      await alertOnError(
-        context,
-        () => eventPageProvider.enterMeeting(
-          surveyQuestions: joinResults.surveyQuestions,
-        ),
-      );
-
-      // Log enter event in analytics.
-      final communityId = event.communityId;
-      final eventId = event.id;
-      final templateId = event.templateId;
-      final isHost = (event.eventType != EventType.hostless) &&
-          event.creatorId == userService.currentUserId;
-      analytics.logEvent(
-        AnalyticsEnterEventEvent(
-          communityId: communityId,
-          eventId: eventId,
-          asHost: isHost,
-          templateId: templateId,
-        ),
-      );
-      return true;
-    });
-    // If user joined, should not reach this point.
-    return false;
+          // Log enter event in analytics.
+          final communityId = event.communityId;
+          final eventId = event.id;
+          final templateId = event.templateId;
+          final isHost = (event.eventType != EventType.hostless) &&
+              event.creatorId == userService.currentUserId;
+          analytics.logEvent(
+            AnalyticsEnterEventEvent(
+              communityId: communityId,
+              eventId: eventId,
+              asHost: isHost,
+              templateId: templateId,
+            ),
+          );
+          return true;
+        }) ??
+        false;
   }
 
   Future<void> _showSendMessageDialog() async {

--- a/client/lib/features/events/features/event_page/presentation/widgets/event_info.dart
+++ b/client/lib/features/events/features/event_page/presentation/widgets/event_info.dart
@@ -426,7 +426,7 @@ class _EventInfoState extends State<EventInfo> {
           showRegularToast(
             context,
             'Event was not entered.',
-            toastType: ToastType.failed,
+            toastType: ToastType.neutral,
           );
         }
       },

--- a/client/lib/features/events/features/event_page/presentation/widgets/event_info.dart
+++ b/client/lib/features/events/features/event_page/presentation/widgets/event_info.dart
@@ -414,10 +414,13 @@ class _EventInfoState extends State<EventInfo> {
         if (!mounted) return;
         if (!isEventOpen && !successfullyJoined) {
           // If the event is not open yet, we expect user not to be able to join.
-          await showAlert(
-            context,
-            'The event has not started yet. We\'ll see you soon!',
-          );
+          // Show the "not started" message for events that are not open and not joined, unless they're past concluded events.
+          if (daysDifference >= 0) {
+            await showAlert(
+              context,
+              'The event has not started yet. We\'ll see you soon!',
+            );
+          }
           return;
         } else if (!successfullyJoined) {
           showRegularToast(

--- a/client/lib/features/events/features/event_page/presentation/widgets/event_info.dart
+++ b/client/lib/features/events/features/event_page/presentation/widgets/event_info.dart
@@ -411,6 +411,7 @@ class _EventInfoState extends State<EventInfo> {
       onPressed: () async {
         final successfullyJoined =
             await widget.onJoinEvent(enterMeeting: isEventOpen || kDebugMode);
+        if (!mounted) return;
         if (!isEventOpen && !successfullyJoined) {
           // If the event is not open yet, we expect user not to be able to join.
           await showAlert(
@@ -418,6 +419,12 @@ class _EventInfoState extends State<EventInfo> {
             'The event has not started yet. We\'ll see you soon!',
           );
           return;
+        } else if (!successfullyJoined) {
+          showRegularToast(
+            context,
+            'Could not enter event.',
+            toastType: ToastType.failed,
+          );
         }
       },
       text: text,

--- a/client/lib/features/events/features/event_page/presentation/widgets/event_info.dart
+++ b/client/lib/features/events/features/event_page/presentation/widgets/event_info.dart
@@ -425,7 +425,7 @@ class _EventInfoState extends State<EventInfo> {
         } else if (!successfullyJoined) {
           showRegularToast(
             context,
-            'Could not enter event.',
+            'Event was not entered.',
             toastType: ToastType.failed,
           );
         }


### PR DESCRIPTION
## What is in this PR?
<!-- What is the goal of this PR? What steps are involved in achieving that goal? -->
This PR fixes an issue caught shortly after the most recent release to production (2.1.2), where the "Enter Event" button would only briefly show a loading indicator and not respond when users clicked on it (and the button should have been active).

## Changes in the codebase
<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

* Fixes accidental deletion of `enterMeeting` method.
* Added basic visible user feedback (in the form of a "Could not join meeting" error toast) to prevent this button from silently failing in the future.
* Removed large `InkWell` wrapper around the Enter Event graphic in order to reduce by 1 the number of `joinEvent` calls we need to maintain. Eventually would like to have this logic all unified.

## Changes outside the codebase
<!-- If you have made changes to external services, need to add additional values to the job settings, or need to add something new to the database, explain it here. This may include updates to third-party services, changes to infrastructure configuration, integration with external APIs, etc. -->

* N/A

## Testing this PR
<!-- Give your reviewer some context or recommendations on how to test your work. -->

* Create an event.
* Enter the meeting any time starting 15 min before the meeting.
* Observe that the button should bring you to the meeting.

## Additional information
<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->

