### PR TITLE
Add configurable Firebase function regions

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -22,6 +22,8 @@ jobs:
           filters: |
             client:
               - 'client/**'
+              - 'firebase.json'
+              - 'scripts/render-firebase-config.mjs'
 
       - name: Set Up Flutter
         if: steps.changes.outputs.client == 'true'

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -62,6 +62,7 @@ jobs:
           envkey_FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
           envkey_FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
           envkey_FUNCTIONS_URL_PREFIX: ${{ secrets.FUNCTIONS_URL_PREFIX }}
+          envkey_FUNCTIONS_REGION: ${{ secrets.FUNCTIONS_REGION || 'us-central1' }}
           envkey_SHARE_LINK_URL: ${{ secrets.APP_STAGING_FULL_URL }}/share
           envkey_ENABLE_FAKE_PARTICIPANTS: true
           envkey_ENABLE_DEV_EVENT_SETTINGS: true
@@ -90,6 +91,11 @@ jobs:
         if: steps.changes.outputs.client == 'true' 
         id: build_app
         run: flutter build web --release web-renderer html -t lib/main.dart --dart-define-from-file=${{ github.workspace }}/.env
+
+      - name: Render Firebase hosting config
+        if: steps.changes.outputs.client == 'true'
+        working-directory: ${{ github.workspace }}
+        run: node scripts/render-firebase-config.mjs --region "${{ secrets.FUNCTIONS_REGION || 'us-central1' }}" --in-place
 
       # Workaround for an upstream issue in action-hosting-deploy 0.9.0 which
       # doesn't automatically generate default preview channel IDs as

--- a/.github/workflows/deploy_client_prod.yaml
+++ b/.github/workflows/deploy_client_prod.yaml
@@ -48,6 +48,7 @@ jobs:
           envkey_FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
           envkey_FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
           envkey_FUNCTIONS_URL_PREFIX: ${{ secrets.FUNCTIONS_URL_PREFIX }}
+          envkey_FUNCTIONS_REGION: ${{ secrets.FUNCTIONS_REGION || 'us-central1' }}
           envkey_SHARE_LINK_URL: ${{ secrets.APP_FULL_URL }}/share
           envkey_SENTRY_RELEASE: ${{ github.ref_name }}
           envkey_SENTRY_ENVIRONMENT: production
@@ -76,6 +77,10 @@ jobs:
 
       - name: Build the Flutter App
         run: flutter build web --release --source-maps --web-renderer html -t lib/main.dart --dart-define-from-file=${{ github.workspace }}/.env
+
+      - name: Render Firebase hosting config
+        working-directory: ${{ github.workspace }}
+        run: node scripts/render-firebase-config.mjs --region "${{ secrets.FUNCTIONS_REGION || 'us-central1' }}" --in-place
 
       - name: Upload sourcemaps to Sentry
         env:

--- a/.github/workflows/deploy_client_staging.yaml
+++ b/.github/workflows/deploy_client_staging.yaml
@@ -24,6 +24,8 @@ jobs:
           filters: |
             client:
               - 'client/**'
+              - 'firebase.json'
+              - 'scripts/render-firebase-config.mjs'
 
       - name: Set Up Flutter
         if: steps.changes.outputs.client == 'true' || github.event_name== 'workflow_dispatch'

--- a/.github/workflows/deploy_client_staging.yaml
+++ b/.github/workflows/deploy_client_staging.yaml
@@ -75,6 +75,7 @@ jobs:
           envkey_FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
           envkey_FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
           envkey_FUNCTIONS_URL_PREFIX: ${{ secrets.FUNCTIONS_URL_PREFIX }}
+          envkey_FUNCTIONS_REGION: ${{ secrets.FUNCTIONS_REGION || 'us-central1' }}
           envkey_SHARE_LINK_URL: ${{ secrets.APP_STAGING_FULL_URL }}/share
           envkey_ENABLE_FAKE_PARTICIPANTS: true
           envkey_ENABLE_DEV_EVENT_SETTINGS: true
@@ -108,6 +109,11 @@ jobs:
       - name: Build the Flutter App
         if: steps.changes.outputs.client == 'true' || github.event_name== 'workflow_dispatch'
         run: flutter build web --release --source-maps --web-renderer html -t lib/main.dart --dart-define-from-file=${{ github.workspace }}/.env
+
+      - name: Render Firebase hosting config
+        if: steps.changes.outputs.client == 'true' || github.event_name== 'workflow_dispatch'
+        working-directory: ${{ github.workspace }}
+        run: node scripts/render-firebase-config.mjs --region "${{ secrets.FUNCTIONS_REGION || 'us-central1' }}" --in-place
 
       - name: Upload sourcemaps to Sentry
         if: steps.changes.outputs.client == 'true' || github.event_name== 'workflow_dispatch'

--- a/.github/workflows/test_client.yaml
+++ b/.github/workflows/test_client.yaml
@@ -25,6 +25,8 @@ jobs:
           filters: |
             client:
               - 'client/**'
+              - 'firebase.json'
+              - 'scripts/render-firebase-config.mjs'
 
       - name: Set Up Flutter
         if: steps.changes.outputs.client == 'true'

--- a/.github/workflows/test_client.yaml
+++ b/.github/workflows/test_client.yaml
@@ -74,6 +74,7 @@ jobs:
           envkey_FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
           envkey_FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
           envkey_FUNCTIONS_URL_PREFIX: ${{ secrets.FUNCTIONS_URL_PREFIX }}
+          envkey_FUNCTIONS_REGION: ${{ secrets.FUNCTIONS_REGION || 'us-central1' }}
           envkey_SHARE_LINK_URL: ${{ secrets.APP_STAGING_FULL_URL }}/share
           envkey_ENABLE_FAKE_PARTICIPANTS: true
           envkey_ENABLE_DEV_EVENT_SETTINGS: true
@@ -103,6 +104,11 @@ jobs:
         if: steps.changes.outputs.client == 'true' && steps.test.outcome == 'success'
         id: build_app
         run: flutter build web --release web-renderer html -t lib/main.dart --dart-define-from-file=${{ github.workspace }}/.env
+
+      - name: Render Firebase hosting config
+        if: steps.changes.outputs.client == 'true' && steps.build_app.outcome == 'success' &&  github.event.pull_request.head.repo.full_name == github.repository
+        working-directory: ${{ github.workspace }}
+        run: node scripts/render-firebase-config.mjs --region "${{ secrets.FUNCTIONS_REGION || 'us-central1' }}" --in-place
 
       - name: Deploy to Preview Channel
         if: steps.changes.outputs.client == 'true' && steps.build_app.outcome == 'success' &&  github.event.pull_request.head.repo.full_name == github.repository

--- a/client/.env.hosted.example
+++ b/client/.env.hosted.example
@@ -16,6 +16,7 @@ COPYRIGHT_STATEMENT='2024 President and Fellows of Harvard College.'
 
 # App Connections
 SHARE_LINK_URL=<value> # The URL prefix for links included in the share buttons. Likely takes the form https://<app URL>/share
+FUNCTIONS_REGION=us-central1 # The Firebase Functions region used by callable clients and emulator URLs.
 FUNCTIONS_URL_PREFIX=<value> # The URL prefix for this app's Google Cloud Run Functions
 
 # SAAS Connections

--- a/client/.env.local.example
+++ b/client/.env.local.example
@@ -25,10 +25,10 @@ LINK_PREVIEW_API_KEY=<value>
 # Firebase project ID — must match your actual Firebase project.
 # The emulators script reads this at startup.
 FIREBASE_PROJECT_ID=<your-firebase-project-id>
+FUNCTIONS_REGION=us-central1
 
 # Development settings/features
 ENABLE_FAKE_PARTICIPANTS=true
 ENABLE_DEV_EVENT_SETTINGS=true
 ENABLE_DEV_ADMIN_SETTINGS=true
 ENABLE_TRACE_LOG=true
-

--- a/client/lib/config/environment.dart
+++ b/client/lib/config/environment.dart
@@ -20,10 +20,14 @@ class Environment {
       String.fromEnvironment('FIREBASE_STORAGE_BUCKET', defaultValue: 'any');
   static const firebaseMeasurementId =
       String.fromEnvironment('FIREBASE_MEASUREMENT_ID', defaultValue: 'any');
+  static const functionsRegion = String.fromEnvironment(
+    'FUNCTIONS_REGION',
+    defaultValue: 'us-central1',
+  );
   static String get functionsUrlPrefix {
     const explicit = String.fromEnvironment('FUNCTIONS_URL_PREFIX');
     if (explicit.isNotEmpty) return explicit;
-    return 'http://127.0.0.1:5001/$firebaseProjectId/us-central1';
+    return 'http://127.0.0.1:5001/$firebaseProjectId/$functionsRegion';
   }
 
   static const sentryDSN = String.fromEnvironment('SENTRY_DSN');
@@ -35,8 +39,10 @@ class Environment {
   // App branding and URL properties
   static const appName =
       String.fromEnvironment('APP_NAME', defaultValue: 'Frankly');
-  static const appUrl = String.fromEnvironment('APP_URL',
-      defaultValue: 'https://app.frankly.org',);
+  static const appUrl = String.fromEnvironment(
+    'APP_URL',
+    defaultValue: 'https://app.frankly.org',
+  );
   static const sidebarFooter = String.fromEnvironment('SIDEBAR_FOOTER');
   static const copyrightStatement =
       String.fromEnvironment('COPYRIGHT_STATEMENT');

--- a/client/lib/core/data/services/cloud_functions.dart
+++ b/client/lib/core/data/services/cloud_functions.dart
@@ -1,3 +1,4 @@
+import 'package:client/config/environment.dart';
 import 'package:cloud_functions/cloud_functions.dart';
 import 'package:client/core/utils/platform_utils.dart';
 
@@ -6,7 +7,8 @@ class CloudFunctions {
 
   Future<void> initialize() async {
     if (usingEmulator) {
-      FirebaseFunctions.instance.useFunctionsEmulator('localhost', 5001);
+      FirebaseFunctions.instanceFor(region: Environment.functionsRegion)
+          .useFunctionsEmulator('localhost', 5001);
     }
   }
 
@@ -26,7 +28,9 @@ class CloudFunctions {
       final result = await callable.call(data);
       return result ?? {};
     } else {
-      final callable = FirebaseFunctions.instance.httpsCallable(function);
+      final callable = FirebaseFunctions.instanceFor(
+        region: Environment.functionsRegion,
+      ).httpsCallable(function);
       final result = await callable.call(data);
       final resultData = result.data;
       if (resultData != null &&

--- a/client/lib/core/utils/web_utils.dart
+++ b/client/lib/core/utils/web_utils.dart
@@ -3,6 +3,7 @@ library web_utils;
 
 import 'dart:ui_web' as ui_web;
 
+import 'package:client/config/environment.dart';
 import 'package:client/core/utils/error_utils.dart';
 import 'package:cloud_functions_platform_interface/cloud_functions_platform_interface.dart';
 import 'package:cloud_functions_web/cloud_functions_web.dart';
@@ -79,7 +80,7 @@ void registerWebViewFactory(String key, html.Element Function(int) factory) {
 
 HttpsCallablePlatform? getHttpsCallableWeb(String functionName) {
   final callable = FirebaseFunctionsWeb(
-    region: 'us-central1',
+    region: Environment.functionsRegion,
     app: FirebaseFunctionsWeb.instance.app,
   ).httpsCallable(null, functionName, HttpsCallableOptions());
 

--- a/client/lib/features/events/features/live_meeting/data/services/cloud_functions_live_meeting_service.dart
+++ b/client/lib/features/events/features/live_meeting/data/services/cloud_functions_live_meeting_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:client/config/environment.dart';
 import 'package:client/services.dart';
 import 'package:cloud_functions/cloud_functions.dart';
 import 'package:data_models/cloud_functions/requests.dart';
@@ -142,8 +143,9 @@ class CloudFunctionsLiveMeetingService {
   Future<void> toggleLikeDislikeOnMeetingUserSuggestion(
     ParticipantAgendaItemDetailsMeta request,
   ) async {
-    final HttpsCallable callable = FirebaseFunctions.instance
-        .httpsCallable('toggleLikeDislikeOnMeetingUserSuggestion');
+    final HttpsCallable callable = FirebaseFunctions.instanceFor(
+      region: Environment.functionsRegion,
+    ).httpsCallable('toggleLikeDislikeOnMeetingUserSuggestion');
 
     await callable.call(request.toJson());
   }

--- a/firebase/functions/.runtimeconfig.json.example
+++ b/firebase/functions/.runtimeconfig.json.example
@@ -1,5 +1,7 @@
 {
   "functions": {
+    "region": "us-central1",
+    "cloud_tasks_region": "us-east4",
     "on_firestore": {
       "min_instances": "0"
     },

--- a/firebase/functions/index.js
+++ b/firebase/functions/index.js
@@ -1,0 +1,9 @@
+const dartFunctions = require('./build/node/main.dart.js')
+
+Object.assign(exports, dartFunctions)
+
+exports.downloadRecording = require('./js/download-recordings.js')
+exports.getSessionDownloadUrl = require('./js/get-session-download-url.js')
+exports.produceSessions = require('./js/produce-sessions.js')
+exports.agoraRecordingWebhook = require('./js/agora-recording-webhook.js')
+exports.imageProxy = require('./js/image-proxy.js')

--- a/firebase/functions/js/agora-recording-webhook.js
+++ b/firebase/functions/js/agora-recording-webhook.js
@@ -1,6 +1,7 @@
 const functions = require('firebase-functions')
 const admin = require('firebase-admin')
 const crypto = require('crypto')
+const { regionalFunctions } = require('./function-region')
 
 const firestore = admin.firestore()
 
@@ -30,7 +31,7 @@ function verifySignature(req) {
     return crypto.timingSafeEqual(sigBuf, expBuf)
 }
 
-const agoraRecordingWebhook = functions.https.onRequest(async (req, res) => {
+const agoraRecordingWebhook = regionalFunctions().https.onRequest(async (req, res) => {
     if (req.method !== 'POST') {
         res.status(405).send('Method Not Allowed')
         return

--- a/firebase/functions/js/download-recordings.js
+++ b/firebase/functions/js/download-recordings.js
@@ -1,6 +1,7 @@
 const functions = require('firebase-functions')
 const admin = require('firebase-admin')
 const cors = require('cors')({ origin: true })
+const { regionalFunctions } = require('./function-region')
 
 const firestore = admin.firestore()
 
@@ -13,7 +14,7 @@ const signedUrlExpiration = 15 * 60 * 1000
 // Expected path shape: community/{id}/templates/{id}/events/{id}
 const eventPathRegex = /^community\/[^\/]+\/templates\/[^\/]+\/events\/[^\/]+$/
 
-const downloadRecording = functions.https.onRequest((req, res) => {
+const downloadRecording = regionalFunctions().https.onRequest((req, res) => {
     cors(req, res, async () => {
         try {
             const authToken = req.headers.authorization?.split('Bearer ')[1]

--- a/firebase/functions/js/function-region.js
+++ b/firebase/functions/js/function-region.js
@@ -1,0 +1,21 @@
+const functions = require('firebase-functions')
+
+const defaultRegion = 'us-central1'
+
+function configuredFunctionRegion() {
+    const configured = functions.config().functions?.region
+    if (typeof configured !== 'string') return defaultRegion
+
+    const trimmed = configured.trim()
+    return trimmed.length > 0 ? trimmed : defaultRegion
+}
+
+function regionalFunctions() {
+    return functions.region(configuredFunctionRegion())
+}
+
+module.exports = {
+    configuredFunctionRegion,
+    defaultRegion,
+    regionalFunctions,
+}

--- a/firebase/functions/js/get-session-download-url.js
+++ b/firebase/functions/js/get-session-download-url.js
@@ -1,6 +1,7 @@
 const functions = require('firebase-functions')
 const admin = require('firebase-admin')
 const cors = require('cors')({ origin: true })
+const { regionalFunctions } = require('./function-region')
 
 const firestore = admin.firestore()
 const storage = admin.storage()
@@ -9,7 +10,7 @@ const bucketName = functions.config().agora.storage_bucket_name
 // Signed URLs expire after 15 minutes
 const signedUrlExpiration = 15 * 60 * 1000
 
-const getSessionDownloadUrl = functions.https.onRequest((req, res) => {
+const getSessionDownloadUrl = regionalFunctions().https.onRequest((req, res) => {
     cors(req, res, async () => {
         try {
             const authToken = req.headers.authorization?.split('Bearer ')[1]

--- a/firebase/functions/js/image-proxy.js
+++ b/firebase/functions/js/image-proxy.js
@@ -1,8 +1,9 @@
 const functions = require('firebase-functions');
 const cors = require('cors')({origin: true})
 const fetch = require('node-fetch');
+const { regionalFunctions } = require('./function-region');
 
-const imageProxy = functions.https.onRequest((req, res) => {
+const imageProxy = regionalFunctions().https.onRequest((req, res) => {
   cors(req, res, async () => {
      console.log('Requested URI:', req.originalUrl);
      const url = req.query.url;

--- a/firebase/functions/js/produce-sessions.js
+++ b/firebase/functions/js/produce-sessions.js
@@ -1,5 +1,6 @@
 const functions = require('firebase-functions')
 const admin = require('firebase-admin')
+const { regionalFunctions } = require('./function-region')
 
 const firestore = admin.firestore()
 const storage = admin.storage()
@@ -8,7 +9,7 @@ const bucketName = functions.config().agora.storage_bucket_name
 // Triggered when a recording session transitions to 'stopped'.
 // Locates the MP4 Agora deposited under gcsPrefix and registers its path on
 // the session document.
-const produceSessions = functions.firestore
+const produceSessions = regionalFunctions().firestore
     .document('recording-sessions/{sessionId}')
     .onUpdate(async (change, context) => {
         const before = change.before.data()

--- a/firebase/functions/lib/events/live_meetings/update_live_stream_participant_count.dart
+++ b/firebase/functions/lib/events/live_meetings/update_live_stream_participant_count.dart
@@ -2,8 +2,7 @@ import 'dart:async';
 
 import 'package:firebase_admin_interop/firebase_admin_interop.dart';
 import 'package:firebase_functions_interop/firebase_functions_interop.dart'
-    as functions_interop
-    show functions;
+    as functions_interop show functions;
 import 'package:firebase_functions_interop/firebase_functions_interop.dart'
     hide CloudFunction;
 import '../../cloud_function.dart';

--- a/firebase/functions/lib/events/live_meetings/update_live_stream_participant_count.dart
+++ b/firebase/functions/lib/events/live_meetings/update_live_stream_participant_count.dart
@@ -2,6 +2,9 @@ import 'dart:async';
 
 import 'package:firebase_admin_interop/firebase_admin_interop.dart';
 import 'package:firebase_functions_interop/firebase_functions_interop.dart'
+    as functions_interop
+    show functions;
+import 'package:firebase_functions_interop/firebase_functions_interop.dart'
     hide CloudFunction;
 import '../../cloud_function.dart';
 import '../../utils/infra/firestore_utils.dart';
@@ -131,14 +134,14 @@ class UpdateLiveStreamParticipantCount implements CloudFunction {
   }
 
   @override
-  void register(FirebaseFunctions functions) {
-    functions[functionName] = functions
+  void register(FirebaseFunctions targetFunctions) {
+    targetFunctions[functionName] = targetFunctions
         .runWith(
           RuntimeOptions(
             timeoutSeconds: 60,
             memory: '256MB',
             minInstances: int.parse(
-              functions.config.get(
+              functions_interop.functions.config.get(
                 'functions.update_live_stream_participant_count.min_instances',
               ),
             ),

--- a/firebase/functions/lib/on_firestore_function.dart
+++ b/firebase/functions/lib/on_firestore_function.dart
@@ -2,8 +2,7 @@ import 'dart:async';
 
 import 'package:firebase_admin_interop/firebase_admin_interop.dart';
 import 'package:firebase_functions_interop/firebase_functions_interop.dart'
-    as functions_interop
-    show functions;
+    as functions_interop show functions;
 import 'package:firebase_functions_interop/firebase_functions_interop.dart'
     show EventContext, Change, FirebaseFunctions, RuntimeOptions;
 import 'utils/infra/firestore_event_function.dart';

--- a/firebase/functions/lib/on_firestore_function.dart
+++ b/firebase/functions/lib/on_firestore_function.dart
@@ -2,6 +2,9 @@ import 'dart:async';
 
 import 'package:firebase_admin_interop/firebase_admin_interop.dart';
 import 'package:firebase_functions_interop/firebase_functions_interop.dart'
+    as functions_interop
+    show functions;
+import 'package:firebase_functions_interop/firebase_functions_interop.dart'
     show EventContext, Change, FirebaseFunctions, RuntimeOptions;
 import 'utils/infra/firestore_event_function.dart';
 import 'utils/infra/on_firestore_helper.dart';
@@ -149,20 +152,20 @@ abstract class OnFirestoreFunction<T extends SerializeableRequest>
   }
 
   @override
-  void register(FirebaseFunctions functions) {
+  void register(FirebaseFunctions targetFunctions) {
     for (var data in appFirestoreFunctionData) {
       final functionName = data.functionName;
       final eventType = data.firestoreEventType;
 
       switch (eventType) {
         case FirestoreEventType.onCreate:
-          functions[functionName] = functions
+          targetFunctions[functionName] = targetFunctions
               .runWith(
                 RuntimeOptions(
                   timeoutSeconds: 60,
                   memory: '1GB',
                   minInstances: int.parse(
-                    functions.config
+                    functions_interop.functions.config
                         .get('functions.on_firestore.min_instances'),
                   ),
                 ),
@@ -175,13 +178,13 @@ abstract class OnFirestoreFunction<T extends SerializeableRequest>
               );
           break;
         case FirestoreEventType.onUpdate:
-          functions[functionName] = functions
+          targetFunctions[functionName] = targetFunctions
               .runWith(
                 RuntimeOptions(
                   timeoutSeconds: 60,
                   memory: '1GB',
                   minInstances: int.parse(
-                    functions.config
+                    functions_interop.functions.config
                         .get('functions.on_firestore.min_instances'),
                   ),
                 ),
@@ -194,13 +197,13 @@ abstract class OnFirestoreFunction<T extends SerializeableRequest>
               );
           break;
         case FirestoreEventType.onWrite:
-          functions[functionName] = functions
+          targetFunctions[functionName] = targetFunctions
               .runWith(
                 RuntimeOptions(
                   timeoutSeconds: 60,
                   memory: '1GB',
                   minInstances: int.parse(
-                    functions.config
+                    functions_interop.functions.config
                         .get('functions.on_firestore.min_instances'),
                   ),
                 ),
@@ -213,13 +216,13 @@ abstract class OnFirestoreFunction<T extends SerializeableRequest>
               );
           break;
         case FirestoreEventType.onDelete:
-          functions[functionName] = functions
+          targetFunctions[functionName] = targetFunctions
               .runWith(
                 RuntimeOptions(
                   timeoutSeconds: 60,
                   memory: '1GB',
                   minInstances: int.parse(
-                    functions.config
+                    functions_interop.functions.config
                         .get('functions.on_firestore.min_instances'),
                   ),
                 ),

--- a/firebase/functions/lib/utils/infra/scheduled_functions.dart
+++ b/firebase/functions/lib/utils/infra/scheduled_functions.dart
@@ -27,7 +27,8 @@ class ScheduledFunctions {
   }
 
   String get queueRegion {
-    final configuredRegion = _configValueOrEmpty('functions.cloud_tasks_region');
+    final configuredRegion =
+        _configValueOrEmpty('functions.cloud_tasks_region');
     if (configuredRegion.isNotEmpty) return configuredRegion;
 
     final functionsRegion = _configValueOrEmpty('functions.region');

--- a/firebase/functions/lib/utils/infra/scheduled_functions.dart
+++ b/firebase/functions/lib/utils/infra/scheduled_functions.dart
@@ -16,9 +16,29 @@ class ScheduledFunctions {
   tasks.CloudTasksClient get client =>
       _client ??= tasks.createCloudTasksClient();
 
+  String _configValueOrEmpty(String key) {
+    try {
+      final value = functions.config.get(key);
+      if (value == null) return '';
+      return value.toString().trim();
+    } catch (_) {
+      return '';
+    }
+  }
+
+  String get queueRegion {
+    final configuredRegion = _configValueOrEmpty('functions.cloud_tasks_region');
+    if (configuredRegion.isNotEmpty) return configuredRegion;
+
+    final functionsRegion = _configValueOrEmpty('functions.region');
+    if (functionsRegion.isNotEmpty) return functionsRegion;
+
+    return 'us-east4';
+  }
+
   String get parentPath => client.queuePath(
         functions.config.get('app.project_id') as String,
-        'us-east4',
+        queueRegion,
         'scheduled-functions',
       );
 

--- a/firebase/functions/node/main.dart
+++ b/firebase/functions/node/main.dart
@@ -69,7 +69,6 @@ import 'package:functions/admin/payments/stripe_webhooks.dart';
 import 'package:functions/community/trigger_email_digests.dart';
 import 'package:functions/events/live_meetings/update_live_stream_participant_count.dart';
 import 'package:functions/utils/infra/firestore_utils.dart';
-import 'package:node_interop/node.dart';
 import 'package:uuid/uuid.dart';
 
 final _onCallFunctions = <CloudFunction>[
@@ -156,32 +155,36 @@ final _eventFunctions = <FirestoreEventFunction>[
 
 void _registerServices() {
   setFirebaseAppFactory(() => FirebaseAdmin.instance.initializeApp()!);
-  // reference firebaseApp to call initializeApp() and set singleton prior to
-  // javascript function registration
+  // Force initialization before any exported function code reads Firestore.
   firebaseApp.firestore();
   GetIt.instance.registerSingleton(const Uuid());
 }
 
-void _registerJsFunctions() {
-  functions['downloadRecording'] = require('../js/download-recordings.js');
-  functions['getSessionDownloadUrl'] =
-      require('../js/get-session-download-url.js');
-  functions['produceSessions'] = require('../js/produce-sessions.js');
-  functions['agoraRecordingWebhook'] =
-      require('../js/agora-recording-webhook.js');
-  functions['imageProxy'] = require('../js/image-proxy.js');
+String _configValueOrEmpty(String key) {
+  try {
+    final value = functions.config.get(key);
+    if (value == null) return '';
+    return value.toString().trim();
+  } catch (_) {
+    return '';
+  }
+}
+
+String _functionsRegion() {
+  final configuredRegion = _configValueOrEmpty('functions.region');
+  if (configuredRegion.isNotEmpty) return configuredRegion;
+  return 'us-central1';
 }
 
 void main() {
   _registerServices();
+  final regionalFunctions = functions.region(_functionsRegion());
 
   for (var function in _cloudFunctions) {
-    function.register(functions);
+    function.register(regionalFunctions);
   }
 
   for (var function in _eventFunctions) {
-    function.register(functions);
+    function.register(regionalFunctions);
   }
-
-  _registerJsFunctions();
 }

--- a/firebase/functions/package.json
+++ b/firebase/functions/package.json
@@ -13,7 +13,7 @@
   "engines": {
     "node": "20"
   },
-  "main": "build/node/main.dart.js",
+  "main": "index.js",
   "dependencies": {
     "@google-cloud/firestore": "^4.15.1",
     "@google-cloud/tasks": "^2.4.2",

--- a/firebase/functions/test/test_config.json
+++ b/firebase/functions/test/test_config.json
@@ -1,5 +1,7 @@
 {
     "functions": {
+      "region": "us-central1",
+      "cloud_tasks_region": "us-east4",
       "on_firestore": {
         "min_instances": "0"
       },

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "./run-dev.sh",
-    "build": "./build-all.sh"
+    "build": "./build-all.sh",
+    "render:firebase-config": "node scripts/render-firebase-config.mjs"
   }
 }

--- a/scripts/render-firebase-config.mjs
+++ b/scripts/render-firebase-config.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const defaultRegion = 'us-central1';
+const defaultInput = resolve('firebase.json');
+const defaultOutput = resolve('firebase.generated.json');
+const rewriteFunctionIds = new Set(['ShareLink', 'CalendarFeedIcs', 'CalendarFeedRss']);
+
+function parseArgs(argv) {
+  const options = {
+    region: process.env.FUNCTIONS_REGION?.trim() || defaultRegion,
+    input: defaultInput,
+    output: defaultOutput,
+    inPlace: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--region') {
+      options.region = argv[++index] ?? defaultRegion;
+    } else if (arg === '--input') {
+      options.input = resolve(argv[++index] ?? defaultInput);
+    } else if (arg === '--output') {
+      options.output = resolve(argv[++index] ?? defaultOutput);
+    } else if (arg === '--in-place') {
+      options.inPlace = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (options.inPlace) {
+    options.output = options.input;
+  }
+
+  if (!options.region.trim()) {
+    options.region = defaultRegion;
+  }
+
+  return options;
+}
+
+function withFunctionRegion(rewrites, region) {
+  return rewrites.map((rewrite) => {
+    const functionTarget =
+      typeof rewrite.function === 'string'
+        ? rewrite.function
+        : rewrite.function?.functionId;
+    if (!rewriteFunctionIds.has(functionTarget)) {
+      return rewrite;
+    }
+
+    return {
+      ...rewrite,
+      function: {
+        functionId: functionTarget,
+        region,
+      },
+    };
+  });
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const config = JSON.parse(readFileSync(options.input, 'utf8'));
+  const rewrites = config.hosting?.rewrites ?? [];
+
+  const renderedConfig = {
+    ...config,
+    hosting: {
+      ...config.hosting,
+      rewrites: withFunctionRegion(rewrites, options.region),
+    },
+  };
+
+  writeFileSync(options.output, `${JSON.stringify(renderedConfig, null, 2)}\n`);
+}
+
+main();


### PR DESCRIPTION
Summary: make Firebase callable and function regions configurable, preserve current defaults when unset, and add region-aware Hosting and CI plumbing. Validation: git diff check, node syntax checks, targeted Dart analyze, targeted Flutter analyze. Notes: opened from the Dembrane fork only to isolate the EU extraction; broader repo test and toolchain issues outside this diff still exist, so this PR is a draft.