### PR TITLE
Fix Breakouts Recording in Prod

### DIFF
--- a/firebase/functions/js/agora-recording-webhook.js
+++ b/firebase/functions/js/agora-recording-webhook.js
@@ -23,10 +23,7 @@ function verifySignature(req) {
     // Agora signs the raw request body bytes, not a re-serialized JSON string.
     // Firebase Functions exposes the original bytes via req.rawBody.
     const rawBody = req.rawBody ?? Buffer.from(JSON.stringify(req.body))
-    const expected = crypto
-        .createHmac('sha1', secret)
-        .update(rawBody)
-        .digest('hex')
+    const expected = crypto.createHmac('sha1', secret).update(rawBody).digest('hex')
     const sigBuf = Buffer.from(signature)
     const expBuf = Buffer.from(expected)
     if (sigBuf.length !== expBuf.length) return false

--- a/firebase/functions/js/produce-sessions.js
+++ b/firebase/functions/js/produce-sessions.js
@@ -1,9 +1,8 @@
 const functions = require('firebase-functions')
 const admin = require('firebase-admin')
-const { Storage } = require('@google-cloud/storage')
 
 const firestore = admin.firestore()
-const storage = new Storage()
+const storage = admin.storage()
 const bucketName = functions.config().agora.storage_bucket_name
 
 // Triggered when a recording session transitions to 'stopped'.


### PR DESCRIPTION

## What is in this PR?

Fix produce-sessions.js failing to list recording files from GCS, which caused recording downloads to error in the UI (`artifactPaths` never populated).

## Changes in the codebase

- produce-sessions.js: Replace `new Storage()` with `admin.storage()`, matching the fix applied to the other two JS download functions in `58132b6`. This was the last remaining disjoint `@google-cloud/storage` call site.

## Changes outside the codebase

Configured Agora Notification Callback Service webhook URL in the Agora console for `Deliberations Prod` pointing to https://us-central1-asml-deliberations.cloudfunctions.net/agoraRecordingWebhook
Set `agora.webhook_secret` in prod functions config via firebase functions:config:set

## Testing this PR

Trigger a recording session status update to `stopped` in the emulator. Verify `produceSessions` lists MP4s from the bucket and writes paths to `artifactPaths` on the session document.