### PR TITLE
Add "last active time" and fix breakout room assignments in registration exports.

### DIFF
--- a/client/lib/features/admin/presentation/widgets/event_data_download_dialog.dart
+++ b/client/lib/features/admin/presentation/widgets/event_data_download_dialog.dart
@@ -134,6 +134,7 @@ class _EventDataDownloadDialogState extends State<EventDataDownloadDialog> {
       await provider.generateRegistrationDataCsvFile(
         eventId: event.id,
         registrationData: members,
+        participantData: participants.toList(),
         breakoutRooms: breakoutRooms,
       );
     } finally {

--- a/client/lib/features/admin/presentation/widgets/event_data_download_dialog.dart
+++ b/client/lib/features/admin/presentation/widgets/event_data_download_dialog.dart
@@ -424,7 +424,7 @@ class _EventDataDownloadDialogState extends State<EventDataDownloadDialog> {
                   ),
                   title: Text(context.l10n.registrationDataDownload),
                   subtitle: Text(
-                    'Times are shown in your local timezone.',
+                    context.l10n.timesShownInLocalTimezone,
                     style: context.theme.textTheme.bodySmall?.copyWith(
                       color: context.theme.colorScheme.onSurfaceVariant,
                     ),

--- a/client/lib/features/admin/presentation/widgets/event_data_download_dialog.dart
+++ b/client/lib/features/admin/presentation/widgets/event_data_download_dialog.dart
@@ -423,6 +423,12 @@ class _EventDataDownloadDialogState extends State<EventDataDownloadDialog> {
                     () => registrantListSelected = value ?? false,
                   ),
                   title: Text(context.l10n.registrationDataDownload),
+                  subtitle: Text(
+                    'Times are shown in your local timezone.',
+                    style: context.theme.textTheme.bodySmall?.copyWith(
+                      color: context.theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
                 ),
               CheckboxListTile(
                 value: chatDataSelected,

--- a/client/lib/features/events/features/event_page/data/providers/event_provider.dart
+++ b/client/lib/features/events/features/event_page/data/providers/event_provider.dart
@@ -375,6 +375,7 @@ class EventProvider with ChangeNotifier {
 
   Future<void> generateRegistrationDataCsvFile({
     required List<MemberDetails> registrationData,
+    required List<Participant> participantData,
     required String eventId,
     required List<BreakoutRoom> breakoutRooms,
   }) async {
@@ -386,6 +387,7 @@ class EventProvider with ChangeNotifier {
     firstRow.add('Email');
     firstRow.add('Member Status');
     firstRow.add('RSVP Time');
+    firstRow.add('Last Active Time');
     firstRow.add('Room Assigned');
     rows.add(firstRow);
 
@@ -409,6 +411,13 @@ class EventProvider with ChangeNotifier {
       );
       row.add(
         registrationData[i].memberEvent?.participant?.createdDate?.toUtc(),
+      final mostRecentPresentTime = participantData
+          .firstWhereOrNull((p) => p.id == registrationData[i].id)
+          ?.mostRecentPresentTime;
+      row.add(
+        mostRecentPresentTime != null
+            ? dateTimeFormat(date: mostRecentPresentTime.toUtc())
+            : '\u200B',
       );
 
       // Added Room Assigned field from Participant.currentBreakoutRoomId

--- a/client/lib/features/events/features/event_page/data/providers/event_provider.dart
+++ b/client/lib/features/events/features/event_page/data/providers/event_provider.dart
@@ -409,14 +409,17 @@ class EventProvider with ChangeNotifier {
       row.add(
         EnumToString.convertToString(registrationData[i].membership?.status),
       );
+      final createdDate =
+          registrationData[i].memberEvent?.participant?.createdDate;
       row.add(
-        registrationData[i].memberEvent?.participant?.createdDate?.toUtc(),
+        createdDate != null ? dateTimeFormat(date: createdDate.toLocal()) : '',
+      );
       final mostRecentPresentTime = participantData
           .firstWhereOrNull((p) => p.id == registrationData[i].id)
           ?.mostRecentPresentTime;
       row.add(
         mostRecentPresentTime != null
-            ? dateTimeFormat(date: mostRecentPresentTime.toUtc())
+            ? dateTimeFormat(date: mostRecentPresentTime.toLocal())
             : '\u200B',
       );
 

--- a/client/lib/features/events/features/event_page/data/providers/event_provider.dart
+++ b/client/lib/features/events/features/event_page/data/providers/event_provider.dart
@@ -420,16 +420,20 @@ class EventProvider with ChangeNotifier {
             : '\u200B',
       );
 
-      // Added Room Assigned field from Participant.currentBreakoutRoomId
-      // Convert room ID to room name for better readability
-      final currentRoomId =
-          registrationData[i].memberEvent?.participant?.currentBreakoutRoomId;
-
-      final roomAssigned = _getRoomName(
-        roomId: currentRoomId ?? '',
-        eventId: eventId,
-        breakoutRooms: breakoutRooms,
+      // Look up the participant's breakout room within the breakout info. We
+      // can't rely on the breakoutRoomId in Participant because it is a live
+      // value that is cleared when users leave the event.
+      final participantId = registrationData[i].id;
+      final assignedRoom = breakoutRooms.firstWhereOrNull(
+        (room) => room.participantIds.contains(participantId),
       );
+      final roomAssigned = assignedRoom != null
+          ? _getRoomName(
+              roomId: assignedRoom.roomId,
+              eventId: eventId,
+              breakoutRooms: breakoutRooms,
+            )
+          : 'Main room';
       row.add(roomAssigned);
 
       final event = registrationData[i].memberEvent;

--- a/client/lib/features/events/features/event_page/data/providers/event_provider.dart
+++ b/client/lib/features/events/features/event_page/data/providers/event_provider.dart
@@ -420,7 +420,7 @@ class EventProvider with ChangeNotifier {
       row.add(
         mostRecentPresentTime != null
             ? dateTimeFormat(date: mostRecentPresentTime.toLocal())
-            : '\u200B',
+            : '',
       );
 
       // Look up the participant's breakout room within the breakout info. We

--- a/client/lib/l10n/app_en.arb
+++ b/client/lib/l10n/app_en.arb
@@ -924,6 +924,7 @@
   "thisEventIsNowBeingRecorded": "This event is now\nbeing recorded.",
   "thisUrlWasNotFound": "This URL was not found.",
   "thisUser": "this user",
+  "timesShownInLocalTimezone": "Times are shown in your local timezone.",
   "titleCannotBeEmpty": "Title cannot be empty",
   "titleIsRequired": "Title is required",
   "tooManyRequests": "Too many failed requests. Please try again later.",

--- a/client/lib/l10n/app_es.arb
+++ b/client/lib/l10n/app_es.arb
@@ -992,6 +992,7 @@
   "thisEventIsNowBeingRecorded": "Este evento ahora está\nsiendo grabado.",
   "thisUrlWasNotFound": "Esta URL no se encontró.",
   "thisUser": "este usuario",
+  "timesShownInLocalTimezone": "Los horarios se muestran en su zona horaria local.",
   "titleCannotBeEmpty": "El título no puede estar vacío",
   "titleIsRequired": "El título es obligatorio",
   "tooManyRequests": "Demasiadas solicitudes fallidas. Por favor, inténtelo de nuevo más tarde.",

--- a/client/lib/l10n/app_zh.arb
+++ b/client/lib/l10n/app_zh.arb
@@ -976,6 +976,7 @@
   "thisEventIsNowBeingRecorded": "此活动现在正在录制中",
   "thisUrlWasNotFound": "未找到此URL。",
   "thisUser": "该用户",
+  "timesShownInLocalTimezone": "时间以您的本地时区显示。",
   "titleCannotBeEmpty": "标题不能为空",
   "titleIsRequired": "标题为必填项",
   "tooManyRequests": "请求失败次数过多。请稍后再试。",

--- a/client/lib/l10n/app_zh_Hant_TW.arb
+++ b/client/lib/l10n/app_zh_Hant_TW.arb
@@ -971,6 +971,7 @@
   "thisEventIsNowBeingRecorded": "此活動現在正在錄製中",
   "thisUrlWasNotFound": "未找到此URL。",
   "thisUser": "此用戶",
+  "timesShownInLocalTimezone": "時間以您的當地時區顯示。",
   "titleCannotBeEmpty": "標題不能為空",
   "titleIsRequired": "標題為必填項",
   "tooManyRequests": "請求失敗次數過多。請稍後再試。",

--- a/firebase/functions/lib/events/on_event_participant.dart
+++ b/firebase/functions/lib/events/on_event_participant.dart
@@ -21,9 +21,6 @@ class OnEventParticipant extends OnFirestoreFunction<Participant> {
             ),
           ],
           (snapshot) {
-            if (!snapshot.exists) {
-              return Participant(id: snapshot.documentID);
-            }
             return Participant.fromJson(
               firestoreUtils.fromFirestoreJson(snapshot.data.toMap()),
             ).copyWith(id: snapshot.documentID);
@@ -34,11 +31,9 @@ class OnEventParticipant extends OnFirestoreFunction<Participant> {
   String get documentPath =>
       'community/{communityId}/templates/{templateId}/events/{eventId}/event-participants/{participantId}';
 
-  // firestoreOnWrite (base class) dispatches to onUpdate for all event
-  // types (create, update, delete). For non-existent snapshots (create has
-  // no before, delete has no after), the parser above returns a stub
-  // Participant with null status, ensuring the status-change guard below
-  // passes through to the recount query.
+  // firestoreOnWrite (base class) dispatches to onUpdate, not onWrite.
+  // onCreate and onDelete are not triggered by the onWrite registration, so
+  // they are intentionally unreachable here.
   @override
   Future<void> onUpdate(
     Change<DocumentSnapshot> changes,

--- a/firebase/functions/lib/events/on_event_participant.dart
+++ b/firebase/functions/lib/events/on_event_participant.dart
@@ -21,6 +21,9 @@ class OnEventParticipant extends OnFirestoreFunction<Participant> {
             ),
           ],
           (snapshot) {
+            if (!snapshot.exists) {
+              return Participant(id: snapshot.documentID);
+            }
             return Participant.fromJson(
               firestoreUtils.fromFirestoreJson(snapshot.data.toMap()),
             ).copyWith(id: snapshot.documentID);
@@ -31,9 +34,11 @@ class OnEventParticipant extends OnFirestoreFunction<Participant> {
   String get documentPath =>
       'community/{communityId}/templates/{templateId}/events/{eventId}/event-participants/{participantId}';
 
-  // firestoreOnWrite (base class) dispatches to onUpdate, not onWrite.
-  // onCreate and onDelete are not triggered by the onWrite registration, so
-  // they are intentionally unreachable here.
+  // firestoreOnWrite (base class) dispatches to onUpdate for all event
+  // types (create, update, delete). For non-existent snapshots (create has
+  // no before, delete has no after), the parser above returns a stub
+  // Participant with null status, ensuring the status-change guard below
+  // passes through to the recount query.
   @override
   Future<void> onUpdate(
     Change<DocumentSnapshot> changes,


### PR DESCRIPTION
<!-- 
FRANKLY PULL REQUEST TEMPLATE
Thank you for contributing to this open-source project - we appreciate you! 🙌

AI Policy: 
- When using AI assistance for contributions, please disclose your usage in the Additional Information section below. 
- To help our human reviewers, please thoroughly review AI-assisted and AI-generated code yourself before submitting.
- Please ensure you fully understand code contributions you submit. 
-->

## What is in this PR?
<!-- What is the goal of this PR? What steps are involved in achieving that goal? -->
Adds a new column to the registration data exports which tells admins, roughly, when the user was last present in an event. This is also a bugfix PR that fixes the "Breakout Room Assigned" column, which was returning "Main Room" for all participants. 

## Changes in the codebase
<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

* Pull breakout room info from the Breakout Room data list instead of from the Participant, where "currentBreakoutRoomId" gets overwritten when users leave the event (by `UpdatePresenceStatus`) 😓 
* Used local instead of UTC timestamps
* Add and export `mostRecentPresentTime` on event participants so admins can also access this data

## Changes outside the codebase
<!-- If you have made changes to external services, need to add additional values to the job settings, or need to add something new to the database, explain it here. This may include updates to third-party services, changes to infrastructure configuration, integration with external APIs, etc. -->

* 

## Testing this PR
<!-- Give your reviewer some context or recommendations on how to test your work. -->
* Choose a hostless event that was used for testing breakout rooms. **Ensure that UpdatePresenceStatus fired on the participants when they left the meeting**, which clears their breakout room info and had caused the previous bug. Using an old event is a more convenient way to do this.
* Download registration data.
* Observe that prior to this PR, the breakout rooms say "Main Room" for all participants. After this PR, there should be different room numbers.
* Observe that Last Active Time is now a new column.

## PR Checklist
<!-- Items to remember to address before submitting. -->
- [ ] Where applicable, I have added localization (l10n) entries to my feature for user-facing text.
- [ ] For new Cloud Functions, I have added the function to `function-mapping.json`. 

## Additional information
<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->

**AI tools used (if applicable)**: 
Copilot assisted in writing this PR and adding localizations.
