### PR TITLE
Fixing layout bugs

### DIFF
--- a/client/lib/core/routing/locations.dart
+++ b/client/lib/core/routing/locations.dart
@@ -342,7 +342,7 @@ class CommunityPageRoutes {
       _getLocation(path: '$prefix/discuss');
 
   CommunityLocation communityAdmin({String? tab}) => _getLocation(
-        path: '$prefix/admin',
+        path: '$prefix/admin/${tab ?? 'overview'}',
         queryParameters: tab != null ? {'tab': tab} : null,
       );
 

--- a/client/lib/core/routing/locations.dart
+++ b/client/lib/core/routing/locations.dart
@@ -183,7 +183,7 @@ class CommunityLocation extends BeamLocation<BeamState> {
       '/challenge',
       '/instant',
       '/admin',
-      '/admin/overview',
+      '/admin/profile',
       '/admin/members',
       '/admin/data',
       '/admin/settings',
@@ -342,7 +342,7 @@ class CommunityPageRoutes {
       _getLocation(path: '$prefix/discuss');
 
   CommunityLocation communityAdmin({String? tab}) => _getLocation(
-        path: '$prefix/admin/${tab ?? 'overview'}',
+        path: '$prefix/admin/${tab ?? 'profile'}',
         queryParameters: tab != null ? {'tab': tab} : null,
       );
 

--- a/client/lib/features/admin/presentation/views/community_admin.dart
+++ b/client/lib/features/admin/presentation/views/community_admin.dart
@@ -35,7 +35,7 @@ class CommunityAdminState extends State<CommunityAdmin>
     int initialIndex = 0;
     if (widget.tab != null) {
       switch (widget.tab) {
-        case 'overview':
+        case 'profile':
           break;
         case 'members':
           initialIndex = 1;
@@ -146,7 +146,7 @@ class CommunityAdminState extends State<CommunityAdmin>
                 null,
                 '',
                 'space/${community.displayId}/admin/${[
-                  'overview',
+                  'profile',
                   'members',
                   'data',
                   'settings',

--- a/client/lib/features/admin/presentation/views/community_admin.dart
+++ b/client/lib/features/admin/presentation/views/community_admin.dart
@@ -72,10 +72,11 @@ class CommunityAdminState extends State<CommunityAdmin>
         SizedBox(width: mobile ? 0 : 8),
         HeightConstrainedText(
           text,
+          textAlign: TextAlign.center,
           style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                fontSize: mobile ? 11 : 16,
+                fontSize: mobile ? 9 : 16,
               ),
-          maxLines: 1,
+          maxLines: 2,
         ),
       ],
     );

--- a/client/lib/features/admin/presentation/views/overview_tab.dart
+++ b/client/lib/features/admin/presentation/views/overview_tab.dart
@@ -68,7 +68,7 @@ class _OverviewTabState extends State<OverviewTab> {
           Align(
             alignment: Alignment.centerLeft,
             child: Padding(
-              padding: EdgeInsets.only(top: 20),
+              padding: EdgeInsets.only(top: 20, left: 8),
               child: Text(
                 label,
                 style: context.theme.textTheme.titleLarge,

--- a/client/lib/features/admin/presentation/views/overview_tab.dart
+++ b/client/lib/features/admin/presentation/views/overview_tab.dart
@@ -20,7 +20,7 @@ import 'package:provider/provider.dart';
 
 class OverviewTab extends StatefulWidget {
   const OverviewTab({super.key});
-  
+
   @override
   State<OverviewTab> createState() => _OverviewTabState();
 }
@@ -68,7 +68,7 @@ class _OverviewTabState extends State<OverviewTab> {
           Align(
             alignment: Alignment.centerLeft,
             child: Padding(
-              padding: EdgeInsets.only(top: 20, left: 8),
+              padding: const EdgeInsets.only(top: 20, left: 8),
               child: Text(
                 label,
                 style: context.theme.textTheme.titleLarge,
@@ -87,7 +87,7 @@ class _OverviewTabState extends State<OverviewTab> {
             child: Align(
               alignment: Alignment.centerLeft,
               child: Padding(
-                padding: EdgeInsets.fromLTRB(50, 30, 0, 0),
+                padding: const EdgeInsets.fromLTRB(50, 30, 0, 0),
                 child: Text(
                   label,
                   style: context.theme.textTheme.titleLarge,
@@ -394,7 +394,12 @@ class _OverviewTabState extends State<OverviewTab> {
 
   Future<void> _removeImage() async {
     setState(() {
-      _community = _community.copyWith(profileImageUrl: generateRandomImageUrl(seed: _community.id.hashCode, resolution: 160));
+      _community = _community.copyWith(
+        profileImageUrl: generateRandomImageUrl(
+          seed: _community.id.hashCode,
+          resolution: 160,
+        ),
+      );
     });
     await cloudFunctionsCommunityService.removeImage(
       community: _community,

--- a/client/lib/features/admin/presentation/views/overview_tab.dart
+++ b/client/lib/features/admin/presentation/views/overview_tab.dart
@@ -108,7 +108,7 @@ class _OverviewTabState extends State<OverviewTab> {
   @override
   Widget build(BuildContext context) {
     final mobile = responsiveLayoutService.isMobile(context);
-    
+
     context.watch<CommunityProvider>();
 
     return Scaffold(
@@ -167,40 +167,45 @@ class _OverviewTabState extends State<OverviewTab> {
                   ),
                   _buildSection(
                     context.l10n.links,
-                    CreateCommunityTextFields(
-                      fieldsView: FieldsView.links,
-                      borderType: BorderType.outline,
-                      // Catch form errors from child widget
-                      onFieldsHaveErrors: (hasErrors) {
-                        WidgetsBinding.instance.addPostFrameCallback((_) {
-                          if (!mounted) return;
-                          setState(() {
-                            _formHasErrors = hasErrors;
+                    Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 8.0,
+                      ),
+                      child: CreateCommunityTextFields(
+                        fieldsView: FieldsView.links,
+                        borderType: BorderType.outline,
+                        // Catch form errors from child widget
+                        onFieldsHaveErrors: (hasErrors) {
+                          WidgetsBinding.instance.addPostFrameCallback((_) {
+                            if (!mounted) return;
+                            setState(() {
+                              _formHasErrors = hasErrors;
+                            });
                           });
-                        });
-                      },
-                      onWebsiteUrlChanged: (value) => {
-                        _community = _community.copyWith(websiteUrl: value),
-                      },
-                      onFacebookUrlChanged: (value) => {
-                        _community = _community.copyWith(facebookUrl: value),
-                      },
-                      onLinkedinUrlChanged: (value) => {
-                        _community = _community.copyWith(linkedinUrl: value),
-                      },
-                      onTwitterUrlChanged: (value) => {
-                        _community = _community.copyWith(twitterUrl: value),
-                      },
-                      onBlueskyUrlChanged: (value) => {
-                        _community = _community.copyWith(blueskyUrl: value),
-                      },
-                      onYoutubeUrlChanged: (value) => {
-                        _community = _community.copyWith(youtubeUrl: value),
-                      },
-                      onInstagramUrlChanged: (value) => {
-                        _community = _community.copyWith(instagramUrl: value),
-                      },
-                      community: _community,
+                        },
+                        onWebsiteUrlChanged: (value) => {
+                          _community = _community.copyWith(websiteUrl: value),
+                        },
+                        onFacebookUrlChanged: (value) => {
+                          _community = _community.copyWith(facebookUrl: value),
+                        },
+                        onLinkedinUrlChanged: (value) => {
+                          _community = _community.copyWith(linkedinUrl: value),
+                        },
+                        onTwitterUrlChanged: (value) => {
+                          _community = _community.copyWith(twitterUrl: value),
+                        },
+                        onBlueskyUrlChanged: (value) => {
+                          _community = _community.copyWith(blueskyUrl: value),
+                        },
+                        onYoutubeUrlChanged: (value) => {
+                          _community = _community.copyWith(youtubeUrl: value),
+                        },
+                        onInstagramUrlChanged: (value) => {
+                          _community = _community.copyWith(instagramUrl: value),
+                        },
+                        community: _community,
+                      ),
                     ),
                     mobile,
                   ),
@@ -214,6 +219,7 @@ class _OverviewTabState extends State<OverviewTab> {
                     Padding(
                       padding: const EdgeInsets.symmetric(
                         vertical: 18.0,
+                        horizontal: 8.0,
                       ),
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,

--- a/client/lib/features/admin/presentation/views/settings_tab.dart
+++ b/client/lib/features/admin/presentation/views/settings_tab.dart
@@ -148,7 +148,7 @@ class _SettingsTabState extends State<SettingsTab> {
           flex: isMobile ? 0 : 2,
           child: Padding(
             padding: EdgeInsets.symmetric(
-              horizontal: isMobile ? 0 : 46,
+              horizontal: isMobile ? 8 : 46,
               vertical: 28,
             ),
             child: helperText,


### PR DESCRIPTION
This fixes #347 by causing a word wrap on tabs at really really small widths (unlikely most users will see it):

<img width="682" height="882" alt="image" src="https://github.com/user-attachments/assets/9eda5b19-d726-475a-a51d-647b58e8d306" />

And fixes #346 by applying margin.

Also fixing #348 by changing the default route and renaming it to `admin/profile`

