### PR TITLE
Replace "**" functions ignore that blocked all Cloud Functions deploys since Mar 11

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -95,7 +95,25 @@
     {
       "source": "firebase/functions",
       "codebase": "default",
-      "ignore": ["**", "node_modules", ".git"]
+      "ignore": [
+        "node_modules",
+        ".git",
+        ".dart_tool",
+        "packages",
+        "lib",
+        "test",
+        ".build.manifest",
+        ".packages",
+        "*.dart",
+        "*.yaml",
+        "*.lock",
+        "*.sh",
+        "*.md",
+        "*.example",
+        "*.local",
+        "firebase-debug.log",
+        "firebase-debug.*.log"
+      ]
     }
   ],
   "database": {


### PR DESCRIPTION
## What is in this PR?

This PR restores settings so that our build pipeline will once again automatically build and deploy firebase functions changes.

## Changes in the codebase

Since commit `c385c163` from `mw/dev/fix-and-simplify-local-dev` (PR #337, merged Mar 24, "just don't auto-rebuild, too much unexpected behavior"), the `functions[].ignore` array in `firebase.json` has been set to:

```json
"ignore": ["**", "node_modules", ".git"]
```

The `"**"` glob matches every file. This causes the Firebase CLI to upload an essentially empty source zip (only the injected `.runtimeconfig.json`). When GCF receives this, it can't find `package.json`, falls back to looking for `function.js` as the entry point, and fails with:

```
Build failed: function.js does not exist
```

Every automated Cloud Functions deploy on staging has been broken since Mar 11 (hence all the manual functions deploys I was having to do with recordings). This includes:

- Deploy runs #121 and #122 (PR #316, Mar 25)
- Deploy run #128 (PR #352, Apr 8)

Deploys that appeared to succeed during this period only deployed client/docs changes and never triggered the functions deploy path.

### Fix

Replace `"**"` with a targeted ignore list that excludes Dart source, tests, and build intermediates while preserving the files GCF needs at runtime:

- `package.json` (entry point resolution via `"main"` field)
- `build/node/main.dart.js` (compiled Dart functions)
- `build/js/` (JS function files referenced by the compiled Dart)
- `js/` (original JS source, referenced via `require("../js/...")`)
- `node_modules/` (installed by GCF during build — excluded from upload as usual)

## Changes outside the codebase

This change alone won't trigger a functions deploy (the paths filter doesn't include `firebase.json`). After merging, I'll execute a GH workflow_dispatch to manually trigger "Deploy Firebase Components to Staging" with no inputs. This will deploy all functions with the accumulated code changes from PRs #316 and #352 and hopefully get us back on track.

## Reviewing / testing this PR

### What to verify

The `functions[].ignore` array in `firebase.json` controls which files the Firebase CLI excludes when packaging the source zip for GCF. The CLI uses `minimatch` with `{matchBase: true, dot: true}`, which means bare names like `"lib"` match the directory entry itself (preventing recursion into it), and `"*.dart"` matches any `.dart` file at any depth.

**These files MUST be included** (without them, deploy fails):

- `package.json` — GCF reads `"main"` to find the entry point
- `build/node/main.dart.js` — compiled Dart → JS functions
- `build/js/*.js` — JS functions (`download-recordings.js`, `image-proxy.js`)
- `js/*.js` — same JS files, referenced via `require("../js/...")` from compiled output

**These dirs/files SHOULD be excluded** (unnecessary for runtime, wastes upload size):

- `lib`, `test`, `node` — Dart source dirs (~2 MB)
- `packages`, `.dart_tool` — Dart build tooling (~85 MB)
- `*.dart`, `*.yaml`, `*.lock`, `*.sh` — source/config files (small)
- `.build.manifest`, `.packages` — build intermediates (small)

### History of the ignore list

- `084637a4` from `mw/dev/fix-and-simplify-local-dev` (PR #337, merged Mar 24) — `["node_modules", ".git", "firebase-debug.log", ...]` — **Working**, but uploads everything including 85MB of build intermediates
- `090969d9` from `mw/dev/fix-and-simplify-local-dev` (PR #337, merged Mar 24, "ignore irrelevant files to avoid triggering build every branch change") — added `"*.json"`, `"js/**"`, `"node/**"`, etc. — **Broken**: `"*.json"` excludes `package.json`
- `c385c163` from `mw/dev/fix-and-simplify-local-dev` (PR #337, merged Mar 24, "just don't auto-rebuild, too much unexpected behavior") — `["**", "node_modules", ".git"]` — **Broken**: `"**"` excludes all files
- This PR — targeted list (see diff) — **Working**: includes runtime files, excludes source/intermediates, saves ~85MB upload

Note: `090969d9` was also broken (it excluded `package.json` via `"*.json"`), but `c385c163` replaced it the same day so it was never tested in a real deploy.

## Additional information

A few weeks back I accidentally merged some code that I was using as a temporary workaround sanity check. Initially that OVER deployed (uploaded intermediates and such). Then, in changing it back, I did a quick temporary fix to test it without re-deployments, but left the change in, preventing any functions changes from deploying except via manual push to firebase. After that, we were no longer auto-deploying back end changes to firebase / GCS via our normal GitHub build process that happens automatically for PRs.