### PR TITLE
Speed loading by enabling Flutter service worker for asset caching

### DIFF
--- a/client/web/index.html
+++ b/client/web/index.html
@@ -81,13 +81,13 @@
     <!-- This script installs service_worker.js to provide PWA functionality to
        application. For more information, see:
        https://developers.google.com/web/fundamentals/primers/service-workers -->
-    <!--script>
-    if ('serviceWorker' in navigator) {
-      window.addEventListener('load', function () {
-        navigator.serviceWorker.register('flutter_service_worker.js');
-      });
-    }
-  </script-->
+    <script nonce="__SCRIPT_NONCE__">
+      if ("serviceWorker" in navigator) {
+        window.addEventListener("load", function () {
+          navigator.serviceWorker.register("flutter_service_worker.js");
+        });
+      }
+    </script>
     <!-- The core Firebase JS SDK is always required and must be listed first -->
     <script
       nonce="__SCRIPT_NONCE__"

--- a/client/web/index.html
+++ b/client/web/index.html
@@ -78,7 +78,7 @@
   </head>
 
   <body>
-    <!-- This script installs service_worker.js to provide PWA functionality to
+    <!-- This script installs flutter_service_worker.js to provide PWA functionality to
        application. For more information, see:
        https://developers.google.com/web/fundamentals/primers/service-workers -->
     <script nonce="__SCRIPT_NONCE__">


### PR DESCRIPTION
Solves [#536](https://github.com/berkmancenter/frankly/issues/536)

The service worker registration was commented out, causing every page visit to re-download the entire Flutter bundle from scratch. Re-enabling it allows returning users to load cached assets instantly, significantly improving load time on repeat visits.

## What is in this PR?
This PR should speed up page loads for repeat site visits by a good margin (multiple seconds, depending on the device).

## Changes in the codebase
Just uncomment and add nonce to activate caching.

## Changes outside the codebase
None

## Testing this PR
Should work on the preview branch; Load some pages of the app, once, then re-navigate to them and see if loading is noticeably faster.

## PR Checklist
- [NA] Where applicable, I have added localization (l10n) entries to my feature for user-facing text.
- [NA] For new Cloud Functions, I have added the function to `function-mapping.json`. 

## Additional information
-

**AI tools used (if applicable)**: 
-