### PR TITLE
Fix for AgoraRtcException

### DIFF
--- a/client/lib/features/events/features/live_meeting/features/video/data/providers/agora_room.dart
+++ b/client/lib/features/events/features/live_meeting/features/video/data/providers/agora_room.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:ui';
 
 import 'package:agora_rtc_engine/agora_rtc_engine.dart';
+import 'package:client/app.dart';
 import 'package:client/core/utils/media_device_service.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
@@ -361,8 +362,9 @@ class AgoraRoom with ChangeNotifier {
       engine.enableLocalAudio(false);
       engine.leaveChannel();
       engine.release();
-    } catch (e) {
+    } catch (e, stackTrace) {
       print('Error disposing Agora engine: $e');
+      reportError(e, stackTrace);
     }
     super.dispose();
   }

--- a/client/lib/features/events/features/live_meeting/features/video/data/providers/agora_room.dart
+++ b/client/lib/features/events/features/live_meeting/features/video/data/providers/agora_room.dart
@@ -350,16 +350,20 @@ class AgoraRoom with ChangeNotifier {
 
   @override
   dispose() {
-    engine.unregisterEventHandler(_rtcEngineEventHandler);
-    // Ensure local video preview was started before disposing
-    if(_localParticipant?.videoLocalPreviewStarted == true) {
-      engine.stopPreview();
-    }
-    engine.enableLocalVideo(false);
-    engine.enableLocalAudio(false);
-    engine.leaveChannel();
-    engine.release();
+    try {
+      engine.unregisterEventHandler(_rtcEngineEventHandler);
+      // Ensure local video preview was started before disposing
+      if (_localParticipant?.videoLocalPreviewStarted == true) {
+        engine.stopPreview();
+      }
 
+      engine.enableLocalVideo(false);
+      engine.enableLocalAudio(false);
+      engine.leaveChannel();
+      engine.release();
+    } catch (e) {
+      print('Error disposing Agora engine: $e');
+    }
     super.dispose();
   }
 }

--- a/client/lib/features/events/features/live_meeting/features/video/data/providers/agora_room.dart
+++ b/client/lib/features/events/features/live_meeting/features/video/data/providers/agora_room.dart
@@ -351,7 +351,10 @@ class AgoraRoom with ChangeNotifier {
   @override
   dispose() {
     engine.unregisterEventHandler(_rtcEngineEventHandler);
-    engine.stopPreview();
+    // Ensure local video preview was started before disposing
+    if(_localParticipant?.videoLocalPreviewStarted == true) {
+      engine.stopPreview();
+    }
     engine.enableLocalVideo(false);
     engine.enableLocalAudio(false);
     engine.leaveChannel();


### PR DESCRIPTION
<!-- 
FRANKLY PULL REQUEST TEMPLATE
Thank you for contributing to this open-source project - we appreciate you! 🙌

AI Policy: 
- When using AI assistance for contributions, please disclose your usage in the Additional Information section below. 
- To help our human reviewers, please thoroughly review AI-assisted and AI-generated code yourself before submitting.
- Please ensure you fully understand code contributions you submit. 
-->

## What is in this PR?
<!-- What is the goal of this PR? What steps are involved in achieving that goal? -->
This aims to resolve #88 by adding error handling and an additional pre-condition check during the disposal process in a meeting room.

## Changes in the codebase
<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->
* Wrapped the `dispose` method logic in a `try-catch` block to prevent crashes and log errors if any exceptions occur during cleanup in `AgoraRoom`.
* Added a check to ensure the local video preview is running before calling `engine.stopPreview()`, preventing unsafe calls.

## Testing this PR
<!-- Give your reviewer some context or recommendations on how to test your work. -->
This issue is difficult to repro but a try-catch _should_ help! Deploying it to staging to see if instances of the issue falloff is my recommendation.