### PR TITLE
hotfix: Remove _resetAudioVideoOn() call that initializes A/V to false in non-hosted events.

### DIFF
--- a/client/lib/features/events/features/live_meeting/data/providers/live_meeting_provider.dart
+++ b/client/lib/features/events/features/live_meeting/data/providers/live_meeting_provider.dart
@@ -303,13 +303,6 @@ class LiveMeetingProvider with ChangeNotifier {
     notifyListeners();
   }
 
-  void _resetAudioVideoOn() {
-    shouldStartLocalAudioOn =
-        shouldStartLocalAudioOn && eventProvider.event.isHosted;
-    shouldStartLocalVideoOn =
-        shouldStartLocalVideoOn && eventProvider.event.isHosted;
-  }
-
   Stream<List<EventProposal>> get proposals {
     final path =
         firestoreLiveMeetingService.getLiveMeetingPath(eventProvider.event);
@@ -327,8 +320,6 @@ class LiveMeetingProvider with ChangeNotifier {
 
     shouldStartLocalAudioOn = audioDefaultOn;
     shouldStartLocalVideoOn = videoDefaultOn;
-
-    _resetAudioVideoOn();
 
     _liveMeetingStream = firestoreLiveMeetingService.liveMeetingStream(
       parentDoc: eventPath,
@@ -830,8 +821,6 @@ class LiveMeetingProvider with ChangeNotifier {
       event: eventProvider.event,
       isPresent: true,
     );
-
-    _resetAudioVideoOn();
 
     notifyListeners();
   }


### PR DESCRIPTION
<!-- 
FRANKLY PULL REQUEST TEMPLATE
Thank you for contributing to this open-source project - we appreciate you! 🙌

AI Policy: 
- When using AI assistance for contributions, please disclose your usage in the Additional Information section below. 
- To help our human reviewers, please thoroughly review AI-assisted and AI-generated code yourself before submitting.
- Please ensure you fully understand code contributions you submit. 
-->

## What is in this PR?
<!-- What is the goal of this PR? What steps are involved in achieving that goal? -->
Hotfix for A/V not working until refresh in hostless events.

## Changes in the codebase
<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

* 

## Changes outside the codebase
<!-- If you have made changes to external services, need to add additional values to the job settings, or need to add something new to the database, explain it here. This may include updates to third-party services, changes to infrastructure configuration, integration with external APIs, etc. -->

* 

## Testing this PR
<!-- Give your reviewer some context or recommendations on how to test your work. -->

## PR Checklist
<!-- Items to remember to address before submitting. -->
- [ ] Where applicable, I have added localization (l10n) entries to my feature for user-facing text.
- [ ] For new Cloud Functions, I have added the function to `function-mapping.json`. 

## Additional information
<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->

**AI tools used (if applicable)**: 
