### PR TITLE
fix(accessibility): remove redundant Semantics label on SelectableLinkify

### DIFF
--- a/client/lib/features/chat/presentation/widgets/message_display.dart
+++ b/client/lib/features/chat/presentation/widgets/message_display.dart
@@ -151,21 +151,17 @@ class MessageDisplayState extends State<MessageDisplay> {
                           // Note: There are highlighting issues due to the below
                           // https://github.com/Cretezy/flutter_linkify/issues/59
                           // https://github.com/Cretezy/flutter_linkify/issues/54
-                          Semantics(
-                            label: context.l10n.chatMessage,
-                            child: SelectableLinkify(
-                              text: widget.message.message ?? '',
-                              style:
-                                  context.theme.textTheme.bodyLarge!.copyWith(
-                                color: Theme.of(context).isDark
-                                    ? context.theme.colorScheme.onPrimary
-                                    : context.theme.colorScheme.primary,
-                              ),
-                              options: LinkifyOptions(looseUrl: true),
-                              onOpen: (link) async {
-                                await launch(link.url);
-                              },
+                          SelectableLinkify(
+                            text: widget.message.message ?? '',
+                            style: context.theme.textTheme.bodyLarge!.copyWith(
+                              color: Theme.of(context).isDark
+                                  ? context.theme.colorScheme.onPrimary
+                                  : context.theme.colorScheme.primary,
                             ),
+                            options: LinkifyOptions(looseUrl: true),
+                            onOpen: (link) async {
+                              await launch(link.url);
+                            },
                           ),
                       ],
                     ),


### PR DESCRIPTION
## Summary

Fixes #340

The outer `Semantics` widget in `MessageDisplayState.build` already labels the entire chat message widget with `context.l10n.chatMessage`. The inner `Semantics` wrapping only the `SelectableLinkify` (raw message text) was redundant and misleading:

- **Redundant:** screen readers announced "chat message" twice on focus — once for the full widget, once for the text fragment alone.
- **Misleading:** the inner label described only the raw text as "chat message", which omits the sender name and timestamp that are part of the semantic whole.

## Change

Removed the inner `Semantics` wrapper from `message_display.dart` lines 154–168. `SelectableLinkify` now renders directly without an additional semantics node; the outer `Semantics` at the widget root still provides the single, correct announcement.

## Testing

No automated widget tests needed — this is a pure semantic tree reduction with no behavior change. Manual verification: focus a chat message with a screen reader and confirm it announces once, not twice.