### PR TITLE
Remove duplicative login/signup options and nav

### DIFF
--- a/client/lib/core/routing/locations.dart
+++ b/client/lib/core/routing/locations.dart
@@ -83,12 +83,16 @@ class HomeLocation extends BeamLocation<BeamState> {
   @override
   List<String> get pathPatterns => ['/home'];
 
+  final bool showLoginByDefault;
+
+  HomeLocation({this.showLoginByDefault = false});
+
   @override
   List<BeamPage> buildPages(BuildContext context, BeamState state) => [
         _buildBeamPage(
           key: ValueKey('home'),
           title: context.l10n.appNameHome(Environment.appName),
-          child: HomePage(),
+          child: HomePage(showLoginByDefault: showLoginByDefault),
         ),
       ];
 }

--- a/client/lib/core/widgets/navbar/nav_bar/nav_bar.dart
+++ b/client/lib/core/widgets/navbar/nav_bar/nav_bar.dart
@@ -201,6 +201,8 @@ class NavBarState extends State<NavBar> implements NavBarView {
           padding: const EdgeInsets.symmetric(horizontal: 8.0),
           child: ProfileOrLogin(
             showMenuAboveIcon: false,
+            showLoginSignUp:
+                routerDelegate.currentConfiguration?.uri.path != '/',
           ),
         )
       else ...[

--- a/client/lib/core/widgets/navbar/profile_or_login.dart
+++ b/client/lib/core/widgets/navbar/profile_or_login.dart
@@ -8,17 +8,20 @@ import 'package:provider/provider.dart';
 /// links to the profile or a 'Sign in' button.
 class ProfileOrLogin extends StatelessWidget {
   final bool showMenuAboveIcon;
+  final bool showLoginSignUp;
 
   const ProfileOrLogin({
     Key? key,
     this.showMenuAboveIcon = true,
+    this.showLoginSignUp = false,
   }) : super(key: key);
   @override
   Widget build(BuildContext context) {
     if (Provider.of<UserService>(context).isSignedIn) {
       return UserProfileNavigation(showMenuAboveIcon: showMenuAboveIcon);
-    } else {
+    } else if (showLoginSignUp) {
       return SignInWidget();
     }
+    return SizedBox.shrink();
   }
 }

--- a/client/lib/core/widgets/navbar/sidebar/sidebar.dart
+++ b/client/lib/core/widgets/navbar/sidebar/sidebar.dart
@@ -51,49 +51,29 @@ class _SideBarState extends State<SideBar> {
       color: context.theme.colorScheme.surfaceContainerLowest,
       child: LayoutBuilder(
         builder: (context, constraints) {
-          if (constraints.maxHeight < 750) {
-            return _buildMobileLayout();
-          } else {
-            return _buildDesktopLayout();
-          }
+            return _buildLayout();
+
         },
       ),
     );
   }
 
-  Widget _buildMobileLayout() {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        _buildSidebarCloseButton(),
-        Expanded(
-          child: CustomListView(
-            children: [
-              Padding(
-                padding: const EdgeInsets.all(20),
-                child: _buildNavigation(),
-              ),
-              _buildBottomSidebarButtons(),
-            ],
-          ),
-        ),
-      ],
-    );
-  }
+  Widget _buildLayout() {
+    final isSignedIn = Provider.of<UserService>(context).isSignedIn;
 
-  Widget _buildDesktopLayout() {
     return Column(
       children: [
         _buildSidebarCloseButton(),
-        Expanded(
-          child: CustomListView(
-            padding: const EdgeInsets.all(20),
-            children: [
-              _buildNavigation(),
-            ],
+        if (isSignedIn)
+          Expanded(
+            child: CustomListView(
+              padding: const EdgeInsets.all(20),
+              children: [
+                _buildNavigation(),
+              ],
+            ),
           ),
-        ),
-        _buildBottomSidebarButtons(),
+        _buildBottomSidebarButtons(isSignedIn),
       ],
     );
   }
@@ -103,12 +83,17 @@ class _SideBarState extends State<SideBar> {
       alignment: Alignment.centerRight,
       child: Padding(
         padding: const EdgeInsets.only(top: 26, right: 26),
-        child: Semantics(
+        child:
+           Semantics(
           button: true,
           label: context.l10n.close,
-          child: CustomInkWell(
-            onTap: () => Navigator.of(context).pop(),
-            child: Icon(Icons.close, size: 20),
+          child: IconButton(
+            onPressed: () =>  Navigator.of(context).pop(),
+            icon: Icon(
+              Icons.close,
+              size: 34,
+              color: context.theme.colorScheme.secondary,
+            ),
           ),
         ),
       ),
@@ -181,11 +166,11 @@ class _SideBarState extends State<SideBar> {
         ],
       );
 
-  Widget _buildBottomSidebarButtons() {
+  Widget _buildBottomSidebarButtons(bool isSignedIn) {
     final version =
         js_util.getProperty(html.window, 'platformVersion').toString();
     return Container(
-      color: context.theme.colorScheme.surface,
+      color: isSignedIn ? context.theme.colorScheme.surface : null,
       padding: const EdgeInsets.all(20),
       child: Column(
         mainAxisSize: MainAxisSize.min,

--- a/client/lib/core/widgets/navbar/sidebar/sidebar.dart
+++ b/client/lib/core/widgets/navbar/sidebar/sidebar.dart
@@ -8,7 +8,6 @@ import 'package:client/core/localization/localization_helper.dart';
 import 'package:client/features/community/features/create_community/presentation/widgets/dialog_flow.dart';
 import 'package:client/features/community/data/providers/community_provider.dart';
 import 'package:client/core/widgets/proxied_image.dart';
-import 'package:client/core/widgets/custom_ink_well.dart';
 import 'package:client/core/widgets/custom_list_view.dart';
 import 'package:client/core/widgets/custom_stream_builder.dart';
 import 'package:client/core/widgets/navbar/nav_bar_provider.dart';
@@ -33,7 +32,7 @@ class SideBar extends StatefulWidget {
   SideBar() : super(key: Key('sideBar'));
 
   @override
-  _SideBarState createState() => _SideBarState();
+  State<SideBar> createState() => _SideBarState();
 }
 
 class _SideBarState extends State<SideBar> {

--- a/client/lib/core/widgets/navbar/sidebar/sidebar.dart
+++ b/client/lib/core/widgets/navbar/sidebar/sidebar.dart
@@ -13,7 +13,6 @@ import 'package:client/core/widgets/custom_list_view.dart';
 import 'package:client/core/widgets/custom_stream_builder.dart';
 import 'package:client/core/widgets/navbar/nav_bar_provider.dart';
 import 'package:client/core/widgets/navbar/sidebar/sidebar_navigation_list_item.dart';
-import 'package:client/features/auth/presentation/widgets/sign_in_options_content.dart';
 import 'package:client/features/user/data/providers/user_info_builder.dart';
 import 'package:client/config/environment.dart';
 import 'package:client/core/routing/locations.dart';
@@ -72,7 +71,7 @@ class _SideBarState extends State<SideBar> {
             children: [
               Padding(
                 padding: const EdgeInsets.all(20),
-                child: _buildNavigationOrSignIn(),
+                child: _buildNavigation(),
               ),
               _buildBottomSidebarButtons(),
             ],
@@ -90,7 +89,7 @@ class _SideBarState extends State<SideBar> {
           child: CustomListView(
             padding: const EdgeInsets.all(20),
             children: [
-              _buildNavigationOrSignIn(),
+              _buildNavigation(),
             ],
           ),
         ),
@@ -116,15 +115,13 @@ class _SideBarState extends State<SideBar> {
     );
   }
 
-  Widget _buildNavigationOrSignIn() {
+  Widget _buildNavigation() {
     final isSignedIn = Provider.of<UserService>(context).isSignedIn;
 
     if (isSignedIn) {
       return _buildSignedInSidebarContent();
     } else {
-      return SignInOptionsContent(
-        onComplete: () => Navigator.of(context).pop(),
-      );
+      return SizedBox.shrink();
     }
   }
 

--- a/client/lib/features/auth/presentation/widgets/sign_in_widget.dart
+++ b/client/lib/features/auth/presentation/widgets/sign_in_widget.dart
@@ -1,17 +1,12 @@
+import 'package:client/core/routing/locations.dart';
 import 'package:client/core/widgets/buttons/action_button.dart';
 import 'package:flutter/material.dart';
-import 'package:client/features/auth/presentation/views/sign_in_dialog.dart';
 import 'package:client/core/localization/localization_helper.dart';
 
 class SignInWidget extends StatelessWidget {
   @visibleForTesting
   static const signInKey = Key('sign-in');
   static const signUpKey = Key('sign-up');
-
-  Future<void> _showLogin(BuildContext context, {bool isNewUser = true}) async {
-    await SignInDialog.show(newUser: isNewUser);
-  }
-
   @override
   Widget build(BuildContext context) {
     return Row(
@@ -20,14 +15,14 @@ class SignInWidget extends StatelessWidget {
         ActionButton(
           type: ActionButtonType.text,
           key: signInKey,
-          onPressed: () => _showLogin(context, isNewUser: false),
+            onPressed: () => routerDelegate.beamTo(HomeLocation(showLoginByDefault: true)),
           text: context.l10n.signIn,
         ),
         const SizedBox(width: 8),
         ActionButton(
           type: ActionButtonType.filled,
           key: signUpKey,
-          onPressed: () => _showLogin(context),
+          onPressed: () => routerDelegate.beamTo(HomeLocation()),
           text: context.l10n.signUp,
         ),
       ],

--- a/client/lib/features/home/presentation/views/home_page.dart
+++ b/client/lib/features/home/presentation/views/home_page.dart
@@ -12,13 +12,15 @@ import 'package:client/styles/styles.dart';
 import 'package:provider/provider.dart';
 
 class HomePage extends StatefulWidget {
-  const HomePage({super.key});
+  const HomePage({super.key, this.showLoginByDefault = false});
 
   @override
-  _HomePageState createState() => _HomePageState();
+  HomePageState createState() => HomePageState();
+
+  final bool showLoginByDefault;
 }
 
-class _HomePageState extends State<HomePage> {
+class HomePageState extends State<HomePage> {
   @override
   void initState() {
     context.read<NavBarProvider>().checkIfShouldResetNav();
@@ -33,7 +35,9 @@ class _HomePageState extends State<HomePage> {
       bottomNavigationBar: responsiveLayoutService.showBottomNavBar(context)
           ? HomeBottomNavBar()
           : null,
-      child: isUserSignedIn ? _buildHomePageContent() : HomePageSignInSection(),
+      child: isUserSignedIn ? _buildHomePageContent() : HomePageSignInSection(
+        showLoginByDefault: widget.showLoginByDefault,
+      ),
     );
   }
 

--- a/client/lib/features/home/presentation/widgets/sign_in_section.dart
+++ b/client/lib/features/home/presentation/widgets/sign_in_section.dart
@@ -2,10 +2,12 @@ import 'package:client/features/auth/presentation/widgets/sign_in_options_conten
 import 'package:flutter/material.dart';
 
 class HomePageSignInSection extends StatefulWidget {
-  const HomePageSignInSection({Key? key}) : super(key: key);
+  const HomePageSignInSection({Key? key, this.showLoginByDefault = false}) : super(key: key);
 
   @override
   _HomePageSignInSectionState createState() => _HomePageSignInSectionState();
+
+  final bool showLoginByDefault;
 }
 
 class _HomePageSignInSectionState extends State<HomePageSignInSection> {
@@ -14,7 +16,7 @@ class _HomePageSignInSectionState extends State<HomePageSignInSection> {
     return SingleChildScrollView(
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
-        children: const [
+        children: [
           Column(
             mainAxisAlignment: MainAxisAlignment.center,
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -23,7 +25,7 @@ class _HomePageSignInSectionState extends State<HomePageSignInSection> {
               SizedBox(
                 width: 300,
                 child: SignInOptionsContent(
-                  showSignUp: true,
+                  showSignUp: !widget.showLoginByDefault,
                 ),
               ),
             ],


### PR DESCRIPTION
## What is in this PR?
This simplifies the sign-up/login experience and navigation logic.
- The sign-up and login buttons no longer trigger a modal popup and do not appear on the app's root (`/`) page. 
- The sidebar no longer shows sign-in options for signed-out users; instead, it shows an empty space, and the bottom sidebar buttons are styled differently depending on sign-in state. 

## Changes in the codebase
* The `SignInWidget` now navigates to the `HomeLocation` with a parameter to control whether the login dialog is shown by default, instead of opening a dialog directly. The sign-up button no longer triggers the login dialog either. 
* The `HomePage` and `HomePageSignInSection` components accept a `showLoginByDefault` parameter, which determines whether to show the login or sign-up UI by default. This parameter is passed through the routing logic. 
* Consolidated `Sidebar` layout methods; close button is now an `IconButton` with improved accessibility, styling.
* The navigation bar's profile/login widget now only shows login/sign-up options when not on the home page, using the new `showLoginSignUp` parameter.
* Unused imports and methods related to the old sign-in dialog flow are removed.

## Testing this PR
<!-- Give your reviewer some context or recommendations on how to test your work. -->
- [ ] After applying this change, note that sign-up/login buttons no longer trigger a modal, and do not appear on the app's root page when signed out. 
- [ ] Also note that the sidebar no longer contains a sign-up or login form when signed out, and appears as depicted:
<img width="379" height="755" alt="Screenshot 2026-04-29 at 14 48 54" src="https://github.com/user-attachments/assets/24509e3c-11b4-4f55-8ef8-23d5ce5eed51" />