### PR TITLE
Whitelisted agora websocket connections and picsum requests

### DIFF
--- a/firebase/functions/js/serve-index.js
+++ b/firebase/functions/js/serve-index.js
@@ -44,7 +44,7 @@ function buildCsp(nonce) {
         `connect-src 'self'` +
             ` https://*.firebaseio.com wss://*.firebaseio.com` +
             ` https://*.googleapis.com https://*.cloudfunctions.net` +
-            ` https://api.agora.io https://*.agora.io` +
+            ` https://api.agora.io https://*.agora.io wss://*.agora.io` +
             ` https://*.twiliocdn.com https://*.twilio.com` +
             ` https://api.mux.com https://stream.mux.com` +
             ` https://res.cloudinary.com https://api.cloudinary.com` +
@@ -52,7 +52,8 @@ function buildCsp(nonce) {
             ` https://api.linkpreview.net https://*.stripe.com` +
             ` https://frankly.org https://fonts.gstatic.com https://www.gstatic.com`,
         `img-src 'self' data: blob:` +
-            ` https://res.cloudinary.com https://*.googleusercontent.com`,
+            ` https://res.cloudinary.com https://*.googleusercontent.com` +
+            ` https://picsum.photos https://fastly.picsum.photos`,
         `media-src 'self' blob: https://res.cloudinary.com https://*.mux.com`,
         `frame-src 'self'` +
             ` https://player.vimeo.com https://*.stripe.com https://*.firebaseapp.com`,


### PR DESCRIPTION
## PR Message

Fix CSP violations blocking Agora WebSocket connections and picsum.photos images.

### What is in this PR?

After merging `mw/sec/domain-and-email-sec` with staging, two CSP gaps were preventing loading:

1. Agora's real-time SDK connects via `wss://` but only `https://*.agora.io` was whitelisted in `connect-src`.
2. Event page placeholder images from `picsum.photos` were blocked because that domain was missing from `img-src`.

### Changes in the codebase

- `firebase/functions/js/serve-index.js`: Add `wss://*.agora.io` to `connect-src`. Add `https://picsum.photos https://fastly.picsum.photos` to `img-src`.

### Changes outside the codebase

N/A

### Testing this PR

1. Join a live meeting and verify no "violates Content Security Policy" console errors for `wss://*.edge.agora.io`.
2. Open an event page with a picsum.photos placeholder image, verify image loads without `(blocked:csp)` errors.

### PR Checklist

- [x] Where applicable, I have added localization (l10n) entries to my feature for user-facing text.
- [x] For new Cloud Functions, I have added the function to `function-mapping.json`.

### Additional information

N/A

**AI tools used (if applicable)**: 

N/A