### PR TITLE
Make the CommunityProvider nullable

### DIFF
--- a/client/lib/core/widgets/navbar/sidebar/sidebar.dart
+++ b/client/lib/core/widgets/navbar/sidebar/sidebar.dart
@@ -159,7 +159,7 @@ class _SideBarState extends State<SideBar> {
         !isInitializedOnHome) {
       final currentCommunity = communities.firstWhere(
         (element) =>
-            context.watch<CommunityProvider>().communityId == element.id,
+            context.watch<CommunityProvider?>()?.communityId == element.id,
       );
 
       communities = [


### PR DESCRIPTION
Fixes #358, an error surfaced by Sentry that I don't believe caused any user-facing errors. Previously there was a boolean expression in a filter that would sometimes try to compare a property of `CommunityProvider` - but sometimes `CommunityProvider` is null, so accessing the property to evaluate the expression would throw an error.

This fix makes the boolean expression return `false` when there's no CommunityProvider available, instead of throwing an error.

## Testing this PR
There's not much to test - I did a smoke test and things were working fine, and you could access nav menus as expected. The real test is whether the bug shows up in production again after this fix is applied.