### PR TITLE
Add mounted guard to members tab

### DIFF
--- a/client/lib/features/admin/presentation/views/members_tab.dart
+++ b/client/lib/features/admin/presentation/views/members_tab.dart
@@ -529,6 +529,7 @@ class _ChangeMembershipDropdownState extends State<ChangeMembershipDropdown> {
       );
       if (!confirm) return;
     }
+    if (!mounted) return;
     setState(() => _isLoading = true);
     await alertOnError(
       context,
@@ -538,7 +539,9 @@ class _ChangeMembershipDropdownState extends State<ChangeMembershipDropdown> {
         newStatus: newStatus!,
       ),
     );
-    setState(() => _isLoading = false);
+    if (mounted) {
+      setState(() => _isLoading = false);
+    }
   }
 
   @override


### PR DESCRIPTION
## What is in this PR?
Prevents error `NoSuchMethodError` by adding a mounted guard where one was missing on admin members tab.

## Changes in the codebase
<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

* Made a minor improvement to the `ChangeMembershipDropdown` widget in `members_tab.dart`.
* Added checks for `mounted` before calling `setState` to prevent exceptions if the widget is disposed before asynchronous operations complete. [[1]](diffhunk://#diff-171c28f4ca04a404d84c1a13e1cc3cbc85fbc4399b630b8ede8d5d96bc74d76aR532) [[2]](diffhunk://#diff-171c28f4ca04a404d84c1a13e1cc3cbc85fbc4399b630b8ede8d5d96bc74d76aR542-R545)

## Testing this PR
<!-- Give your reviewer some context or recommendations on how to test your work. -->
_Before_ applying this change:
- [ ] On the admin members tab of any community, change the role of a number and then quickly move to a different tab.
- [ ] A null exception ought to occur.
Apply this change, and then do the same action. No exception should occur.

## Additional information
**AI tools used**: 

Sentry's Seer was used in finding root cause. Copilot helped author this PR.