### PR TITLE
Adding a link to the event editing page from event data

### DIFF
--- a/client/lib/features/admin/presentation/views/data_tab.dart
+++ b/client/lib/features/admin/presentation/views/data_tab.dart
@@ -288,6 +288,7 @@ class _DataTabState extends State<DataTab> {
             backgroundColor:
                 context.theme.colorScheme.surfaceContainerHighest,
             contentPadding: EdgeInsets.zero,
+            actionsPadding: const EdgeInsets.fromLTRB(8, 8, 8, 8),
             titlePadding: const EdgeInsets.fromLTRB(24, 24, 24, 48),
             content: Material(
               color: context.theme.colorScheme.surfaceContainer,
@@ -313,6 +314,39 @@ class _DataTabState extends State<DataTab> {
                           ),
                         title: Text(context.l10n.registrationDataDownload),
                       ),
+                    Container(
+                      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                      child: SizedBox(
+                        width: 200,
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                              Text(
+                                context.l10n.otherDataDownload,
+                                style: context.theme.textTheme.bodySmall,
+                              ),
+                              TextButton(
+                                onPressed: () {
+                                  routerDelegate.beamTo(
+                                    CommunityPageRoutes(
+                                      communityDisplayId:
+                                          CommunityProvider.readOrNull(context)?.displayId ??
+                                              event.communityId,
+                                    ).eventPage(
+                                      templateId: event.templateId,
+                                      eventId: event.id,
+                                    ),
+                                  );
+                                },
+                                child: Text(
+                                  context.l10n.otherDataDownloadAction,
+                                  style: context.theme.textTheme.bodySmall,
+                                ),
+                              ),
+                          ],
+                        ),
+                      ),
+                    ),
                   ],
                 ),
               ),

--- a/client/lib/l10n/app_en.arb
+++ b/client/lib/l10n/app_en.arb
@@ -570,6 +570,8 @@
   "onboardingInviteSomeoneSubtitle": "Follow along for upcoming events, resources, and more.",
   "optional": "Optional",
   "or": "Or",
+  "otherDataDownload": "Chats and polls can be downloaded on the event editing page. In a future release they will be available via this page.",
+  "otherDataDownloadAction": "Download chats and polls",
   "outlookCalendar": "Outlook Calendar",
   "owner": "Owner",
   "participant": "Participant",


### PR DESCRIPTION
This adds a piece of text and a button to link to the event editing page so a user in the current release can find chat and poll data. This will be removed once we unify the download functionality into the event data tab.

<img width="748" height="778" alt="image" src="https://github.com/user-attachments/assets/e1f4f4b0-4de3-4fc7-91a0-c716a2b27b3f" />
