### PR TITLE
Hide RSVP button for ongoing events, show countdown or enter

### DIFF
--- a/client/lib/features/events/features/event_page/presentation/widgets/event_info.dart
+++ b/client/lib/features/events/features/event_page/presentation/widgets/event_info.dart
@@ -366,6 +366,8 @@ class _EventInfoState extends State<EventInfo> {
     );
   }
 
+  /// Builds the "Enter Event" button with dynamic text based on the event's scheduled time.
+  /// [scheduled] is the scheduled time of the event.
   ActionButton _buildEnterEvent(DateTime scheduled) {
     final kEventOpenText = context.l10n.enterEvent;
     final now = clockService.now();
@@ -394,8 +396,11 @@ class _EventInfoState extends State<EventInfo> {
       key: EventInfo.enterEventButtonKey,
       expand: true,
       onPressed: () async {
-        final successfullyJoined =
-            await widget.onJoinEvent(enterMeeting: isEventOpen || kDebugMode);
+        // Show confirmation dialog if the event is not open yet, otherwise join the event directly
+        final successfullyJoined = await widget.onJoinEvent(
+          enterMeeting: isEventOpen || kDebugMode,
+          showConfirm: !isEventOpen,
+        );
         if (!mounted) return;
         if (!isEventOpen && !successfullyJoined) {
           // If the event is not open yet, we expect user not to be able to join.
@@ -426,17 +431,20 @@ class _EventInfoState extends State<EventInfo> {
     final localEventProvider = _eventProvider;
     final isBanned = localEventProvider.isBanned;
     final canShowFollowCommunity = _canShowFollowCommunity();
+    final eventAlmostStarted = clockService.now().isAfter(
+          startTime.subtract(Duration(minutes: kMinutesBeforeEventToJoin)),
+        );
+    final eventHasStarted = clockService.now().isAfter(startTime);
 
     final showJoinButton = !isBanned &&
         context.read<EventPermissionsProvider>().canJoinEvent &&
         _status != _ParticipantStatus.full;
 
+    // Show the "Enter Event" button if the user already RSVP'd/joined
+    // or if the event is within 15 minutes of starting,
+    // or if the event has already started
     final showEnterEventButton = _isParticipant ||
-        (showJoinButton &&
-            clockService.now().isAfter(
-                  startTime
-                      .subtract(Duration(minutes: kMinutesBeforeEventToJoin)),
-                ));
+        (showJoinButton && eventAlmostStarted || eventHasStarted);
     if (showPrerequisiteWarning) {
       return WarningInfo(
         icon: CircleAvatar(
@@ -625,7 +633,9 @@ class _EventInfoState extends State<EventInfo> {
         return Row(
           children: [
             Tooltip(
-              message: isPublic ? context.l10n.publicVisibility : context.l10n.privateVisibility,
+              message: isPublic
+                  ? context.l10n.publicVisibility
+                  : context.l10n.privateVisibility,
               child: ProxiedImage(null, asset: appAsset, width: 20, height: 20),
             ),
             SizedBox(width: 6),

--- a/client/lib/features/events/features/event_page/presentation/widgets/event_info.dart
+++ b/client/lib/features/events/features/event_page/presentation/widgets/event_info.dart
@@ -431,20 +431,22 @@ class _EventInfoState extends State<EventInfo> {
     final localEventProvider = _eventProvider;
     final isBanned = localEventProvider.isBanned;
     final canShowFollowCommunity = _canShowFollowCommunity();
-    final eventAlmostStarted = clockService.now().isAfter(
-          startTime.subtract(Duration(minutes: kMinutesBeforeEventToJoin)),
-        );
-    final eventHasStarted = clockService.now().isAfter(startTime);
 
     final showJoinButton = !isBanned &&
         context.read<EventPermissionsProvider>().canJoinEvent &&
         _status != _ParticipantStatus.full;
+    final eventAlmostStarted = showJoinButton &&
+        clockService.now().isAfter(
+              startTime.subtract(Duration(minutes: kMinutesBeforeEventToJoin)),
+            );
+    final eventHasStarted =
+        showJoinButton && clockService.now().isAfter(startTime);
 
     // Show the "Enter Event" button if the user already RSVP'd/joined
     // or if the event is within 15 minutes of starting,
     // or if the event has already started
-    final showEnterEventButton = _isParticipant ||
-        (showJoinButton && eventAlmostStarted || eventHasStarted);
+    final showEnterEventButton =
+        _isParticipant || (eventAlmostStarted || eventHasStarted);
     if (showPrerequisiteWarning) {
       return WarningInfo(
         icon: CircleAvatar(


### PR DESCRIPTION

<!-- 
FRANKLY PULL REQUEST TEMPLATE
Thank you for contributing to this open-source project - we appreciate you! 🙌

AI Policy: 
- When using AI assistance for contributions, please disclose your usage in the Additional Information section below. 
- To help our human reviewers, please thoroughly review AI-assisted and AI-generated code yourself before submitting.
- Please ensure you fully understand code contributions you submit. 
-->

## What is in this PR?
This change adjusts the conditions for when the "Enter Event" button is shown, and resolved an issue where the "RSVP" button and confirmation dialog would appear for ongoing events.

## Changes in the codebase
<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->
* The logic for displaying the "Enter Event" button now allows users to see the button if they have already RSVP'd/joined, if the event is within 15 minutes of starting, or if the event has already started.
* The event join handler (`onJoinEvent`) now receives an additional `showConfirm` parameter, which triggers a confirmation dialog if the event is not open yet. 
* Added descriptive comments to clarify the purpose and logic of the "Enter Event" button and related conditions.

## Testing this PR
<!-- Give your reviewer some context or recommendations on how to test your work. -->

- [ ] Create an event scheduled for a future date and time.
- [ ] On the event information page, note that the RSVP button appears. Clicking on it pops a confirmation dialogue confirming the user will be there when the event time arrives. This is the expected legacy behavior.
- [ ] The button now changes to an event countdown.
- [ ] Create another event for a minute or two in the future. Wait until the scheduled time arrives.
- [ ] Open the event information page, and notice that the RSVP button does not appear, as it did incorrectly prior to this change. Instead, "Enter Event" button shows.
- [ ] Clicking the button enters the user into the event immediately, unless the event is being recorded in which case they must confirm the consent dialog.

## PR Checklist
<!-- Items to remember to address before submitting. -->
- [ ] Where applicable, I have added localization (l10n) entries to my feature for user-facing text.
- [ ] For new Cloud Functions, I have added the function to `function-mapping.json`. 