### PR TITLE
Show registration count for non-hosted videos

### DIFF
--- a/.github/workflows/function-mapping.json
+++ b/.github/workflows/function-mapping.json
@@ -123,6 +123,9 @@
       "EventOnUpdate",
       "EventOnCreate"
     ],
+    "firebase/functions/lib/events/on_event_participant.dart": [
+      "EventParticipantOnWrite"
+    ],
     "firebase/functions/lib/events/calendar/calendar_feed_ics.dart": [
       "CalendarFeedIcs"
     ],
@@ -220,6 +223,7 @@
     "firebase/functions/lib/utils/infra/firestore_event_function.dart": [
       "EventOnUpdate",
       "EventOnCreate",
+      "EventParticipantOnWrite",
       "DiscussionThreadOnDelete",
       "DiscussionThreadCommentOnCreate",
       "DiscussionThreadCommentOnDelete",
@@ -239,6 +243,7 @@
       "DiscussionThreadCommentOnDelete",
       "EventOnUpdate",
       "EventOnCreate",
+      "EventParticipantOnWrite",
       "DiscussionThreadOnDelete",
       "CommunityMembershipOnCreate",
       "PartnerAgreementOnCreate",
@@ -362,6 +367,7 @@
     "event": [
       "EventOnUpdate",
       "EventOnCreate",
+      "EventParticipantOnWrite",
       "DiscussionThreadOnDelete",
       "DiscussionThreadCommentOnCreate",
       "DiscussionThreadCommentOnDelete",

--- a/client/lib/features/events/data/services/firestore_event_service.dart
+++ b/client/lib/features/events/data/services/firestore_event_service.dart
@@ -322,6 +322,16 @@ class FirestoreEventService {
     return convertParticipantListAsync(participantDocs);
   }
 
+  // Returns the count of active registered participants using a server-side
+  // aggregation query. Costs 1 Firestore read regardless of participant count,
+  // making it safe for large non-hosted events where streaming all documents
+  // would be prohibitively expensive.
+  Future<int> getEventRegistrationCount({required Event event}) async {
+    final snapshot =
+        await eventParticipantsQuery(event: event).count().get();
+    return snapshot.count ?? 0;
+  }
+
   Future<PrivateLiveStreamInfo?> liveStreamPrivateInfo({
     required Event event,
   }) async {

--- a/client/lib/features/events/data/services/firestore_event_service.dart
+++ b/client/lib/features/events/data/services/firestore_event_service.dart
@@ -322,16 +322,6 @@ class FirestoreEventService {
     return convertParticipantListAsync(participantDocs);
   }
 
-  // Returns the count of active registered participants using a server-side
-  // aggregation query. Costs 1 Firestore read regardless of participant count,
-  // making it safe for large non-hosted events where streaming all documents
-  // would be prohibitively expensive.
-  Future<int> getEventRegistrationCount({required Event event}) async {
-    final snapshot =
-        await eventParticipantsQuery(event: event).count().get();
-    return snapshot.count ?? 0;
-  }
-
   Future<PrivateLiveStreamInfo?> liveStreamPrivateInfo({
     required Event event,
   }) async {

--- a/client/lib/features/events/features/event_page/data/providers/event_provider.dart
+++ b/client/lib/features/events/features/event_page/data/providers/event_provider.dart
@@ -82,6 +82,8 @@ class EventProvider with ChangeNotifier {
 
   late Future<bool> _hasParticipantAttendedPrerequisiteFuture;
 
+  int? _registrationCount;
+
   bool _hasAttendedPrerequisite = false;
 
   BreakoutRoomDefinition get defaultBreakoutRoomDefinition =>
@@ -222,6 +224,19 @@ class EventProvider with ChangeNotifier {
       ? max(1, event.participantCountEstimate ?? 0)
       : eventParticipants.length;
 
+  // Count of signed-up (active) participants. For hosted events this is the
+  // live participant stream length; for non-hosted it is fetched once via a
+  // server-side aggregation query to avoid expensive per-viewer streams.
+  int get registrationCount => useParticipantCountEstimate
+      ? (_registrationCount ?? 0)
+      : eventParticipants.length;
+
+  Future<void> _fetchRegistrationCount() async {
+    _registrationCount = await firestoreEventService
+        .getEventRegistrationCount(event: event);
+    notifyListeners();
+  }
+
   int get presentParticipantCount => useParticipantCountEstimate
       ? max(1, event.presentParticipantCountEstimate ?? 0)
       : eventParticipants.where((p) => p.isPresent).length;
@@ -301,6 +316,9 @@ class EventProvider with ChangeNotifier {
         );
         _eventParticipantsStreamSubscription =
             _eventParticipantsStream?.stream.listen((_) => notifyListeners());
+      }
+      if (useParticipantCountEstimate && _registrationCount == null) {
+        _fetchRegistrationCount();
       }
       notifyListeners();
     });

--- a/client/lib/features/events/features/event_page/data/providers/event_provider.dart
+++ b/client/lib/features/events/features/event_page/data/providers/event_provider.dart
@@ -223,10 +223,10 @@ class EventProvider with ChangeNotifier {
       : eventParticipants.length;
 
   // Count of signed-up (active) participants. For hosted events this is the
-  // live participant stream length; for non-hosted it will be read from the
-  // registrationCount field on the event document once that field is added.
+  // live participant stream length; for non-hosted it is read from the
+  // server-maintained registrationCount field on the event document.
   int get registrationCount => useParticipantCountEstimate
-      ? 0
+      ? (event.registrationCount ?? 0)
       : eventParticipants.length;
 
   int get presentParticipantCount => useParticipantCountEstimate

--- a/client/lib/features/events/features/event_page/data/providers/event_provider.dart
+++ b/client/lib/features/events/features/event_page/data/providers/event_provider.dart
@@ -82,8 +82,6 @@ class EventProvider with ChangeNotifier {
 
   late Future<bool> _hasParticipantAttendedPrerequisiteFuture;
 
-  int? _registrationCount;
-
   bool _hasAttendedPrerequisite = false;
 
   BreakoutRoomDefinition get defaultBreakoutRoomDefinition =>
@@ -225,17 +223,11 @@ class EventProvider with ChangeNotifier {
       : eventParticipants.length;
 
   // Count of signed-up (active) participants. For hosted events this is the
-  // live participant stream length; for non-hosted it is fetched once via a
-  // server-side aggregation query to avoid expensive per-viewer streams.
+  // live participant stream length; for non-hosted it will be read from the
+  // registrationCount field on the event document once that field is added.
   int get registrationCount => useParticipantCountEstimate
-      ? (_registrationCount ?? 0)
+      ? 0
       : eventParticipants.length;
-
-  Future<void> _fetchRegistrationCount() async {
-    _registrationCount = await firestoreEventService
-        .getEventRegistrationCount(event: event);
-    notifyListeners();
-  }
 
   int get presentParticipantCount => useParticipantCountEstimate
       ? max(1, event.presentParticipantCountEstimate ?? 0)
@@ -316,9 +308,6 @@ class EventProvider with ChangeNotifier {
         );
         _eventParticipantsStreamSubscription =
             _eventParticipantsStream?.stream.listen((_) => notifyListeners());
-      }
-      if (useParticipantCountEstimate && _registrationCount == null) {
-        _fetchRegistrationCount();
       }
       notifyListeners();
     });

--- a/client/lib/features/events/presentation/widgets/event_button.dart
+++ b/client/lib/features/events/presentation/widgets/event_button.dart
@@ -143,7 +143,7 @@ class _ParticipantsList extends HookWidget {
           iconSize: 30,
           participantIds: snapshot.map((e) => e.id).toList(),
           numberOfIconsToShow: numberOfParticipantsToShow,
-          registrationCount: snapshot.length,
+          registrationCount: event.registrationCount,
         );
       },
     );

--- a/client/lib/features/events/presentation/widgets/event_button.dart
+++ b/client/lib/features/events/presentation/widgets/event_button.dart
@@ -143,6 +143,7 @@ class _ParticipantsList extends HookWidget {
           iconSize: 30,
           participantIds: snapshot.map((e) => e.id).toList(),
           numberOfIconsToShow: numberOfParticipantsToShow,
+          registrationCount: snapshot.length,
         );
       },
     );

--- a/client/lib/features/events/presentation/widgets/event_participants_list.dart
+++ b/client/lib/features/events/presentation/widgets/event_participants_list.dart
@@ -22,7 +22,9 @@ class EventPageParticipantsList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final participantCount = EventProvider.watch(context).participantCount;
+    final eventProvider = EventProvider.watch(context);
+    final participantCount = eventProvider.participantCount;
+    final registrationCount = eventProvider.registrationCount;
     final maxNumberOfParticipantsToShow =
         responsiveLayoutService.isMobile(context) ? 4 : 6;
     final numberOfParticipantsToShow =
@@ -30,7 +32,7 @@ class EventPageParticipantsList extends StatelessWidget {
 
     return CustomStreamBuilder<List<Participant>>(
       entryFrom: 'event_participants_list.build_participants',
-      stream: EventProvider.watch(context).eventParticipantsStream,
+      stream: eventProvider.eventParticipantsStream,
       showLoading: false,
       builder: (context, participants) {
         final activeParticipants = (participants ?? [])
@@ -40,6 +42,7 @@ class EventPageParticipantsList extends StatelessWidget {
           event: event,
           participantIds: activeParticipants.map((e) => e.id).toList(),
           numberOfIconsToShow: numberOfParticipantsToShow,
+          registrationCount: registrationCount,
         );
       },
     );

--- a/client/lib/features/events/presentation/widgets/participants_list.dart
+++ b/client/lib/features/events/presentation/widgets/participants_list.dart
@@ -20,6 +20,7 @@ class ParticipantsList extends StatefulWidget {
   final int numberOfIconsToShow;
   final double iconSize;
   final int? participantCount;
+  final int? registrationCount;
 
   const ParticipantsList({
     required this.event,
@@ -27,6 +28,7 @@ class ParticipantsList extends StatefulWidget {
     required this.numberOfIconsToShow,
     this.iconSize = 40,
     this.participantCount,
+    this.registrationCount,
     Key? key,
   }) : super(key: key);
 
@@ -128,6 +130,15 @@ class _ParticipantsListState extends State<ParticipantsList> {
   }
 
   Widget _buildParticipantCount() {
+    final regCount = widget.registrationCount;
+    if (widget.event.useParticipantCountEstimate && regCount != null && regCount > 0) {
+      return HeightConstrainedText(
+        '$regCount ${regCount == 1 ? 'Registration' : 'Registrations'}',
+        style: context.theme.textTheme.bodyMedium!
+            .copyWith(color: context.theme.colorScheme.onSurface),
+      );
+    }
+
     if (_participantCount == 1 &&
         !widget.event.useParticipantCountEstimate &&
         !isParticipant) {

--- a/client/lib/features/home/presentation/views/home_page_event_card.dart
+++ b/client/lib/features/home/presentation/views/home_page_event_card.dart
@@ -129,6 +129,7 @@ class _HomePageEventCardState extends State<HomePageEventCard> {
                       participantIds: widget.participants,
                       event: widget.event,
                       numberOfIconsToShow: _maxParticipantsShown,
+                      registrationCount: widget.participants.length,
                     ),
                   ),
                   if (widget.community != null)

--- a/client/lib/features/home/presentation/views/home_page_event_card.dart
+++ b/client/lib/features/home/presentation/views/home_page_event_card.dart
@@ -129,7 +129,7 @@ class _HomePageEventCardState extends State<HomePageEventCard> {
                       participantIds: widget.participants,
                       event: widget.event,
                       numberOfIconsToShow: _maxParticipantsShown,
-                      registrationCount: widget.participants.length,
+                      registrationCount: widget.event.registrationCount,
                     ),
                   ),
                   if (widget.community != null)

--- a/client/test/mocked_classes.mocks.dart
+++ b/client/test/mocked_classes.mocks.dart
@@ -5313,13 +5313,6 @@ class MockCommunitySettings extends _i1.Mock implements _i25.CommunitySettings {
       ) as bool);
 
   @override
-  bool get enablePlatformSelection => (super.noSuchMethod(
-        Invocation.getter(#enablePlatformSelection),
-        returnValue: false,
-        returnValueForMissingStub: false,
-      ) as bool);
-
-  @override
   bool get enableUpdatedLiveMeetingMobile => (super.noSuchMethod(
         Invocation.getter(#enableUpdatedLiveMeetingMobile),
         returnValue: false,
@@ -15820,6 +15813,27 @@ class MockSharedPreferencesService extends _i1.Mock
       ) as _i38.Future<bool>);
 
   @override
+  _i38.Future<void> setPendingEmailVerification(String? email) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #setPendingEmailVerification,
+          [email],
+        ),
+        returnValue: _i38.Future<void>.value(),
+        returnValueForMissingStub: _i38.Future<void>.value(),
+      ) as _i38.Future<void>);
+
+  @override
+  _i38.Future<void> clearPendingEmailVerification() => (super.noSuchMethod(
+        Invocation.method(
+          #clearPendingEmailVerification,
+          [],
+        ),
+        returnValue: _i38.Future<void>.value(),
+        returnValueForMissingStub: _i38.Future<void>.value(),
+      ) as _i38.Future<void>);
+
+  @override
   _i38.Future<void> setLastQueryParameters(String? lastQueryParameters) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -17055,13 +17069,26 @@ class MockUserService extends _i1.Mock implements _i113.UserService {
       ) as bool);
 
   @override
-  void verifyEmail() => super.noSuchMethod(
+  _i38.Future<void> sendMagicVerificationLink(String? email) =>
+      (super.noSuchMethod(
         Invocation.method(
-          #verifyEmail,
-          [],
+          #sendMagicVerificationLink,
+          [email],
         ),
-        returnValueForMissingStub: null,
-      );
+        returnValue: _i38.Future<void>.value(),
+        returnValueForMissingStub: _i38.Future<void>.value(),
+      ) as _i38.Future<void>);
+
+  @override
+  _i38.Future<void> updateEmailAndResendVerification(String? newEmail) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #updateEmailAndResendVerification,
+          [newEmail],
+        ),
+        returnValue: _i38.Future<void>.value(),
+        returnValueForMissingStub: _i38.Future<void>.value(),
+      ) as _i38.Future<void>);
 
   @override
   _i38.Future<void> initialize() => (super.noSuchMethod(
@@ -17576,13 +17603,26 @@ class MockUserServiceNullable extends _i1.Mock implements _i113.UserService {
       ) as bool);
 
   @override
-  void verifyEmail() => super.noSuchMethod(
+  _i38.Future<void> sendMagicVerificationLink(String? email) =>
+      (super.noSuchMethod(
         Invocation.method(
-          #verifyEmail,
-          [],
+          #sendMagicVerificationLink,
+          [email],
         ),
-        returnValueForMissingStub: null,
-      );
+        returnValue: _i38.Future<void>.value(),
+        returnValueForMissingStub: _i38.Future<void>.value(),
+      ) as _i38.Future<void>);
+
+  @override
+  _i38.Future<void> updateEmailAndResendVerification(String? newEmail) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #updateEmailAndResendVerification,
+          [newEmail],
+        ),
+        returnValue: _i38.Future<void>.value(),
+        returnValueForMissingStub: _i38.Future<void>.value(),
+      ) as _i38.Future<void>);
 
   @override
   _i38.Future<void> initialize() => (super.noSuchMethod(

--- a/data_models/lib/events/event.dart
+++ b/data_models/lib/events/event.dart
@@ -42,6 +42,7 @@ class Event with _$Event implements SerializeableRequest {
       'presentParticipantCountEstimate';
   static const String kFieldParticipantCountEstimate =
       'participantCountEstimate';
+  static const String kFieldRegistrationCount = 'registrationCount';
   static const String kFieldScheduledTime = 'scheduledTime';
   static const String kFieldIsPublic = 'isPublic';
   static const String kFieldTitle = 'title';
@@ -117,6 +118,11 @@ class Event with _$Event implements SerializeableRequest {
     /// of seconds and update this field due to large numbers of people
     int? participantCountEstimate,
     int? presentParticipantCountEstimate,
+
+    /// Total number of active registered participants. Updated by a Cloud
+    /// Function on each event-participants write. Safe to read for all event
+    /// types without opening the full participants stream.
+    int? registrationCount,
 
     /// Temporary hacky solution to allow us to specify that some breakout rooms that were matched
     /// using match IDs should be recorded.

--- a/data_models/lib/events/event.freezed.dart
+++ b/data_models/lib/events/event.freezed.dart
@@ -76,6 +76,11 @@ mixin _$Event {
   int? get presentParticipantCountEstimate =>
       throw _privateConstructorUsedError;
 
+  /// Total number of active registered participants. Updated by a Cloud
+  /// Function on each event-participants write. Safe to read for all event
+  /// types without opening the full participants stream.
+  int? get registrationCount => throw _privateConstructorUsedError;
+
   /// Temporary hacky solution to allow us to specify that some breakout rooms that were matched
   /// using match IDs should be recorded.
   dynamic get breakoutMatchIdsToRecord => throw _privateConstructorUsedError;
@@ -129,6 +134,7 @@ abstract class $EventCopyWith<$Res> {
       String? externalCommunityStatus,
       int? participantCountEstimate,
       int? presentParticipantCountEstimate,
+      int? registrationCount,
       dynamic breakoutMatchIdsToRecord});
 
   $WaitingRoomInfoCopyWith<$Res>? get waitingRoomInfo;
@@ -183,6 +189,7 @@ class _$EventCopyWithImpl<$Res, $Val extends Event>
     Object? externalCommunityStatus = freezed,
     Object? participantCountEstimate = freezed,
     Object? presentParticipantCountEstimate = freezed,
+    Object? registrationCount = freezed,
     Object? breakoutMatchIdsToRecord = freezed,
   }) {
     return _then(_value.copyWith(
@@ -311,6 +318,10 @@ class _$EventCopyWithImpl<$Res, $Val extends Event>
           ? _value.presentParticipantCountEstimate
           : presentParticipantCountEstimate // ignore: cast_nullable_to_non_nullable
               as int?,
+      registrationCount: freezed == registrationCount
+          ? _value.registrationCount
+          : registrationCount // ignore: cast_nullable_to_non_nullable
+              as int?,
       breakoutMatchIdsToRecord: freezed == breakoutMatchIdsToRecord
           ? _value.breakoutMatchIdsToRecord
           : breakoutMatchIdsToRecord // ignore: cast_nullable_to_non_nullable
@@ -437,6 +448,7 @@ abstract class _$$_EventCopyWith<$Res> implements $EventCopyWith<$Res> {
       String? externalCommunityStatus,
       int? participantCountEstimate,
       int? presentParticipantCountEstimate,
+      int? registrationCount,
       dynamic breakoutMatchIdsToRecord});
 
   @override
@@ -493,6 +505,7 @@ class __$$_EventCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$_Event>
     Object? externalCommunityStatus = freezed,
     Object? participantCountEstimate = freezed,
     Object? presentParticipantCountEstimate = freezed,
+    Object? registrationCount = freezed,
     Object? breakoutMatchIdsToRecord = freezed,
   }) {
     return _then(_$_Event(
@@ -621,6 +634,10 @@ class __$$_EventCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$_Event>
           ? _value.presentParticipantCountEstimate
           : presentParticipantCountEstimate // ignore: cast_nullable_to_non_nullable
               as int?,
+      registrationCount: freezed == registrationCount
+          ? _value.registrationCount
+          : registrationCount // ignore: cast_nullable_to_non_nullable
+              as int?,
       breakoutMatchIdsToRecord: freezed == breakoutMatchIdsToRecord
           ? _value.breakoutMatchIdsToRecord!
           : breakoutMatchIdsToRecord,
@@ -670,6 +687,7 @@ class _$_Event extends _Event {
       this.externalCommunityStatus,
       this.participantCountEstimate,
       this.presentParticipantCountEstimate,
+      this.registrationCount,
       this.breakoutMatchIdsToRecord = const []})
       : super._();
 
@@ -765,6 +783,12 @@ class _$_Event extends _Event {
   @override
   final int? presentParticipantCountEstimate;
 
+  /// Total number of active registered participants. Updated by a Cloud
+  /// Function on each event-participants write. Safe to read for all event
+  /// types without opening the full participants stream.
+  @override
+  final int? registrationCount;
+
   /// Temporary hacky solution to allow us to specify that some breakout rooms that were matched
   /// using match IDs should be recorded.
   @override
@@ -773,7 +797,7 @@ class _$_Event extends _Event {
 
   @override
   String toString() {
-    return 'Event(id: $id, status: $status, nullableEventType: $nullableEventType, collectionPath: $collectionPath, communityId: $communityId, templateId: $templateId, creatorId: $creatorId, prerequisiteTemplateId: $prerequisiteTemplateId, creatorDisplayName: $creatorDisplayName, createdDate: $createdDate, scheduledTime: $scheduledTime, scheduledTimeZone: $scheduledTimeZone, title: $title, description: $description, image: $image, isPublic: $isPublic, minParticipants: $minParticipants, maxParticipants: $maxParticipants, agendaItems: $agendaItems, waitingRoomInfo: $waitingRoomInfo, breakoutRoomDefinition: $breakoutRoomDefinition, isLocked: $isLocked, liveStreamInfo: $liveStreamInfo, preEventCardData: $preEventCardData, postEventCardData: $postEventCardData, eventSettings: $eventSettings, durationInMinutes: $durationInMinutes, externalCommunityId: $externalCommunityId, externalCommunityStatus: $externalCommunityStatus, participantCountEstimate: $participantCountEstimate, presentParticipantCountEstimate: $presentParticipantCountEstimate, breakoutMatchIdsToRecord: $breakoutMatchIdsToRecord)';
+    return 'Event(id: $id, status: $status, nullableEventType: $nullableEventType, collectionPath: $collectionPath, communityId: $communityId, templateId: $templateId, creatorId: $creatorId, prerequisiteTemplateId: $prerequisiteTemplateId, creatorDisplayName: $creatorDisplayName, createdDate: $createdDate, scheduledTime: $scheduledTime, scheduledTimeZone: $scheduledTimeZone, title: $title, description: $description, image: $image, isPublic: $isPublic, minParticipants: $minParticipants, maxParticipants: $maxParticipants, agendaItems: $agendaItems, waitingRoomInfo: $waitingRoomInfo, breakoutRoomDefinition: $breakoutRoomDefinition, isLocked: $isLocked, liveStreamInfo: $liveStreamInfo, preEventCardData: $preEventCardData, postEventCardData: $postEventCardData, eventSettings: $eventSettings, durationInMinutes: $durationInMinutes, externalCommunityId: $externalCommunityId, externalCommunityStatus: $externalCommunityStatus, participantCountEstimate: $participantCountEstimate, presentParticipantCountEstimate: $presentParticipantCountEstimate, registrationCount: $registrationCount, breakoutMatchIdsToRecord: $breakoutMatchIdsToRecord)';
   }
 
   @override
@@ -843,6 +867,8 @@ class _$_Event extends _Event {
                     presentParticipantCountEstimate) ||
                 other.presentParticipantCountEstimate ==
                     presentParticipantCountEstimate) &&
+            (identical(other.registrationCount, registrationCount) ||
+                other.registrationCount == registrationCount) &&
             const DeepCollectionEquality().equals(
                 other.breakoutMatchIdsToRecord, breakoutMatchIdsToRecord));
   }
@@ -882,6 +908,7 @@ class _$_Event extends _Event {
         externalCommunityStatus,
         participantCountEstimate,
         presentParticipantCountEstimate,
+        registrationCount,
         const DeepCollectionEquality().hash(breakoutMatchIdsToRecord)
       ]);
 
@@ -939,6 +966,7 @@ abstract class _Event extends Event {
       final String? externalCommunityStatus,
       final int? participantCountEstimate,
       final int? presentParticipantCountEstimate,
+      final int? registrationCount,
       final dynamic breakoutMatchIdsToRecord}) = _$_Event;
   _Event._() : super._();
 
@@ -1028,6 +1056,12 @@ abstract class _Event extends Event {
   int? get participantCountEstimate;
   @override
   int? get presentParticipantCountEstimate;
+  @override
+
+  /// Total number of active registered participants. Updated by a Cloud
+  /// Function on each event-participants write. Safe to read for all event
+  /// types without opening the full participants stream.
+  int? get registrationCount;
   @override
 
   /// Temporary hacky solution to allow us to specify that some breakout rooms that were matched

--- a/data_models/lib/events/event.g.dart
+++ b/data_models/lib/events/event.g.dart
@@ -61,6 +61,7 @@ _$_Event _$$_EventFromJson(Map<String, dynamic> json) => _$_Event(
       participantCountEstimate: json['participantCountEstimate'] as int?,
       presentParticipantCountEstimate:
           json['presentParticipantCountEstimate'] as int?,
+      registrationCount: json['registrationCount'] as int?,
       breakoutMatchIdsToRecord: json['breakoutMatchIdsToRecord'] ?? const [],
     );
 
@@ -97,6 +98,7 @@ Map<String, dynamic> _$$_EventToJson(_$_Event instance) => <String, dynamic>{
       'participantCountEstimate': instance.participantCountEstimate,
       'presentParticipantCountEstimate':
           instance.presentParticipantCountEstimate,
+      'registrationCount': instance.registrationCount,
       'breakoutMatchIdsToRecord': instance.breakoutMatchIdsToRecord,
     };
 

--- a/firebase/functions/lib/events/on_event_participant.dart
+++ b/firebase/functions/lib/events/on_event_participant.dart
@@ -31,23 +31,28 @@ class OnEventParticipant extends OnFirestoreFunction<Participant> {
   String get documentPath =>
       'community/{communityId}/templates/{templateId}/events/{eventId}/event-participants/{participantId}';
 
+  // firestoreOnWrite (base class) dispatches to onUpdate, not onWrite.
+  // onCreate and onDelete are not triggered by the onWrite registration, so
+  // they are intentionally unreachable here.
   @override
-  Future<void> onWrite(
+  Future<void> onUpdate(
     Change<DocumentSnapshot> changes,
     Participant before,
     Participant after,
     DateTime updateTime,
     EventContext context,
   ) async {
+    // Skip writes that don't affect active status (presence, breakout room,
+    // timestamp updates, etc.) to avoid rescanning all participants on every
+    // live-meeting heartbeat.
+    if (before.status == after.status) return;
+
     try {
-      // Resolve the participant path regardless of whether this is a create,
-      // update, or delete (after may not exist on delete).
       final participantRef = changes.after.exists
           ? changes.after.reference
           : changes.before.reference;
       final eventPath = participantRef.path.split('/event-participants/').first;
 
-      // Count participants whose status is 'active'.
       final activeDocs = await firestore
           .collection('$eventPath/event-participants')
           .where(
@@ -62,9 +67,7 @@ class OnEventParticipant extends OnFirestoreFunction<Participant> {
             UpdateData.fromMap({Event.kFieldRegistrationCount: count}),
           );
 
-      print(
-        '$_functionName: set registrationCount=$count on $eventPath',
-      );
+      print('$_functionName: set registrationCount=$count on $eventPath');
     } catch (e, s) {
       print('Error in $_functionName: $e\n$s');
       rethrow;
@@ -72,9 +75,10 @@ class OnEventParticipant extends OnFirestoreFunction<Participant> {
   }
 
   @override
-  Future<void> onCreate(
-    DocumentSnapshot documentSnapshot,
-    Participant parsedData,
+  Future<void> onWrite(
+    Change<DocumentSnapshot> changes,
+    Participant before,
+    Participant after,
     DateTime updateTime,
     EventContext context,
   ) {
@@ -82,10 +86,9 @@ class OnEventParticipant extends OnFirestoreFunction<Participant> {
   }
 
   @override
-  Future<void> onUpdate(
-    Change<DocumentSnapshot> changes,
-    Participant before,
-    Participant after,
+  Future<void> onCreate(
+    DocumentSnapshot documentSnapshot,
+    Participant parsedData,
     DateTime updateTime,
     EventContext context,
   ) {

--- a/firebase/functions/lib/events/on_event_participant.dart
+++ b/firebase/functions/lib/events/on_event_participant.dart
@@ -1,0 +1,70 @@
+import 'dart:async';
+
+import 'package:firebase_admin_interop/firebase_admin_interop.dart';
+import 'package:firebase_functions_interop/firebase_functions_interop.dart';
+import '../utils/infra/firestore_event_function.dart';
+import '../utils/infra/firestore_utils.dart';
+import 'package:data_models/events/event.dart';
+
+/// Maintains Event.registrationCount by counting active participants whenever
+/// any event-participants document is written (created, updated, or deleted).
+class OnEventParticipant implements FirestoreEventFunction {
+  static const String _functionName = 'EventParticipantOnWrite';
+
+  static const String _documentPath =
+      'community/{communityId}/templates/{templateId}/events/{eventId}/event-participants/{participantId}';
+
+  @override
+  List<AppFirestoreFunctionData> get appFirestoreFunctionData => [
+        AppFirestoreFunctionData(_functionName, FirestoreEventType.onWrite),
+      ];
+
+  @override
+  void register(FirebaseFunctions functions) {
+    functions[_functionName] = functions
+        .runWith(
+          RuntimeOptions(
+            timeoutSeconds: 60,
+            memory: '256MB',
+            minInstances: int.parse(
+              functions.config.get('functions.on_firestore.min_instances'),
+            ),
+          ),
+        )
+        .firestore
+        .document(_documentPath)
+        .onWrite((changes, context) => _onWrite(changes));
+  }
+
+  Future<void> _onWrite(Change<DocumentSnapshot> changes) async {
+    try {
+      // Resolve the participant path regardless of whether this is a create,
+      // update, or delete (after may not exist on delete).
+      final participantRef = changes.after.exists
+          ? changes.after.reference
+          : changes.before.reference;
+      final eventPath =
+          participantRef.path.split('/event-participants/').first;
+
+      // Count participants whose status is 'active'.
+      final activeDocs = await firestore
+          .collection('$eventPath/event-participants')
+          .where(
+            Participant.kFieldStatus,
+            isEqualTo: ParticipantStatus.active.name,
+          )
+          .select([]).get();
+
+      final count = activeDocs.documents.length;
+
+      await firestore.document(eventPath).updateData(
+            UpdateData.fromMap({Event.kFieldRegistrationCount: count}),
+          );
+
+      print('$_functionName: set registrationCount=$count on $eventPath');
+    } catch (e, s) {
+      print('Error in $_functionName: $e\n$s');
+      rethrow;
+    }
+  }
+}

--- a/firebase/functions/lib/events/on_event_participant.dart
+++ b/firebase/functions/lib/events/on_event_participant.dart
@@ -3,48 +3,49 @@ import 'dart:async';
 import 'package:firebase_admin_interop/firebase_admin_interop.dart';
 import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 import '../utils/infra/firestore_event_function.dart';
+import '../on_firestore_function.dart';
 import '../utils/infra/firestore_utils.dart';
 import 'package:data_models/events/event.dart';
 
 /// Maintains Event.registrationCount by counting active participants whenever
 /// any event-participants document is written (created, updated, or deleted).
-class OnEventParticipant implements FirestoreEventFunction {
+class OnEventParticipant extends OnFirestoreFunction<Participant> {
   static const String _functionName = 'EventParticipantOnWrite';
 
-  static const String _documentPath =
+  OnEventParticipant()
+      : super(
+          [
+            AppFirestoreFunctionData(
+              _functionName,
+              FirestoreEventType.onWrite,
+            ),
+          ],
+          (snapshot) {
+            return Participant.fromJson(
+              firestoreUtils.fromFirestoreJson(snapshot.data.toMap()),
+            ).copyWith(id: snapshot.documentID);
+          },
+        );
+
+  @override
+  String get documentPath =>
       'community/{communityId}/templates/{templateId}/events/{eventId}/event-participants/{participantId}';
 
   @override
-  List<AppFirestoreFunctionData> get appFirestoreFunctionData => [
-        AppFirestoreFunctionData(_functionName, FirestoreEventType.onWrite),
-      ];
-
-  @override
-  void register(FirebaseFunctions functions) {
-    functions[_functionName] = functions
-        .runWith(
-          RuntimeOptions(
-            timeoutSeconds: 60,
-            memory: '256MB',
-            minInstances: int.parse(
-              functions.config.get('functions.on_firestore.min_instances'),
-            ),
-          ),
-        )
-        .firestore
-        .document(_documentPath)
-        .onWrite((changes, context) => _onWrite(changes));
-  }
-
-  Future<void> _onWrite(Change<DocumentSnapshot> changes) async {
+  Future<void> onWrite(
+    Change<DocumentSnapshot> changes,
+    Participant before,
+    Participant after,
+    DateTime updateTime,
+    EventContext context,
+  ) async {
     try {
       // Resolve the participant path regardless of whether this is a create,
       // update, or delete (after may not exist on delete).
       final participantRef = changes.after.exists
           ? changes.after.reference
           : changes.before.reference;
-      final eventPath =
-          participantRef.path.split('/event-participants/').first;
+      final eventPath = participantRef.path.split('/event-participants/').first;
 
       // Count participants whose status is 'active'.
       final activeDocs = await firestore
@@ -61,10 +62,43 @@ class OnEventParticipant implements FirestoreEventFunction {
             UpdateData.fromMap({Event.kFieldRegistrationCount: count}),
           );
 
-      print('$_functionName: set registrationCount=$count on $eventPath');
+      print(
+        '$_functionName: set registrationCount=$count on $eventPath',
+      );
     } catch (e, s) {
       print('Error in $_functionName: $e\n$s');
       rethrow;
     }
+  }
+
+  @override
+  Future<void> onCreate(
+    DocumentSnapshot documentSnapshot,
+    Participant parsedData,
+    DateTime updateTime,
+    EventContext context,
+  ) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> onUpdate(
+    Change<DocumentSnapshot> changes,
+    Participant before,
+    Participant after,
+    DateTime updateTime,
+    EventContext context,
+  ) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> onDelete(
+    DocumentSnapshot documentSnapshot,
+    Participant parsedData,
+    DateTime updateTime,
+    EventContext context,
+  ) {
+    throw UnimplementedError();
   }
 }

--- a/firebase/functions/node/main.dart
+++ b/firebase/functions/node/main.dart
@@ -49,6 +49,7 @@ import 'package:functions/admin/payments/update_stripe_subscription_plan.dart';
 import 'package:functions/events/live_meetings/vote_to_kick.dart';
 import 'package:functions/events/live_meetings/update_presence_status.dart';
 import 'package:functions/events/on_event.dart';
+import 'package:functions/events/on_event_participant.dart';
 import 'package:functions/discussion_threads/on_discussion_thread.dart';
 import 'package:functions/discussion_threads/on_discussion_thread_comment.dart';
 import 'package:functions/community/on_community.dart';
@@ -144,6 +145,7 @@ final _cloudFunctions = <CloudFunction>[
 
 final _eventFunctions = <FirestoreEventFunction>[
   OnEvent(),
+  OnEventParticipant(),
   OnDiscussionThread(),
   OnDiscussionThreadComment(),
   OnCommunity(),


### PR DESCRIPTION
## What is in this PR?

This PR fixes issue [#459](https://github.com/berkmancenter/frankly/issues/459)

## Changes in the codebase

I add a simple cloud function for registration count, gate the showing of the old participant count / member previews on the event being hosted-type, and use the "Registered" wording instead of "Person" or "People" when the registration data is available. 

## Changes outside the codebase

None. 

## Testing this PR

[ ] Create hostless or livestream event.
[ ] Register with one account; verify that 1 is shown as the count.
[ ] Navigate to event page (without registering) from another browser; verify that 1 is still shown.
[ ] Join from second browser. Verify that "2" is now shown for both instances.
[ ] Create a hosted event.
[ ] Verify that the functionality is unchanged from before (still shows a participant list) and count.

## PR Checklist
[ ] Count calculated via cloud function?
[ ] Cloud function properly permissioned and other permissions unaffected?
[ ] Gated changed functionality on event being non-hosted?
[ ] Registration count read and correctly displayed on cards?

## Additional information
Started incorrectly thinking this was a front-end only issue. It is not actually because, although the aggregates (i.e. count) for data are available already, they require permissions that also grant read access to all the user data, which is not an option. So we're making a very simple cloud function for registration count that can be more openly permissioned.

**AI tools used (if applicable)**: 
NA