### PR TITLE
Always use project-pinned toolchain rather than system versions

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR"
+
+CLIENT_DIR="$REPO_ROOT/client"
+DATA_MODELS_DIR="$REPO_ROOT/data_models"
+FUNCTIONS_DIR="$REPO_ROOT/firebase/functions"
+
+FVM_FLUTTER_BIN="$CLIENT_DIR/.fvm/flutter_sdk/bin/flutter"
+FVM_DART_BIN="$CLIENT_DIR/.fvm/flutter_sdk/bin/dart"
+
+if [ -x "$FVM_FLUTTER_BIN" ] && [ -x "$FVM_DART_BIN" ]; then
+  FLUTTER_CMD="$FVM_FLUTTER_BIN"
+  DART_CMD="$FVM_DART_BIN"
+else
+  FLUTTER_CMD="flutter"
+  DART_CMD="dart"
+fi
+
+flutter_version="$($FLUTTER_CMD --version 2>/dev/null || true)"
+flutter_version="${flutter_version%%$'\n'*}"
+printf '\n[build-all] Using Flutter: %s\n' "$flutter_version"
+printf '[build-all] Using Dart: %s\n\n' "$($DART_CMD --version 2>&1)"
+
+cd "$CLIENT_DIR"
+"$FLUTTER_CMD" pub get
+
+cd "$DATA_MODELS_DIR"
+"$FLUTTER_CMD" pub get
+"$DART_CMD" run build_runner build --delete-conflicting-outputs
+
+cd "$FUNCTIONS_DIR"
+npm install
+"$FLUTTER_CMD" pub get
+"$DART_CMD" run build_runner build --output=build

--- a/build-all.sh
+++ b/build-all.sh
@@ -19,10 +19,10 @@ else
   DART_CMD="dart"
 fi
 
-flutter_version="$($FLUTTER_CMD --version 2>/dev/null || true)"
+flutter_version="$("$FLUTTER_CMD" --version 2>/dev/null || true)"
 flutter_version="${flutter_version%%$'\n'*}"
 printf '\n[build-all] Using Flutter: %s\n' "$flutter_version"
-printf '[build-all] Using Dart: %s\n\n' "$($DART_CMD --version 2>&1)"
+printf '[build-all] Using Dart: %s\n\n' "$("$DART_CMD" --version 2>&1)"
 
 cd "$CLIENT_DIR"
 "$FLUTTER_CMD" pub get

--- a/data_models/build.sh
+++ b/data_models/build.sh
@@ -1,1 +1,0 @@
-flutter pub get && dart run build_runner build --delete-conflicting-outputs

--- a/firebase/functions/build.sh
+++ b/firebase/functions/build.sh
@@ -1,1 +1,0 @@
-dart pub run tool/build_node.dart $@

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "frankly-dev-tools",
   "private": true,
   "scripts": {
-    "dev": "./run-dev.sh"
+    "dev": "./run-dev.sh",
+    "build": "./build-all.sh"
   }
 }

--- a/run-dev.sh
+++ b/run-dev.sh
@@ -8,16 +8,58 @@ CLIENT_DIR="$REPO_ROOT/client"
 DATA_MODELS_DIR="$REPO_ROOT/data_models"
 FUNCTIONS_DIR="$REPO_ROOT/firebase/functions"
 
+FVM_FLUTTER_BIN="$CLIENT_DIR/.fvm/flutter_sdk/bin/flutter"
+FVM_DART_BIN="$CLIENT_DIR/.fvm/flutter_sdk/bin/dart"
+
+if [ -x "$FVM_FLUTTER_BIN" ] && [ -x "$FVM_DART_BIN" ]; then
+  FLUTTER_CMD="$FVM_FLUTTER_BIN"
+  DART_CMD="$FVM_DART_BIN"
+else
+  FLUTTER_CMD="flutter"
+  DART_CMD="dart"
+fi
+
 STAMP_DIR="$REPO_ROOT/.local/dev-stamps"
 mkdir -p "$STAMP_DIR"
 
 DATA_MODELS_STAMP="$STAMP_DIR/data_models_build.stamp"
 FUNCTIONS_STAMP="$STAMP_DIR/functions_build.stamp"
+SDK_FINGERPRINT_FILE="$STAMP_DIR/sdk_fingerprint.txt"
 
 EMULATOR_PID=""
 
 log() {
   printf '\n[run-dev] %s\n' "$*"
+}
+
+current_sdk_fingerprint() {
+  local flutter_version
+  flutter_version="$("$FLUTTER_CMD" --version 2>/dev/null || true)"
+  flutter_version="${flutter_version%%$'\n'*}"
+
+  {
+    printf '%s\n' "$flutter_version"
+    "$DART_CMD" --version 2>&1
+  } | tr -d '\r'
+}
+
+refresh_stamps_on_sdk_change() {
+  local current_fingerprint
+  current_fingerprint="$(current_sdk_fingerprint)"
+
+  if [ ! -f "$SDK_FINGERPRINT_FILE" ]; then
+    printf '%s\n' "$current_fingerprint" > "$SDK_FINGERPRINT_FILE"
+    return
+  fi
+
+  local previous_fingerprint
+  previous_fingerprint="$(cat "$SDK_FINGERPRINT_FILE")"
+
+  if [ "$previous_fingerprint" != "$current_fingerprint" ]; then
+    log "Flutter/Dart SDK changed; clearing build stamps."
+    rm -f "$DATA_MODELS_STAMP" "$FUNCTIONS_STAMP"
+    printf '%s\n' "$current_fingerprint" > "$SDK_FINGERPRINT_FILE"
+  fi
 }
 
 require_dir() {
@@ -114,11 +156,13 @@ require_dir "$FUNCTIONS_DIR"
 
 log "Repo root: $REPO_ROOT"
 
+refresh_stamps_on_sdk_change
+
 log "Checking client Dart dependencies..."
 cd "$CLIENT_DIR"
 if need_flutter_pub_get; then
   log "Running flutter pub get in client..."
-  flutter pub get
+  "$FLUTTER_CMD" pub get
 else
   log "Client dependencies unchanged; skipping flutter pub get."
 fi
@@ -127,14 +171,14 @@ log "Checking data_models Dart dependencies..."
 cd "$DATA_MODELS_DIR"
 if need_flutter_pub_get; then
   log "Running flutter pub get in data_models..."
-  flutter pub get
+  "$FLUTTER_CMD" pub get
 else
   log "data_models dependencies unchanged; skipping flutter pub get."
 fi
 
 if need_data_models_build; then
   log "Rebuilding data_models..."
-  dart run build_runner build --delete-conflicting-outputs
+  "$DART_CMD" run build_runner build --delete-conflicting-outputs
   touch "$DATA_MODELS_STAMP"
 else
   log "data_models unchanged; skipping build_runner."
@@ -153,14 +197,14 @@ fi
 log "Checking functions Dart dependencies..."
 if need_flutter_pub_get; then
   log "Running flutter pub get in firebase/functions..."
-  flutter pub get
+  "$FLUTTER_CMD" pub get
 else
   log "Functions Dart dependencies unchanged; skipping flutter pub get."
 fi
 
 if need_functions_build; then
   log "Rebuilding firebase/functions..."
-  dart run build_runner build --output=build
+  "$DART_CMD" run build_runner build --output=build
   touch "$FUNCTIONS_STAMP"
 else
   log "firebase/functions unchanged; skipping build_runner."
@@ -181,7 +225,7 @@ wait_for_port 5001 30
 
 log "Launching Flutter client..."
 cd "$CLIENT_DIR"
-flutter run \
+"$FLUTTER_CMD" run \
   -d chrome \
   --web-renderer html \
   -t lib/dev_emulators_main.dart \


### PR DESCRIPTION
## What is in this PR?

Whenever other Flutter / Dart toolchain versions were present and in use on the local system, there were persistent `build_runner` kernel binary format mismatch errors caused by SDK version misalignment between the global Flutter/Dart toolchain and the project's FVM-pinned version. This fix ensures all local builds consistently use the repo-pinned SDK (Flutter 3.22.2 / Dart 3.4.3) rather than the user's global toolchain, eliminating the "Invalid kernel binary format version" error that recurred even after fixing all application code.

The changes further consolidate and standardize the build pipeline:
1. Update `run-dev.sh` to use the FVM-pinned SDK for all Flutter/Dart invocations.
2. Consolidate per-package build scripts into a single `build-all.sh` at repo root that covers all generators.
3. Add SDK fingerprint and invalidate cached builds when it changes to prevent stale artifacts.
4. Integrate / register build script into `npm run build` for consistency with the `npm run dev` standard launch script.
5. Remove defunct superseded build scripts that were calling global binaries.

## Changes in the codebase

* **run-dev.sh**: Added FVM SDK resolution logic (lines 11–19) that prefers `client/.fvm/flutter_sdk/bin/{flutter,dart}` over global binaries, with graceful fallback. All `flutter` and `dart` command invocations now use the resolved SDK path.
* **run-dev.sh**: Added SDK fingerprint detection (lines 35–60) that tracks active Dart/Flutter versions and automatically clears build stamps when the SDK changes between runs, preventing kernel format mismatches from stale snapshots.
* **build-all.sh**: Renamed from `data_models/build.sh` and expanded to orchestrate builds for all three packages: client (`flutter pub get`), data_models (`flutter pub get` + `dart run build_runner`), and firebase/functions (npm install + `flutter pub get` + `dart run build_runner`). Uses the same FVM-pinned SDK resolution as `run-dev.sh`.
* **package.json**: Added `"build": "./build-all.sh"` script entry for consistency; users can now run `npm run build` instead of calling individual build scripts or aliases.
* **Removed**: `data_models/build.sh` (consolidated into `build-all.sh`), `firebase/functions/build.sh` (obsolete, superseded by `build_runner` integration in `build-all.sh`).

## Changes outside the codebase

None.

## Testing this PR

1. **Local development build**: Run `npm run build` and verify both `data_models` and `firebase/functions` build_runner steps complete without kernel format errors.
2. **Full dev environment**: Run `npm run dev` and confirm the emulator and Flutter app launch successfully.
3. **SDK version change**: Manually update the global Flutter SDK version (or uninstall/reinstall a different version) and re-run `npm run build` or `npm run dev` to confirm build stamps are correctly invalidated and the pinned SDK is used.
4. **Existing application functionality**: Verify the app behaves identically to before the changes (all app code is untouched; only build infrastructure changed).

## Additional information

**Why this matters**: The error "Invalid kernel binary format version (expected 127, found 116)" occurs when `build_runner` tries to load kernel snapshots compiled by an older Dart SDK with a newer SDK runtime. This was recurring because the dev scripts were calling global Flutter/Dart, which is often newer than the repo pin. By centralizing SDK resolution in both `run-dev.sh` and `build-all.sh` eliminates the version mismatch at the source rather than just fixing symptoms.

**CI/CD impact**: No impact. CI runs in a container with a specific Dart/Flutter version baked in; these scripts are local-dev-only.

**Performance**: Build times are unchanged. The new SDK fingerprint check (one file read per session) is negligible and prevents attempting a full rebuild (that will fail) after system SDK changes.