### PR TITLE
Fix vote_to_kick.dart path typo in function-mapping.json

### DIFF
--- a/.github/workflows/function-mapping.json
+++ b/.github/workflows/function-mapping.json
@@ -164,7 +164,7 @@
     "firebase/functions/lib/events/live_meetings/toggle_like_dislike_on_meeting_user_suggestion.dart": [
       "toggleLikeDislikeOnMeetingUserSuggestion"
     ],
-    "firebase/functions/lib/event/live_meetings/vote_to_kick.dart": [
+    "firebase/functions/lib/events/live_meetings/vote_to_kick.dart": [
       "VoteToKick"
     ],
     "firebase/functions/lib/events/live_meetings/update_presence_status.dart": [

--- a/.github/workflows/function-mapping.json
+++ b/.github/workflows/function-mapping.json
@@ -214,7 +214,7 @@
       "CheckHostlessGoToBreakoutsServer"
     ],
     "firebase/functions/lib/templates/on_template.dart": ["TemplateOnCreate"],
-    "firebase/functions/lib/utils/infra/firestore_event_function": [
+    "firebase/functions/lib/utils/infra/firestore_event_function.dart": [
       "EventOnUpdate",
       "EventOnCreate",
       "DiscussionThreadOnDelete",
@@ -343,7 +343,7 @@
       "TriggerEmailDigests",
       "CalendarFeedRss"
     ],
-    "firebase/functions/lib/utils/template_utils": [
+    "firebase/functions/lib/utils/template_utils.dart": [
       "getCommunityCalendarLink",
       "sendEventMessage",
       "TemplateOnCreate",

--- a/.github/workflows/function-mapping.json
+++ b/.github/workflows/function-mapping.json
@@ -1,100 +1,443 @@
 {
-   "files" : {
-      "firebase/functions/js/download-recordings.js": ["downloadRecording"],
-      "firebase/functions/js/image-proxy.js": ["imageProxy"],      
-      "firebase/functions/lib/admin/partner_agreements/on_partner_agreements.dart": ["PartnerAgreementOnCreate","PartnerAgreementOnUpdate"],
-      "firebase/functions/lib/admin/payments/cancel_stripe_subscription_plan.dart": ["CancelStripeSubscriptionPlan"],
-      "firebase/functions/lib/admin/payments/create_donation_checkout_session.dart": ["createDonationCheckoutSession"],
-      "firebase/functions/lib/admin/payments/create_stripe_connected_account.dart": ["createStripeConnectedAccount"],
-      "firebase/functions/lib/admin/payments/create_subscription_checkout_session.dart": ["CreateSubscriptionCheckoutSession"],
-      "firebase/functions/lib/admin/payments/get_stripe_billing_portal_link.dart": ["getStripeBillingPortalLink"],
-      "firebase/functions/lib/admin/payments/get_stripe_connected_account_link.dart": ["getStripeConnectedAccountLink"],
-      "firebase/functions/lib/admin/payments/get_stripe_subscription_plan_info.dart": ["GetStripeSubscriptionPlanInfo"],
-      "firebase/functions/lib/admin/payments/update_stripe_subscription_plan.dart": ["UpdateStripeSubscriptionPlan"],
-      "firebase/functions/lib/admin/payments/stripe_connected_account_webhooks.dart": ["StripeConnectedAccountWebhooks"],
-      "firebase/functions/lib/admin/payments/stripe_webhooks.dart": ["StripeWebhooks"],
-      "firebase/functions/lib/admin/payments/analytics_util.dart": ["createStripeConnectedAccount", "StripeWebhooks"],
-      "firebase/functions/lib/admin/payments/stripe_util.dart": ["CancelStripeSubscriptionPlan","getStripeBillingPortalLink","getStripeConnectedAccountLink","GetStripeSubscriptionPlanInfo","StripeConnectedAccountWebhooks","StripeWebhooks","UpdateStripeSubscriptionPlan","createStripeConnectedAccount","createDonationCheckoutSession","CreateSubscriptionCheckoutSession"],
-      "firebase/functions/lib/community/create_announcement.dart": ["sendAnnouncement"],
-      "firebase/functions/lib/community/create_community.dart": ["createCommunity"],
-      "firebase/functions/lib/community/get_community_capabilities.dart": ["getCommunityCapabilities"],
-      "firebase/functions/lib/community/get_community_donations_enabled.dart": ["GetCommunityDonationsEnabled"],
-      "firebase/functions/lib/community/get_community_pre_post_enabled.dart": ["GetCommunityPrePostEnabled"],
-      "firebase/functions/lib/community/get_members_data.dart": ["GetMembersData"],
-      "firebase/functions/lib/community/get_user_admin_details.dart": ["GetUserAdminDetails"],
-      "firebase/functions/lib/community/resolve_join_request.dart": ["resolveJoinRequest"],
-      "firebase/functions/lib/community/unsubscribe_from_community_notifications.dart": ["unsubscribeFromCommunityNotifications"],
-      "firebase/functions/lib/community/update_community.dart": ["UpdateCommunity"],
-      "firebase/functions/lib/community/update_membership.dart": ["updateMembership"],
-      "firebase/functions/lib/community/on_community.dart": ["CommunityOnCreate"],
-      "firebase/functions/lib/community/on_community_membership.dart": ["CommunityMembershipOnCreate"],
-      "firebase/functions/lib/community/trigger_email_digests.dart": ["TriggerEmailDigests"],
-      "firebase/functions/lib/discussion_threads/on_discussion_thread.dart": ["DiscussionThreadOnDelete"],
-      "firebase/functions/lib/discussion_threads/on_discussion_thread_comment.dart": ["DiscussionThreadCommentOnCreate","DiscussionThreadCommentOnUpdate","DiscussionThreadCommentOnDelete"],
-      "firebase/functions/lib/events/create_event.dart": ["createEvent"],
-      "firebase/functions/lib/events/event_ended.dart": ["eventEnded"],
-      "firebase/functions/lib/events/join_event.dart": ["joinEvent"],
-      "firebase/functions/lib/events/notifications/email_event_reminder.dart": ["EmailEventReminder"],
-      "firebase/functions/lib/events/notifications/send_event_message.dart": ["sendEventMessage"],
-      "firebase/functions/lib/events/event_emails.dart": ["createEvent", "joinEvent","EventOnUpdate","EventOnCreate","EmailEventReminder"],
-      "firebase/functions/lib/events/on_event.dart": ["EventOnUpdate","EventOnCreate"],
-      "firebase/functions/lib/events/calendar/calendar_feed_ics.dart": ["CalendarFeedIcs"],
-      "firebase/functions/lib/events/calendar/get_calendar_link.dart": ["getCommunityCalendarLink"],
-      "firebase/functions/lib/events/calendar/calendar_feed_rss.dart": ["CalendarFeedRss"],
-      "firebase/functions/lib/events/calendar/rss_util.dart": ["CalendarFeedRss"],
-      "firebase/functions/lib/events/live_meetings/agora_api.dart": ["GetBreakoutRoomJoinInfo","GetMeetingJoinInfo","KickParticipant","VoteToKick"],
-      "firebase/functions/lib/events/live_meetings/create_live_stream.dart": ["CreateLiveStream"],
-      "firebase/functions/lib/events/live_meetings/get_meeting_chat_suggestion_data.dart": ["GetMeetingChatSuggestionData"],
-      "firebase/functions/lib/events/live_meetings/get_meeting_poll_data.dart": ["GetMeetingPollData"],
-      "firebase/functions/lib/events/live_meetings/get_meeting_join_info.dart": ["GetMeetingJoinInfo"],
-      "firebase/functions/lib/events/live_meetings/get_user_id_from_agora_id.dart": ["GetUserIdFromAgoraId"],
-      "firebase/functions/lib/events/live_meetings/kick_participant.dart": ["KickParticipant"],
-      "firebase/functions/lib/events/live_meetings/live_meeting_utils.dart": ["GetBreakoutRoomJoinInfo","GetMeetingJoinInfo"],
-      "firebase/functions/lib/events/live_meetings/reset_participant_agenda_items.dart": ["ResetParticipantAgendaItems"],
-      "firebase/functions/lib/events/live_meetings/toggle_like_dislike_on_meeting_user_suggestion.dart": ["toggleLikeDislikeOnMeetingUserSuggestion"],
-      "firebase/functions/lib/event/live_meetings/vote_to_kick.dart": ["VoteToKick"], 
-      "firebase/functions/lib/events/live_meetings/update_presence_status.dart": ["UpdatePresenceStatus"],
-      "firebase/functions/lib/events/live_meetings/mux_webhooks.dart": ["MuxWebhooks"],
-      "firebase/functions/lib/events/live_meetings/update_live_stream_participant_count.dart": ["UpdateLiveStreamParticipantCount"],
-      "firebase/functions/lib/events/live_meetings/mux_client.dart": ["CreateLiveStream"],
-      "firebase/functions/lib/events/live_meetings/breakouts/check_assign_to_breakouts_server.dart": ["CheckAssignToBreakoutsServer"],
-      "firebase/functions/lib/events/live_meetings/breakouts/assign_to_breakouts.dart": ["CheckAssignToBreakouts", "InitiateBreakouts"],
-      "firebase/functions/lib/events/live_meetings/breakouts/check_advance_meeting_guide.dart": ["CheckAdvanceMeetingGuide"],
-      "firebase/functions/lib/events/live_meetings/breakouts/check_assign_to_breakouts.dart": ["CheckAssignToBreakouts"],
-      "firebase/functions/lib/events/live_meetings/breakouts/check_hostless_go_to_breakouts.dart": ["CheckHostlessGoToBreakouts"],
-      "firebase/functions/lib/events/live_meetings/breakouts/get_breakout_room_assignment.dart": ["GetBreakoutRoomAssignment"],
-      "firebase/functions/lib/events/live_meetings/breakouts/get_breakout_room_join_info.dart": ["GetBreakoutRoomJoinInfo"],
-      "firebase/functions/lib/events/live_meetings/breakouts/initiate_breakouts.dart": ["InitiateBreakouts"],
-      "firebase/functions/lib/events/live_meetings/breakouts/reassign_breakout_room.dart": ["ReassignBreakoutRoom"],
-      "firebase/functions/lib/events/live_meetings/breakouts/update_breakout_room_flag_status.dart": ["UpdateBreakoutRoomFlagStatus"],
-      "firebase/functions/lib/events/live_meetings/breakouts/check_hostless_go_to_breakouts_server.dart": ["CheckHostlessGoToBreakoutsServer"],
-      "firebase/functions/lib/templates/on_template.dart": ["TemplateOnCreate"],
-      "firebase/functions/lib/utils/infra/firestore_event_function": ["EventOnUpdate","EventOnCreate","DiscussionThreadOnDelete", "DiscussionThreadCommentOnCreate","DiscussionThreadCommentOnDelete","DiscussionThreadCommentOnUpdate", "CommunityOnCreate","CommunityMembershipOnCreate","PartnerAgreementOnCreate","PartnerAgreementOnUpdate", "TemplateOnCreate"],
-      "firebase/functions/lib/utils/infra/extend_cloud_task_scheduler.dart": ["ExtendCloudTaskScheduler"],
-      "firebase/functions/lib/utils/infra/on_firestore_helper.dart": ["DiscussionThreadCommentOnCreate","DiscussionThreadCommentOnUpdate","DiscussionThreadCommentOnDelete","EventOnUpdate","EventOnCreate","DiscussionThreadOnDelete","CommunityMembershipOnCreate","PartnerAgreementOnCreate","PartnerAgreementOnUpdate","TemplateOnCreate"],
-      "firebase/functions/lib/utils/infra/scheduled_functions.dart": ["ExtendCloudTaskScheduler","CheckAssignToBreakoutsServer","CheckHostlessGoToBreakoutsServer","EmailEventReminder","ExtendCloudTaskScheduler","MuxWebhooks","StripeConnectedAccountWebhooks","StripeWebhooks"],
-      "firebase/functions/lib/utils/get_server_timestamp.dart": ["GetServerTimestamp"],
-      "firebase/functions/lib/utils/server_timestamp.dart": ["serverTimestamp"],
-      "firebase/functions/lib/utils/share_link.dart": ["ShareLink"],
-      "firebase/functions/lib/utils/calendar_link_util.dart": ["getCommunityCalendarLink", "sendAnnouncement","eventEnded","resolveJoinRequest", "sendEventMessage","TriggerEmailDigests","createEvent", "joinEvent","EventOnUpdate","EventOnCreate","EmailEventReminder"],
-      "firebase/functions/lib/utils/email_templates.dart" : ["sendAnnouncement","eventEnded","resolveJoinRequest", "sendEventMessage","TriggerEmailDigests","createEvent", "joinEvent","EventOnUpdate","EventOnCreate","EmailEventReminder"],
-      "firebase/functions/lib/utils/ics_util.dart" : [ "CalendarFeedIcs"],
-      "firebase/functions/lib/utils/notifications_utils.dart" : ["sendAnnouncement","eventEnded","sendEventMessage","unsubscribeFromCommunityNotifications","TriggerEmailDigests"],
-      "firebase/functions/lib/utils/onboarding_steps_helper.dart": ["DiscussionThreadCommentOnCreate","DiscussionThreadCommentOnUpdate","DiscussionThreadCommentOnDelete","EventOnUpdate","EventOnCreate","DiscussionThreadOnDelete","CommunityMembershipOnCreate","PartnerAgreementOnCreate","PartnerAgreementOnUpdate","TemplateOnCreate"],
-      "firebase/functions/lib/utils/send_email_client.dart": ["resolveJoinRequest","TriggerEmailDigests","createEvent", "joinEvent","EventOnUpdate","EventOnCreate","EmailEventReminder","sendAnnouncement","eventEnded","sendEventMessage","unsubscribeFromCommunityNotifications"],
-      "firebase/functions/lib/utils/subscription_plan_util.dart": ["createDonationCheckoutSession","eventEnded","getCommunityCapabilities","GetCommunityDonationsEnabled","GetCommunityPrePostEnabled","UpdateCommunity","UpdateMembership","createEvent", "joinEvent","EventOnUpdate","EventOnCreate","EmailEventReminder"],
-      "firebase/functions/lib/utils/timezone_utils.dart": ["ShareLink","createEvent", "joinEvent","EventOnUpdate","EventOnCreate","EmailEventReminder","sendAnnouncement","eventEnded","resolveJoinRequest", "sendEventMessage","TriggerEmailDigests","CalendarFeedRss"],
-      "firebase/functions/lib/utils/template_utils": ["getCommunityCalendarLink", "sendEventMessage","TemplateOnCreate","ShareLink", "TriggerEmailDigests"],
-      "matching/lib/matching.dart": ["CheckAssignToBreakouts", "InitiateBreakouts"]
-   },
-   "groups" : {
-      "event": ["EventOnUpdate","EventOnCreate","DiscussionThreadOnDelete", "DiscussionThreadCommentOnCreate","DiscussionThreadCommentOnDelete","DiscussionThreadCommentOnUpdate", "CommunityOnCreate","CommunityMembershipOnCreate","PartnerAgreementOnCreate","PartnerAgreementOnUpdate", "TemplateOnCreate"],
-      "request" : ["CalendarFeedIcs","CalendarFeedRss","CheckAssignToBreakoutsServer","CheckHostlessGoToBreakoutsServer","EmailEventReminder","ExtendCloudTaskScheduler","MuxWebhooks","ShareLink"],
-      "helperdbpubsub": ["downloadRecording", "imageProxy","UpdatePresenceStatus","TriggerEmailDigests","UpdateLiveStreamParticipantCount"], 
-      "oncall1": ["CheckAdvanceMeetingGuide","CheckAssignToBreakouts","CheckHostlessGoToBreakouts","sendAnnouncement","createEvent","createCommunity","CreateLiveStream","updateMembership","VoteToKick","eventEnded","getCommunityCalendarLink","InitiateBreakouts"],
-      "oncall2": ["GetBreakoutRoomAssignment","GetBreakoutRoomJoinInfo","getCommunityCapabilities","GetCommunityDonationsEnabled","GetCommunityPrePostEnabled","GetMeetingChatSuggestionData","GetMeetingPollData","GetMeetingJoinInfo","GetMembersData","GetServerTimestamp","GetUserAdminDetails","GetUserIdFromAgoraId"],
-      "oncall3": ["joinEvent","ReassignBreakoutRoom","ResetParticipantAgendaItems","resolveJoinRequest","sendEventMessage","serverTimestamp","toggleLikeDislikeOnMeetingUserSuggestion","KickParticipant","unsubscribeFromCommunityNotifications","UpdateBreakoutRoomFlagStatus","UpdateCommunity"],
-      "stripe" : ["CancelStripeSubscriptionPlan","getStripeBillingPortalLink","getStripeConnectedAccountLink","GetStripeSubscriptionPlanInfo","StripeConnectedAccountWebhooks","StripeWebhooks","UpdateStripeSubscriptionPlan","createStripeConnectedAccount","createDonationCheckoutSession","CreateSubscriptionCheckoutSession"]
-   }
-  
+  "files": {
+    "firebase/functions/js/download-recordings.js": ["downloadRecording"],
+    "firebase/functions/js/image-proxy.js": ["imageProxy"],
+    "firebase/functions/lib/admin/partner_agreements/on_partner_agreements.dart": [
+      "PartnerAgreementOnCreate",
+      "PartnerAgreementOnUpdate"
+    ],
+    "firebase/functions/lib/admin/payments/cancel_stripe_subscription_plan.dart": [
+      "CancelStripeSubscriptionPlan"
+    ],
+    "firebase/functions/lib/admin/payments/create_donation_checkout_session.dart": [
+      "createDonationCheckoutSession"
+    ],
+    "firebase/functions/lib/admin/payments/create_stripe_connected_account.dart": [
+      "createStripeConnectedAccount"
+    ],
+    "firebase/functions/lib/admin/payments/create_subscription_checkout_session.dart": [
+      "CreateSubscriptionCheckoutSession"
+    ],
+    "firebase/functions/lib/admin/payments/get_stripe_billing_portal_link.dart": [
+      "getStripeBillingPortalLink"
+    ],
+    "firebase/functions/lib/admin/payments/get_stripe_connected_account_link.dart": [
+      "getStripeConnectedAccountLink"
+    ],
+    "firebase/functions/lib/admin/payments/get_stripe_subscription_plan_info.dart": [
+      "GetStripeSubscriptionPlanInfo"
+    ],
+    "firebase/functions/lib/admin/payments/update_stripe_subscription_plan.dart": [
+      "UpdateStripeSubscriptionPlan"
+    ],
+    "firebase/functions/lib/admin/payments/stripe_connected_account_webhooks.dart": [
+      "StripeConnectedAccountWebhooks"
+    ],
+    "firebase/functions/lib/admin/payments/stripe_webhooks.dart": [
+      "StripeWebhooks"
+    ],
+    "firebase/functions/lib/admin/payments/analytics_util.dart": [
+      "createStripeConnectedAccount",
+      "StripeWebhooks"
+    ],
+    "firebase/functions/lib/admin/payments/stripe_util.dart": [
+      "CancelStripeSubscriptionPlan",
+      "getStripeBillingPortalLink",
+      "getStripeConnectedAccountLink",
+      "GetStripeSubscriptionPlanInfo",
+      "StripeConnectedAccountWebhooks",
+      "StripeWebhooks",
+      "UpdateStripeSubscriptionPlan",
+      "createStripeConnectedAccount",
+      "createDonationCheckoutSession",
+      "CreateSubscriptionCheckoutSession"
+    ],
+    "firebase/functions/lib/community/create_announcement.dart": [
+      "sendAnnouncement"
+    ],
+    "firebase/functions/lib/community/create_community.dart": [
+      "createCommunity"
+    ],
+    "firebase/functions/lib/community/get_community_capabilities.dart": [
+      "getCommunityCapabilities"
+    ],
+    "firebase/functions/lib/community/get_community_donations_enabled.dart": [
+      "GetCommunityDonationsEnabled"
+    ],
+    "firebase/functions/lib/community/get_community_pre_post_enabled.dart": [
+      "GetCommunityPrePostEnabled"
+    ],
+    "firebase/functions/lib/community/get_members_data.dart": [
+      "GetMembersData"
+    ],
+    "firebase/functions/lib/community/get_user_admin_details.dart": [
+      "GetUserAdminDetails"
+    ],
+    "firebase/functions/lib/community/resolve_join_request.dart": [
+      "resolveJoinRequest"
+    ],
+    "firebase/functions/lib/community/unsubscribe_from_community_notifications.dart": [
+      "unsubscribeFromCommunityNotifications"
+    ],
+    "firebase/functions/lib/community/update_community.dart": [
+      "UpdateCommunity"
+    ],
+    "firebase/functions/lib/community/update_membership.dart": [
+      "updateMembership"
+    ],
+    "firebase/functions/lib/community/on_community.dart": ["CommunityOnCreate"],
+    "firebase/functions/lib/community/on_community_membership.dart": [
+      "CommunityMembershipOnCreate"
+    ],
+    "firebase/functions/lib/community/trigger_email_digests.dart": [
+      "TriggerEmailDigests"
+    ],
+    "firebase/functions/lib/discussion_threads/on_discussion_thread.dart": [
+      "DiscussionThreadOnDelete"
+    ],
+    "firebase/functions/lib/discussion_threads/on_discussion_thread_comment.dart": [
+      "DiscussionThreadCommentOnCreate",
+      "DiscussionThreadCommentOnUpdate",
+      "DiscussionThreadCommentOnDelete"
+    ],
+    "firebase/functions/lib/events/create_event.dart": ["createEvent"],
+    "firebase/functions/lib/events/event_ended.dart": ["eventEnded"],
+    "firebase/functions/lib/events/join_event.dart": ["joinEvent"],
+    "firebase/functions/lib/events/notifications/email_event_reminder.dart": [
+      "EmailEventReminder"
+    ],
+    "firebase/functions/lib/events/notifications/send_event_message.dart": [
+      "sendEventMessage"
+    ],
+    "firebase/functions/lib/events/event_emails.dart": [
+      "createEvent",
+      "joinEvent",
+      "EventOnUpdate",
+      "EventOnCreate",
+      "EmailEventReminder"
+    ],
+    "firebase/functions/lib/events/on_event.dart": [
+      "EventOnUpdate",
+      "EventOnCreate"
+    ],
+    "firebase/functions/lib/events/calendar/calendar_feed_ics.dart": [
+      "CalendarFeedIcs"
+    ],
+    "firebase/functions/lib/events/calendar/get_calendar_link.dart": [
+      "getCommunityCalendarLink"
+    ],
+    "firebase/functions/lib/events/calendar/calendar_feed_rss.dart": [
+      "CalendarFeedRss"
+    ],
+    "firebase/functions/lib/events/calendar/rss_util.dart": ["CalendarFeedRss"],
+    "firebase/functions/lib/events/live_meetings/agora_api.dart": [
+      "GetBreakoutRoomJoinInfo",
+      "GetMeetingJoinInfo",
+      "KickParticipant",
+      "VoteToKick"
+    ],
+    "firebase/functions/lib/events/live_meetings/create_live_stream.dart": [
+      "CreateLiveStream"
+    ],
+    "firebase/functions/lib/events/live_meetings/get_meeting_chat_suggestion_data.dart": [
+      "GetMeetingChatSuggestionData"
+    ],
+    "firebase/functions/lib/events/live_meetings/get_meeting_poll_data.dart": [
+      "GetMeetingPollData"
+    ],
+    "firebase/functions/lib/events/live_meetings/get_meeting_join_info.dart": [
+      "GetMeetingJoinInfo"
+    ],
+    "firebase/functions/lib/events/live_meetings/get_user_id_from_agora_id.dart": [
+      "GetUserIdFromAgoraId"
+    ],
+    "firebase/functions/lib/events/live_meetings/kick_participant.dart": [
+      "KickParticipant"
+    ],
+    "firebase/functions/lib/events/live_meetings/live_meeting_utils.dart": [
+      "GetBreakoutRoomJoinInfo",
+      "GetMeetingJoinInfo"
+    ],
+    "firebase/functions/lib/events/live_meetings/reset_participant_agenda_items.dart": [
+      "ResetParticipantAgendaItems"
+    ],
+    "firebase/functions/lib/events/live_meetings/toggle_like_dislike_on_meeting_user_suggestion.dart": [
+      "toggleLikeDislikeOnMeetingUserSuggestion"
+    ],
+    "firebase/functions/lib/event/live_meetings/vote_to_kick.dart": [
+      "VoteToKick"
+    ],
+    "firebase/functions/lib/events/live_meetings/update_presence_status.dart": [
+      "UpdatePresenceStatus"
+    ],
+    "firebase/functions/lib/events/live_meetings/mux_webhooks.dart": [
+      "MuxWebhooks"
+    ],
+    "firebase/functions/lib/events/live_meetings/update_live_stream_participant_count.dart": [
+      "UpdateLiveStreamParticipantCount"
+    ],
+    "firebase/functions/lib/events/live_meetings/mux_client.dart": [
+      "CreateLiveStream"
+    ],
+    "firebase/functions/lib/events/live_meetings/breakouts/check_assign_to_breakouts_server.dart": [
+      "CheckAssignToBreakoutsServer"
+    ],
+    "firebase/functions/lib/events/live_meetings/breakouts/assign_to_breakouts.dart": [
+      "CheckAssignToBreakouts",
+      "InitiateBreakouts"
+    ],
+    "firebase/functions/lib/events/live_meetings/breakouts/check_advance_meeting_guide.dart": [
+      "CheckAdvanceMeetingGuide"
+    ],
+    "firebase/functions/lib/events/live_meetings/breakouts/check_assign_to_breakouts.dart": [
+      "CheckAssignToBreakouts"
+    ],
+    "firebase/functions/lib/events/live_meetings/breakouts/check_hostless_go_to_breakouts.dart": [
+      "CheckHostlessGoToBreakouts"
+    ],
+    "firebase/functions/lib/events/live_meetings/breakouts/get_breakout_room_assignment.dart": [
+      "GetBreakoutRoomAssignment"
+    ],
+    "firebase/functions/lib/events/live_meetings/breakouts/get_breakout_room_join_info.dart": [
+      "GetBreakoutRoomJoinInfo"
+    ],
+    "firebase/functions/lib/events/live_meetings/breakouts/initiate_breakouts.dart": [
+      "InitiateBreakouts"
+    ],
+    "firebase/functions/lib/events/live_meetings/breakouts/reassign_breakout_room.dart": [
+      "ReassignBreakoutRoom"
+    ],
+    "firebase/functions/lib/events/live_meetings/breakouts/update_breakout_room_flag_status.dart": [
+      "UpdateBreakoutRoomFlagStatus"
+    ],
+    "firebase/functions/lib/events/live_meetings/breakouts/check_hostless_go_to_breakouts_server.dart": [
+      "CheckHostlessGoToBreakoutsServer"
+    ],
+    "firebase/functions/lib/templates/on_template.dart": ["TemplateOnCreate"],
+    "firebase/functions/lib/utils/infra/firestore_event_function": [
+      "EventOnUpdate",
+      "EventOnCreate",
+      "DiscussionThreadOnDelete",
+      "DiscussionThreadCommentOnCreate",
+      "DiscussionThreadCommentOnDelete",
+      "DiscussionThreadCommentOnUpdate",
+      "CommunityOnCreate",
+      "CommunityMembershipOnCreate",
+      "PartnerAgreementOnCreate",
+      "PartnerAgreementOnUpdate",
+      "TemplateOnCreate"
+    ],
+    "firebase/functions/lib/utils/infra/extend_cloud_task_scheduler.dart": [
+      "ExtendCloudTaskScheduler"
+    ],
+    "firebase/functions/lib/utils/infra/on_firestore_helper.dart": [
+      "DiscussionThreadCommentOnCreate",
+      "DiscussionThreadCommentOnUpdate",
+      "DiscussionThreadCommentOnDelete",
+      "EventOnUpdate",
+      "EventOnCreate",
+      "DiscussionThreadOnDelete",
+      "CommunityMembershipOnCreate",
+      "PartnerAgreementOnCreate",
+      "PartnerAgreementOnUpdate",
+      "TemplateOnCreate"
+    ],
+    "firebase/functions/lib/utils/infra/scheduled_functions.dart": [
+      "ExtendCloudTaskScheduler",
+      "CheckAssignToBreakoutsServer",
+      "CheckHostlessGoToBreakoutsServer",
+      "EmailEventReminder",
+      "ExtendCloudTaskScheduler",
+      "MuxWebhooks",
+      "StripeConnectedAccountWebhooks",
+      "StripeWebhooks"
+    ],
+    "firebase/functions/lib/utils/get_server_timestamp.dart": [
+      "GetServerTimestamp"
+    ],
+    "firebase/functions/lib/utils/server_timestamp.dart": ["serverTimestamp"],
+    "firebase/functions/lib/utils/share_link.dart": ["ShareLink"],
+    "firebase/functions/lib/utils/calendar_link_util.dart": [
+      "getCommunityCalendarLink",
+      "sendAnnouncement",
+      "eventEnded",
+      "resolveJoinRequest",
+      "sendEventMessage",
+      "TriggerEmailDigests",
+      "createEvent",
+      "joinEvent",
+      "EventOnUpdate",
+      "EventOnCreate",
+      "EmailEventReminder"
+    ],
+    "firebase/functions/lib/utils/email_templates.dart": [
+      "sendAnnouncement",
+      "eventEnded",
+      "resolveJoinRequest",
+      "sendEventMessage",
+      "TriggerEmailDigests",
+      "createEvent",
+      "joinEvent",
+      "EventOnUpdate",
+      "EventOnCreate",
+      "EmailEventReminder"
+    ],
+    "firebase/functions/lib/utils/ics_util.dart": ["CalendarFeedIcs"],
+    "firebase/functions/lib/utils/notifications_utils.dart": [
+      "sendAnnouncement",
+      "eventEnded",
+      "sendEventMessage",
+      "unsubscribeFromCommunityNotifications",
+      "TriggerEmailDigests"
+    ],
+    "firebase/functions/lib/utils/onboarding_steps_helper.dart": [
+      "DiscussionThreadCommentOnCreate",
+      "DiscussionThreadCommentOnUpdate",
+      "DiscussionThreadCommentOnDelete",
+      "EventOnUpdate",
+      "EventOnCreate",
+      "DiscussionThreadOnDelete",
+      "CommunityMembershipOnCreate",
+      "PartnerAgreementOnCreate",
+      "PartnerAgreementOnUpdate",
+      "TemplateOnCreate"
+    ],
+    "firebase/functions/lib/utils/send_email_client.dart": [
+      "resolveJoinRequest",
+      "TriggerEmailDigests",
+      "createEvent",
+      "joinEvent",
+      "EventOnUpdate",
+      "EventOnCreate",
+      "EmailEventReminder",
+      "sendAnnouncement",
+      "eventEnded",
+      "sendEventMessage",
+      "unsubscribeFromCommunityNotifications"
+    ],
+    "firebase/functions/lib/utils/subscription_plan_util.dart": [
+      "createDonationCheckoutSession",
+      "eventEnded",
+      "getCommunityCapabilities",
+      "GetCommunityDonationsEnabled",
+      "GetCommunityPrePostEnabled",
+      "UpdateCommunity",
+      "UpdateMembership",
+      "createEvent",
+      "joinEvent",
+      "EventOnUpdate",
+      "EventOnCreate",
+      "EmailEventReminder"
+    ],
+    "firebase/functions/lib/utils/timezone_utils.dart": [
+      "ShareLink",
+      "createEvent",
+      "joinEvent",
+      "EventOnUpdate",
+      "EventOnCreate",
+      "EmailEventReminder",
+      "sendAnnouncement",
+      "eventEnded",
+      "resolveJoinRequest",
+      "sendEventMessage",
+      "TriggerEmailDigests",
+      "CalendarFeedRss"
+    ],
+    "firebase/functions/lib/utils/template_utils": [
+      "getCommunityCalendarLink",
+      "sendEventMessage",
+      "TemplateOnCreate",
+      "ShareLink",
+      "TriggerEmailDigests"
+    ],
+    "matching/lib/matching.dart": [
+      "CheckAssignToBreakouts",
+      "InitiateBreakouts"
+    ]
+  },
+  "groups": {
+    "event": [
+      "EventOnUpdate",
+      "EventOnCreate",
+      "DiscussionThreadOnDelete",
+      "DiscussionThreadCommentOnCreate",
+      "DiscussionThreadCommentOnDelete",
+      "DiscussionThreadCommentOnUpdate",
+      "CommunityOnCreate",
+      "CommunityMembershipOnCreate",
+      "PartnerAgreementOnCreate",
+      "PartnerAgreementOnUpdate",
+      "TemplateOnCreate"
+    ],
+    "request": [
+      "CalendarFeedIcs",
+      "CalendarFeedRss",
+      "CheckAssignToBreakoutsServer",
+      "CheckHostlessGoToBreakoutsServer",
+      "EmailEventReminder",
+      "ExtendCloudTaskScheduler",
+      "MuxWebhooks",
+      "ShareLink"
+    ],
+    "helperdbpubsub": [
+      "downloadRecording",
+      "imageProxy",
+      "UpdatePresenceStatus",
+      "TriggerEmailDigests",
+      "UpdateLiveStreamParticipantCount"
+    ],
+    "oncall1": [
+      "CheckAdvanceMeetingGuide",
+      "CheckAssignToBreakouts",
+      "CheckHostlessGoToBreakouts",
+      "sendAnnouncement",
+      "createEvent",
+      "createCommunity",
+      "CreateLiveStream",
+      "updateMembership",
+      "VoteToKick",
+      "eventEnded",
+      "getCommunityCalendarLink",
+      "InitiateBreakouts"
+    ],
+    "oncall2": [
+      "GetBreakoutRoomAssignment",
+      "GetBreakoutRoomJoinInfo",
+      "getCommunityCapabilities",
+      "GetCommunityDonationsEnabled",
+      "GetCommunityPrePostEnabled",
+      "GetMeetingChatSuggestionData",
+      "GetMeetingPollData",
+      "GetMeetingJoinInfo",
+      "GetMembersData",
+      "GetServerTimestamp",
+      "GetUserAdminDetails",
+      "GetUserIdFromAgoraId"
+    ],
+    "oncall3": [
+      "joinEvent",
+      "ReassignBreakoutRoom",
+      "ResetParticipantAgendaItems",
+      "resolveJoinRequest",
+      "sendEventMessage",
+      "serverTimestamp",
+      "toggleLikeDislikeOnMeetingUserSuggestion",
+      "KickParticipant",
+      "unsubscribeFromCommunityNotifications",
+      "UpdateBreakoutRoomFlagStatus",
+      "UpdateCommunity"
+    ],
+    "stripe": [
+      "CancelStripeSubscriptionPlan",
+      "getStripeBillingPortalLink",
+      "getStripeConnectedAccountLink",
+      "GetStripeSubscriptionPlanInfo",
+      "StripeConnectedAccountWebhooks",
+      "StripeWebhooks",
+      "UpdateStripeSubscriptionPlan",
+      "createStripeConnectedAccount",
+      "createDonationCheckoutSession",
+      "CreateSubscriptionCheckoutSession"
+    ]
+  }
 }


### PR DESCRIPTION
## What is in this PR?

Currently, if we make changes to the VoteToKick firebase function, it won't trigger an auto redeploy of the functions upon push because of a typo in the function mapping listing; the path was `lib/event/` instead of `lib/events`. I noticed this when I was figuring out the downloadRecording function but wanted to separate it out so it's trivial to check.

## Changes in the codebase

Saving the file triggered a Prettier autoformat, so that's the first commit with no actual changes.
The second commit is just a 1 character fix of that typo:
`.github/workflows/function-mapping.json` line 55.

## Changes outside the codebase

None.

## Testing this PR

Not needed.

## Additional information

None.