### PR TITLE
fix: Migrate Community onboarding step stored enum values to new values (guide -> template). 

### DIFF
--- a/data_models/lib/community/community.dart
+++ b/data_models/lib/community/community.dart
@@ -50,6 +50,16 @@ enum OnboardingStep {
   createStripeAccount,
 }
 
+List<OnboardingStep> onboardingStepsFromJson(List<dynamic> stepEnumList) {
+  // Migrate legacy stored onboarding step name enum values to new names.
+  return stepEnumList
+      .whereType<String>()
+      .map((e) => e == 'createGuide' ? 'createTemplate' : e)
+      .map((e) => EnumToString.fromString(OnboardingStep.values, e))
+      .whereType<OnboardingStep>()
+      .toList();
+}
+
 @Freezed(makeCollectionsUnmodifiable: false)
 class Community with _$Community implements SerializeableRequest {
   Community._();
@@ -110,7 +120,9 @@ class Community with _$Community implements SerializeableRequest {
     String? ratingSurveyUrl,
     String? themeLightColor,
     String? themeDarkColor,
-    @Default([]) List<OnboardingStep> onboardingSteps,
+    @Default([])
+    @JsonKey(fromJson: onboardingStepsFromJson)
+    List<OnboardingStep> onboardingSteps,
     @Default(false) bool isOnboardingOverviewEnabled,
   }) = _Community;
 

--- a/data_models/lib/community/community.freezed.dart
+++ b/data_models/lib/community/community.freezed.dart
@@ -51,6 +51,7 @@ mixin _$Community {
   String? get ratingSurveyUrl => throw _privateConstructorUsedError;
   String? get themeLightColor => throw _privateConstructorUsedError;
   String? get themeDarkColor => throw _privateConstructorUsedError;
+  @JsonKey(fromJson: onboardingStepsFromJson)
   List<OnboardingStep> get onboardingSteps =>
       throw _privateConstructorUsedError;
   bool get isOnboardingOverviewEnabled => throw _privateConstructorUsedError;
@@ -94,6 +95,7 @@ abstract class $CommunityCopyWith<$Res> {
       String? ratingSurveyUrl,
       String? themeLightColor,
       String? themeDarkColor,
+      @JsonKey(fromJson: onboardingStepsFromJson)
       List<OnboardingStep> onboardingSteps,
       bool isOnboardingOverviewEnabled});
 
@@ -314,6 +316,7 @@ abstract class _$$_CommunityCopyWith<$Res> implements $CommunityCopyWith<$Res> {
       String? ratingSurveyUrl,
       String? themeLightColor,
       String? themeDarkColor,
+      @JsonKey(fromJson: onboardingStepsFromJson)
       List<OnboardingStep> onboardingSteps,
       bool isOnboardingOverviewEnabled});
 
@@ -506,6 +509,7 @@ class _$_Community extends _Community {
       this.ratingSurveyUrl,
       this.themeLightColor,
       this.themeDarkColor,
+      @JsonKey(fromJson: onboardingStepsFromJson)
       this.onboardingSteps = const [],
       this.isOnboardingOverviewEnabled = false})
       : super._();
@@ -569,7 +573,7 @@ class _$_Community extends _Community {
   @override
   final String? themeDarkColor;
   @override
-  @JsonKey()
+  @JsonKey(fromJson: onboardingStepsFromJson)
   final List<OnboardingStep> onboardingSteps;
   @override
   @JsonKey()
@@ -716,6 +720,7 @@ abstract class _Community extends Community {
       final String? ratingSurveyUrl,
       final String? themeLightColor,
       final String? themeDarkColor,
+      @JsonKey(fromJson: onboardingStepsFromJson)
       final List<OnboardingStep> onboardingSteps,
       final bool isOnboardingOverviewEnabled}) = _$_Community;
   _Community._() : super._();
@@ -778,6 +783,7 @@ abstract class _Community extends Community {
   @override
   String? get themeDarkColor;
   @override
+  @JsonKey(fromJson: onboardingStepsFromJson)
   List<OnboardingStep> get onboardingSteps;
   @override
   bool get isOnboardingOverviewEnabled;

--- a/data_models/lib/community/community.g.dart
+++ b/data_models/lib/community/community.g.dart
@@ -43,10 +43,9 @@ _$_Community _$$_CommunityFromJson(Map<String, dynamic> json) => _$_Community(
       ratingSurveyUrl: json['ratingSurveyUrl'] as String?,
       themeLightColor: json['themeLightColor'] as String?,
       themeDarkColor: json['themeDarkColor'] as String?,
-      onboardingSteps: (json['onboardingSteps'] as List<dynamic>?)
-              ?.map((e) => $enumDecode(_$OnboardingStepEnumMap, e))
-              .toList() ??
-          const [],
+      onboardingSteps: json['onboardingSteps'] == null
+          ? const []
+          : onboardingStepsFromJson(json['onboardingSteps']),
       isOnboardingOverviewEnabled:
           json['isOnboardingOverviewEnabled'] as bool? ?? false,
     );
@@ -86,14 +85,6 @@ Map<String, dynamic> _$$_CommunityToJson(_$_Community instance) =>
       'isOnboardingOverviewEnabled': instance.isOnboardingOverviewEnabled,
     };
 
-const _$OnboardingStepEnumMap = {
-  OnboardingStep.brandSpace: 'brandSpace',
-  OnboardingStep.createTemplate: 'createTemplate',
-  OnboardingStep.hostEvent: 'hostEvent',
-  OnboardingStep.inviteSomeone: 'inviteSomeone',
-  OnboardingStep.createStripeAccount: 'createStripeAccount',
-};
-
 const _$CommunityFeatureFlagsEnumMap = {
   CommunityFeatureFlags.allowDonations: 'allowDonations',
   CommunityFeatureFlags.alwaysRecord: 'alwaysRecord',
@@ -117,6 +108,14 @@ const _$CommunityFeatureFlagsEnumMap = {
   CommunityFeatureFlags.showSmartMatchingForBreakouts:
       'showSmartMatchingForBreakouts',
   CommunityFeatureFlags.suppressJoinEventEmails: 'suppressJoinEventEmails',
+};
+
+const _$OnboardingStepEnumMap = {
+  OnboardingStep.brandSpace: 'brandSpace',
+  OnboardingStep.createTemplate: 'createTemplate',
+  OnboardingStep.hostEvent: 'hostEvent',
+  OnboardingStep.inviteSomeone: 'inviteSomeone',
+  OnboardingStep.createStripeAccount: 'createStripeAccount',
 };
 
 _$_Featured _$$_FeaturedFromJson(Map<String, dynamic> json) => _$_Featured(


### PR DESCRIPTION
## What is in this PR?
<!-- What is the goal of this PR? What steps are involved in achieving that goal? -->
This is a fix intended to resolve the frontend client breaking after migrating enum values for Communities' stored `onboardingStep` values. 

## Changes in the codebase
<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

* [Add manual JSON deserialization function to Community data model…](https://github.com/berkmancenter/frankly/commit/5a483680f6c0e02798dc815e581b862482c42937) so that legacy onboarding step names (which use enum values) can be migrated to use the new enum values which are expected by the frontend.
* Build files.

## Changes outside the codebase
<!-- If you have made changes to external services, need to add additional values to the job settings, or need to add something new to the database, explain it here. This may include updates to third-party services, changes to infrastructure configuration, integration with external APIs, etc. -->

* N/A

## Testing this PR
<!-- Give your reviewer some context or recommendations on how to test your work. -->

Staging is not loading communities prior to this PR. Observe that communities should load as expected after this PR.

## Additional information
<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->

