### PR TITLE
chore: add .prettierrc.json to firebase/firestore to match functions config

### DIFF
--- a/firebase/firestore/.prettierrc.json
+++ b/firebase/firestore/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "printWidth": 100,
+  "trailingComma": "es5",
+  "tabWidth": 4,
+  "semi": false,
+  "singleQuote": true
+}


### PR DESCRIPTION
## Summary

Fixes the inconsistent Prettier configuration between Firebase modules (closes #351).

**Problem:** `firebase/functions/` had a `.prettierrc.json` with specific rules, but `firebase/firestore/` had none — causing VS Code to apply different auto-formatting, editor conflicts, and yellow squiggles for the same valid code.

**Fix:** Copy the existing `.prettierrc.json` from `firebase/functions/` into `firebase/firestore/` so both modules share identical formatting rules:

```json
{
  "printWidth": 100,
  "trailingComma": "es5",
  "tabWidth": 4,
  "semi": false,
  "singleQuote": true
}
```

This is Option 1 from the issue — minimal change, no restructuring needed.