### PR TITLE
Fix agenda timer card to display hours correctly

### DIFF
--- a/client/lib/features/events/features/live_meeting/features/meeting_guide/presentation/views/meeting_guide_card.dart
+++ b/client/lib/features/events/features/live_meeting/features/meeting_guide/presentation/views/meeting_guide_card.dart
@@ -235,7 +235,7 @@ class _MeetingGuideCardContentState extends State<MeetingGuideCardContent>
                     } else {
                       negativeTimeRemaining = timeRemaining.isNegative;
                       formattedTime =
-                          timeRemaining.getFormattedTime(showHours: timeRemaining.inHours > 0);
+                          timeRemaining.getFormattedTime(showHours: timeRemaining.inHours.abs() > 0);
                     }
                     return HeightConstrainedText(
                       formattedTime,

--- a/client/lib/features/events/features/live_meeting/features/meeting_guide/presentation/views/meeting_guide_card.dart
+++ b/client/lib/features/events/features/live_meeting/features/meeting_guide/presentation/views/meeting_guide_card.dart
@@ -221,7 +221,7 @@ class _MeetingGuideCardContentState extends State<MeetingGuideCardContent>
             ),
             if (agendaItem.timeInSeconds != null)
               Container(
-                width: 60,
+                width: 120,
                 alignment: Alignment.centerRight,
                 child: PeriodicBuilder(
                   period: const Duration(seconds: 1),
@@ -235,7 +235,7 @@ class _MeetingGuideCardContentState extends State<MeetingGuideCardContent>
                     } else {
                       negativeTimeRemaining = timeRemaining.isNegative;
                       formattedTime =
-                          timeRemaining.getFormattedTime(showHours: false);
+                          timeRemaining.getFormattedTime(showHours: timeRemaining.inHours > 0);
                     }
                     return HeightConstrainedText(
                       formattedTime,


### PR DESCRIPTION
## What is in this PR?
<!-- What is the goal of this PR? What steps are involved in achieving that goal? -->
A minor UI fix to the meeting guide card for the display of an agenda item's remaining time, closing #367.

## Changes in the codebase
<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->
In `_MeetingGuideCardState`:
* Increase the width of the container displaying the agenda item's time to accommodate longer time formats.
* Updated the logic for formatting the remaining time so that hours are shown if the time remaining is greater than zero hours.

## Testing this PR
<!-- Give your reviewer some context or recommendations on how to test your work. -->

- [x] Start a meeting and set an agenda section to a short time (e.g. 10 sec)
- [x] Observe the timer counting down in `min:sec`.
- [x] Stay in that section without "continuing" for more than 1 hour past time (sorry)
- [x] Observe the timer counting down in `hours:min:sec`.