### PR TITLE
Fix for breakouts recordings in prod

### DIFF
--- a/.github/workflows/function-mapping.json
+++ b/.github/workflows/function-mapping.json
@@ -1,7 +1,10 @@
 {
   "files": {
+    "firebase/functions/js/agora-recording-webhook.js": ["agoraRecordingWebhook"],
     "firebase/functions/js/download-recordings.js": ["downloadRecording"],
+    "firebase/functions/js/get-session-download-url.js": ["getSessionDownloadUrl"],
     "firebase/functions/js/image-proxy.js": ["imageProxy"],
+    "firebase/functions/js/produce-sessions.js": ["produceSessions"],
     "firebase/functions/lib/admin/partner_agreements/on_partner_agreements.dart": [
       "PartnerAgreementOnCreate",
       "PartnerAgreementOnUpdate"

--- a/client/lib/features/admin/presentation/views/data_tab.dart
+++ b/client/lib/features/admin/presentation/views/data_tab.dart
@@ -87,6 +87,7 @@ class _DataTabState extends State<DataTab> {
     _sessionSubscriptions[event.id]?.cancel();
     _sessionSubscriptions[event.id] = firestoreDatabase.firestore
         .collection(RecordingSession.kCollection)
+        .where(RecordingSession.kFieldCommunityId, isEqualTo: event.communityId)
         .where(RecordingSession.kFieldEventId, isEqualTo: event.id)
         .snapshots()
         .listen(

--- a/client/lib/features/admin/presentation/views/data_tab.dart
+++ b/client/lib/features/admin/presentation/views/data_tab.dart
@@ -87,7 +87,6 @@ class _DataTabState extends State<DataTab> {
     _sessionSubscriptions[event.id]?.cancel();
     _sessionSubscriptions[event.id] = firestoreDatabase.firestore
         .collection(RecordingSession.kCollection)
-        .where(RecordingSession.kFieldCommunityId, isEqualTo: event.communityId)
         .where(RecordingSession.kFieldEventId, isEqualTo: event.id)
         .snapshots()
         .listen(

--- a/client/lib/features/admin/presentation/widgets/event_data_download_dialog.dart
+++ b/client/lib/features/admin/presentation/widgets/event_data_download_dialog.dart
@@ -407,7 +407,7 @@ class _EventDataDownloadDialogState extends State<EventDataDownloadDialog> {
               if (showRecording)
                 CheckboxListTile(
                   value: recordingSelected,
-                  enabled: recordingParts != null && recordingParts != 0,
+                  enabled: recordingParts != null && recordingParts > 0,
                   onChanged: (value) => setState(
                     () => recordingSelected = value ?? false,
                   ),

--- a/firebase/firestore/firestore.indexes.json
+++ b/firebase/firestore/firestore.indexes.json
@@ -539,6 +539,20 @@
             "queryScope": "COLLECTION",
             "fields": [
                 {
+                    "fieldPath": "communityId",
+                    "order": "ASCENDING"
+                },
+                {
+                    "fieldPath": "eventId",
+                    "order": "ASCENDING"
+                }
+            ]
+        },
+        {
+            "collectionGroup": "recording-sessions",
+            "queryScope": "COLLECTION",
+            "fields": [
+                {
                     "fieldPath": "eventId",
                     "order": "ASCENDING"
                 },

--- a/firebase/functions/lib/events/live_meetings/agora_api.dart
+++ b/firebase/functions/lib/events/live_meetings/agora_api.dart
@@ -74,16 +74,16 @@ class AgoraUtils {
           breakoutSessionId: breakoutSessionId,
         ).toJson(),
       ),
-    ));
+    ),);
 
     print(
-        'recording_start: sessionId=$sessionId roomId=$roomId eventId=$eventId roomType=${roomType.name} breakoutSessionId=$breakoutSessionId');
+        'recording_start: sessionId=$sessionId roomId=$roomId eventId=$eventId roomType=${roomType.name} breakoutSessionId=$breakoutSessionId',);
 
     String resourceId;
     try {
       resourceId = await _acquireResourceId(roomId: roomId);
       print(
-          'recording_acquired: sessionId=$sessionId roomId=$roomId resourceId=$resourceId');
+          'recording_acquired: sessionId=$sessionId roomId=$roomId resourceId=$resourceId',);
     } catch (e) {
       print('Agora acquire failed for room $roomId: $e');
       await sessionRef.updateData(UpdateData.fromMap(
@@ -91,7 +91,7 @@ class AgoraUtils {
           RecordingSession.kFieldStatus: RecordingSessionStatus.failed.name,
           'errorMessage': e.toString(),
         }),
-      ));
+      ),);
       return;
     }
 
@@ -111,11 +111,11 @@ class AgoraUtils {
         fileNamePrefixSegments: prefixSegments,
       );
       print(
-          'recording_started: sessionId=$sessionId roomId=$roomId resourceId=$resourceId sid=$sid gcsPrefix=$gcsPrefix');
+          'recording_started: sessionId=$sessionId roomId=$roomId resourceId=$resourceId sid=$sid gcsPrefix=$gcsPrefix',);
       await sessionRef.updateData(UpdateData.fromMap({
         'agoraSid': sid,
         RecordingSession.kFieldStatus: RecordingSessionStatus.recording.name,
-      }));
+      }),);
     } catch (e) {
       print('Agora start failed for room $roomId: $e');
       await sessionRef.updateData(UpdateData.fromMap(
@@ -123,7 +123,7 @@ class AgoraUtils {
           RecordingSession.kFieldStatus: RecordingSessionStatus.failed.name,
           'errorMessage': e.toString(),
         }),
-      ));
+      ),);
     }
   }
 
@@ -176,7 +176,7 @@ class AgoraUtils {
         RecordingSession.kFieldStatus: RecordingSessionStatus.stopped.name,
         'stoppedAt': serverTimestampValue,
       }),
-    ));
+    ),);
   }
 
   Map<String, String> _getAuthHeaders() {
@@ -208,7 +208,7 @@ class AgoraUtils {
     print('Acquire response (${result.statusCode}): ${result.body}');
     if (result.statusCode < 200 || result.statusCode > 299) {
       throw HttpsError(
-          HttpsError.internal, 'Acquire failed: ${result.body}', null);
+          HttpsError.internal, 'Acquire failed: ${result.body}', null,);
     }
     return convert.jsonDecode(result.body)['resourceId'] as String;
   }
@@ -225,6 +225,7 @@ class AgoraUtils {
       'clientRequest': {
         'token': token,
         'recordingConfig': {
+          'maxIdleTime': 300,
           'transcodingConfig': {
             'height': 360,
             'width': 640,
@@ -262,7 +263,7 @@ class AgoraUtils {
 
     if (result.statusCode < 200 || result.statusCode > 299) {
       throw HttpsError(
-          HttpsError.internal, 'Start failed: ${result.body}', null);
+          HttpsError.internal, 'Start failed: ${result.body}', null,);
     }
 
     return convert.jsonDecode(result.body)['sid'] as String;


### PR DESCRIPTION
## What is in this PR?

Fixes for breakout room recording failures and download issues discovered when staging was deployed to prod. Three symptoms: downloads consistently broken, breakout recordings intermittent, recording status UI broken.

This PR fixes all these problems and makes recording & general joining rooms / video more robust.

## Changes in the codebase

`1596917f` -- `produce-sessions.js`: switch `new Storage()` to `admin.storage()` for consistency with the download signing fix in `58132b63`. Listing works with either client, but this eliminates the last standalone Storage constructor.

`e8dcf96b` -- `agora_api.dart`: set `maxIdleTime: 300` in `recordingConfig`. Agora's default is 30s, which kills the recording bot before users join breakout rooms (recording starts at assignment time, before users are in the channel). This is especially pronounced because the users are added to the Agora meeting serially and because the addition blocks on users enabling (or not enabling) their A/V for the tab.

`87eaac1a` -- `function-mapping.json`: add `produceSessions`, `agoraRecordingWebhook`, `getSessionDownloadUrl`. Without these, staging won't automatically (on push) redeploy the JS functions when source files change.

`64f41589` -- `event_data_download_dialog.dart`: fix checkbox enablement. Was `!= 0`, should be `> 0`. Negative statuses (-1 failed, -2 in-progress) incorrectly enabled the recordings checkbox.

`a3918e2a` -- `data_tab.dart` + `firestore.indexes.json`: restore `communityId` filter in the recording-sessions query and add the required `[communityId, eventId]` compound index. Firestore security rules require the query to constrain on `communityId` ("rules are not filters"), and the compound index didn't exist. 

Note: `1395f9e6` (remove communityId filter) is superseded by `a3918e2a`. It was reverted after discovering Firestore rejects the query without `communityId` due to security rule constraints (would've been nice!).

## Changes outside the Codebase

- Agora webhook URL configured in Agora console for staging (NCS > recorder_leave event 41)
- `agora.webhook_secret` set in staging functions config
- Compound Firestore index deployed to both staging (`gen-hls-bkc-7627`) and prod (`asml-deliberations`)
- Service Account Token Creator role verified on prod service account

## Testing this PR

1. Deploy functions to staging via workflow_dispatch (done)
2. Deploy client preview on the branch (done)
3. Create an event with breakout rooms and `alwaysRecord: true`
4. Run the event, assign breakouts, let users join and talk for 30+ seconds
5. End event, go to Data tab, verify recordings show file count (not "failed")
6. Open download dialog, verify recordings checkbox is enabled, download works

## Additional Notes

The maxIdleTime fix is the key change for breakout recording reliability. Without it, the Agora recording bot joins an empty channel and times out in 30s before users arrive if they take longer than that. The webhook provides a safety net by transitioning stale sessions to `stopped` so the re-entry logic in `getBreakoutRoomJoinInfo` can restart recordings if needed.