### PR TITLE
Error color fixes

### DIFF
--- a/client/lib/core/widgets/custom_text_field.dart
+++ b/client/lib/core/widgets/custom_text_field.dart
@@ -323,7 +323,7 @@ class _CustomTextFieldState extends State<CustomTextField> {
 
   Color _getBorderColor({bool isError = false}) {
     return isError
-        ? context.theme.colorScheme.errorContainer
+        ? context.theme.colorScheme.error
         : _focusNode.hasFocus || _hasMouseHover
             ? context.theme.colorScheme.primary
             : context.theme.colorScheme.onPrimaryContainer;

--- a/client/lib/features/events/features/live_meeting/features/video/presentation/views/video_flutter_meeting.dart
+++ b/client/lib/features/events/features/live_meeting/features/video/presentation/views/video_flutter_meeting.dart
@@ -264,7 +264,7 @@ class _RecordingBadgePill extends StatelessWidget {
               width: _kRecordingPulseSize,
               decoration: BoxDecoration(
                 shape: BoxShape.circle,
-                color: context.theme.colorScheme.errorContainer,
+                color: context.theme.colorScheme.error,
               ),
             ),
             SizedBox(width: 8),

--- a/client/lib/features/events/features/live_meeting/features/video/presentation/widgets/control_bar.dart
+++ b/client/lib/features/events/features/live_meeting/features/video/presentation/widgets/control_bar.dart
@@ -53,7 +53,7 @@ class _ControlBarState extends State<ControlBar> {
           : Icons.videocam_off_outlined,
       iconColor: _conferenceRoom.videoEnabled
           ? context.theme.colorScheme.onPrimary
-          : context.theme.colorScheme.errorContainer,
+          : context.theme.colorScheme.error,
     );
   }
 
@@ -122,7 +122,7 @@ class _ControlBarState extends State<ControlBar> {
               : Icons.mic_off_outlined,
           iconColor: _conferenceRoom.audioEnabled
               ? context.theme.colorScheme.onPrimary
-              : context.theme.colorScheme.errorContainer,
+              : context.theme.colorScheme.error,
         ),
         _buildMoreOptionsButton(),
         SizedBox(width: spacerWidth),

--- a/client/lib/features/events/features/live_meeting/presentation/views/live_meeting_mobile_page.dart
+++ b/client/lib/features/events/features/live_meeting/presentation/views/live_meeting_mobile_page.dart
@@ -501,7 +501,7 @@ class _LiveMeetingMobilePageState extends State<LiveMeetingMobilePage>
                           width: recordingPulseSize,
                           decoration: BoxDecoration(
                             shape: BoxShape.circle,
-                            color: context.theme.colorScheme.errorContainer,
+                            color: context.theme.colorScheme.error,
                           ),
                         ),
                         SizedBox(width: 8),
@@ -709,7 +709,7 @@ class _LiveMeetingMobilePageState extends State<LiveMeetingMobilePage>
                             : Icons.videocam_off_outlined,
                         color: isVideoOn
                             ? context.theme.colorScheme.onPrimary
-                            : context.theme.colorScheme.errorContainer,
+                            : context.theme.colorScheme.error,
                         size: kIconSize,
                       ),
                       onTap: () async => await alertOnError(
@@ -734,7 +734,7 @@ class _LiveMeetingMobilePageState extends State<LiveMeetingMobilePage>
                         size: kIconSize,
                         color: isMicOn
                             ? context.theme.colorScheme.onPrimary
-                            : context.theme.colorScheme.errorContainer,
+                            : context.theme.colorScheme.error,
                       ),
                     ),
                     SizedBox(width: 10),


### PR DESCRIPTION
<!-- 
FRANKLY PULL REQUEST TEMPLATE
Thank you for contributing to this open-source project - we appreciate you! 🙌

AI Policy: 
- When using AI assistance for contributions, please disclose your usage in the Additional Information section below. 
- To help our human reviewers, please thoroughly review AI-assisted and AI-generated code yourself before submitting.
- Please ensure you fully understand code contributions you submit. 
-->

## What is in this PR?
<!-- What is the goal of this PR? What steps are involved in achieving that goal? -->
As per #505, fixed use of `errorContainer` theme color where appropriate.

## Changes in the codebase
<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

* See above.

## Testing this PR
<!-- Give your reviewer some context or recommendations on how to test your work. -->
- Look in the following parts of the app and note that the error color is now corrected (darker): text fields in error state, A/V buttons when muted, breakout room buttons in admin panel for rooms requesting help, the recording indicator on meetings.