### PR TITLE
Update text for recording notice and skip buttons

### DIFF
--- a/client/lib/features/events/features/event_page/presentation/views/event_page.dart
+++ b/client/lib/features/events/features/event_page/presentation/views/event_page.dart
@@ -187,7 +187,7 @@ class EventPageState extends State<EventPage> implements EventPageView {
                     style: TextButton.styleFrom(
                       foregroundColor: context.theme.colorScheme.error,
                     ),
-                    child: Text(context.l10n.close),
+                    child: Text(context.l10n.leave),
                   ),
                   TextButton(
                     onPressed: () => Navigator.pop(context, true),

--- a/client/lib/features/events/features/event_page/presentation/views/pre_post_event_dialog_page.dart
+++ b/client/lib/features/events/features/event_page/presentation/views/pre_post_event_dialog_page.dart
@@ -1,3 +1,4 @@
+import 'package:client/core/localization/localization_helper.dart';
 import 'package:client/styles/styles.dart';
 import 'package:flutter/material.dart';
 import 'package:client/core/utils/error_utils.dart';
@@ -166,7 +167,7 @@ class _PrePostEventDialogPageState extends State<PrePostEventDialogPage>
   Widget _buildNotNowWidget() {
     return ActionButton(
       type: ActionButtonType.outline,
-      text: 'Next',
+      text: context.l10n.close,
       onPressed: () => Navigator.of(context).pop(),
     );
   }


### PR DESCRIPTION
## What is in this PR?
<!-- What is the goal of this PR? What steps are involved in achieving that goal? -->
* Changed the label of the close button from "close" to "leave" in the event page dialog for clarity and to better reflect the action.
* Updated the "Next" button text to use the localized "close" string instead, ensuring proper localization in the pre/post event dialog.
* Added an import for the localization helper in `pre_post_event_dialog_page.dart` to support the use of localized strings.

## Changes in the codebase
<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

See above.

## PR Checklist
<!-- Items to remember to address before submitting. -->
- [ ] Where applicable, I have added localization (l10n) entries to my feature for user-facing text.
- [ ] For new Cloud Functions, I have added the function to `function-mapping.json`. 

## Additional information
<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->

**AI tools used (if applicable)**: 
