### PR TITLE
fix: rm Join Time column from event data exports.

### DIFF
--- a/client/lib/features/events/features/event_page/data/providers/event_provider.dart
+++ b/client/lib/features/events/features/event_page/data/providers/event_provider.dart
@@ -379,7 +379,6 @@ class EventProvider with ChangeNotifier {
     firstRow.add('Email');
     firstRow.add('Member Status');
     firstRow.add('RSVP Time');
-    firstRow.add('Join Time');
     firstRow.add('Room Assigned');
     rows.add(firstRow);
 
@@ -403,15 +402,6 @@ class EventProvider with ChangeNotifier {
       );
       row.add(
         registrationData[i].memberEvent?.participant?.createdDate?.toUtc(),
-      );
-
-      // Added Join Time field from Participant.mostRecentPresentTime
-      row.add(
-        registrationData[i]
-            .memberEvent
-            ?.participant
-            ?.mostRecentPresentTime
-            ?.toUtc(),
       );
 
       // Added Room Assigned field from Participant.currentBreakoutRoomId


### PR DESCRIPTION
fix: rm Join Time column from event data export as "mostRecentPresentTime" just returns the timestamp when the admin user requests the data download - not the actual most recent presence time.

## What is in this PR?
<!-- What is the goal of this PR? What steps are involved in achieving that goal? -->
Removed Join Time column from event data export.

## Changes in the codebase
<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

* 

## Changes outside the codebase
<!-- If you have made changes to external services, need to add additional values to the job settings, or need to add something new to the database, explain it here. This may include updates to third-party services, changes to infrastructure configuration, integration with external APIs, etc. -->

* 

## Testing this PR
<!-- Give your reviewer some context or recommendations on how to test your work. -->


## Additional information
<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->

