### PR TITLE
fix: scale down agenda item timer instead of wrapping text

### DIFF
--- a/client/lib/features/events/features/live_meeting/features/meeting_guide/presentation/views/meeting_guide_card.dart
+++ b/client/lib/features/events/features/live_meeting/features/meeting_guide/presentation/views/meeting_guide_card.dart
@@ -5,6 +5,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:client/features/events/features/event_page/data/providers/event_provider.dart';
 import 'package:client/features/events/features/live_meeting/presentation/views/leave_regular_dialog.dart';
 import 'package:client/features/events/features/live_meeting/data/providers/live_meeting_provider.dart';
+import 'package:client/features/events/features/live_meeting/features/meeting_guide/presentation/widgets/agenda_item_timer.dart';
 import 'package:client/features/events/features/live_meeting/features/meeting_guide/presentation/widgets/meeting_guide_card_item_image.dart';
 import 'package:client/features/events/features/live_meeting/features/meeting_guide/presentation/views/meeting_guide_card_item_poll.dart';
 import 'package:client/features/events/features/live_meeting/features/meeting_guide/presentation/widgets/meeting_guide_card_item_text.dart';
@@ -220,33 +221,25 @@ class _MeetingGuideCardContentState extends State<MeetingGuideCardContent>
               ),
             ),
             if (agendaItem.timeInSeconds != null)
-              Container(
-                width: 120,
-                alignment: Alignment.centerRight,
-                child: PeriodicBuilder(
-                  period: const Duration(seconds: 1),
-                  builder: (context) {
-                    final timeRemaining = _presenter.getTimeRemainingInCard();
-                    final bool negativeTimeRemaining;
-                    final String formattedTime;
-                    if (timeRemaining == null) {
-                      negativeTimeRemaining = false;
-                      formattedTime = context.l10n.start;
-                    } else {
-                      negativeTimeRemaining = timeRemaining.isNegative;
-                      formattedTime =
-                          timeRemaining.getFormattedTime(showHours: timeRemaining.inHours.abs() > 0);
-                    }
-                    return HeightConstrainedText(
-                      formattedTime,
-                      style: AppTextStyle.body.copyWith(
-                        color: negativeTimeRemaining
-                            ? context.theme.colorScheme.error
-                            : context.theme.colorScheme.onSurface,
-                      ),
-                    );
-                  },
-                ),
+              PeriodicBuilder(
+                period: const Duration(seconds: 1),
+                builder: (context) {
+                  final timeRemaining = _presenter.getTimeRemainingInCard();
+                  final bool negativeTimeRemaining;
+                  final String formattedTime;
+                  if (timeRemaining == null) {
+                    negativeTimeRemaining = false;
+                    formattedTime = context.l10n.start;
+                  } else {
+                    negativeTimeRemaining = timeRemaining.isNegative;
+                    formattedTime =
+                        timeRemaining.getFormattedTime(showHours: timeRemaining.inHours.abs() > 0);
+                  }
+                  return AgendaItemTimer(
+                    formattedTime: formattedTime,
+                    negative: negativeTimeRemaining,
+                  );
+                },
               ),
             SizedBox(width: 10),
             ProxiedImage(null, asset: AppAsset.clock(), width: 20, height: 20),

--- a/client/lib/features/events/features/live_meeting/features/meeting_guide/presentation/widgets/agenda_item_timer.dart
+++ b/client/lib/features/events/features/live_meeting/features/meeting_guide/presentation/widgets/agenda_item_timer.dart
@@ -1,0 +1,38 @@
+import 'package:client/core/widgets/height_constained_text.dart';
+import 'package:client/styles/styles.dart';
+import 'package:flutter/material.dart';
+
+/// Displays the time remaining for an agenda item in a fixed-width cell.
+///
+/// Scales the text down rather than wrapping so the timer always renders on a
+/// single line, regardless of the formatted time's length or the user's text
+/// scale. See https://github.com/berkmancenter/frankly/issues/477.
+class AgendaItemTimer extends StatelessWidget {
+  final String formattedTime;
+  final bool negative;
+
+  const AgendaItemTimer({
+    required this.formattedTime,
+    this.negative = false,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 120,
+      alignment: Alignment.centerRight,
+      child: FittedBox(
+        fit: BoxFit.scaleDown,
+        child: HeightConstrainedText(
+          formattedTime,
+          style: AppTextStyle.body.copyWith(
+            color: negative
+                ? Theme.of(context).colorScheme.error
+                : Theme.of(context).colorScheme.onSurface,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/client/test/lib/features/events/features/live_meeting/features/meeting_guide/agenda_timer_wrap_test.dart
+++ b/client/test/lib/features/events/features/live_meeting/features/meeting_guide/agenda_timer_wrap_test.dart
@@ -1,0 +1,49 @@
+import 'package:client/features/events/features/live_meeting/features/meeting_guide/presentation/widgets/agenda_item_timer.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Regression test for https://github.com/berkmancenter/frankly/issues/477
+///
+/// The agenda item timer renders inside a fixed-width cell. Long formatted
+/// times (e.g. negative values with hours) or larger user text scales must
+/// scale the text down instead of wrapping onto a second line.
+void main() {
+  Widget harness({required String time, required double textScale}) {
+    return MaterialApp(
+      builder: (context, child) => MediaQuery(
+        data: MediaQuery.of(context).copyWith(textScaler: TextScaler.linear(textScale)),
+        child: child!,
+      ),
+      home: Scaffold(
+        body: Center(
+          child: AgendaItemTimer(formattedTime: time, negative: true),
+        ),
+      ),
+    );
+  }
+
+  Future<double> oneLineHeight(WidgetTester tester, double textScale) async {
+    // A time short enough that it never needs to shrink or wrap; its height is
+    // the natural single-line height at this text scale.
+    await tester.pumpWidget(harness(time: '5:03', textScale: textScale));
+    return tester.getSize(find.text('5:03')).height;
+  }
+
+  testWidgets('long negative timer stays on one line at normal text scale', (tester) async {
+    const time = '-1:05:30';
+    final oneLine = await oneLineHeight(tester, 1.0);
+    await tester.pumpWidget(harness(time: time, textScale: 1.0));
+    final size = tester.getSize(find.text(time));
+    expect(size.height, lessThanOrEqualTo(oneLine + 0.1),
+        reason: 'Timer text should scale down, not wrap to a second line');
+  });
+
+  testWidgets('short negative timer stays on one line at 2x text scale', (tester) async {
+    const time = '-0:24';
+    final oneLine = await oneLineHeight(tester, 2.0);
+    await tester.pumpWidget(harness(time: time, textScale: 2.0));
+    final size = tester.getSize(find.text(time));
+    expect(size.height, lessThanOrEqualTo(oneLine + 0.1),
+        reason: 'Timer text should scale down, not wrap to a second line');
+  });
+}


### PR DESCRIPTION
Fixes #477.

## Summary

- extract the agenda item timer into an `AgendaItemTimer` widget that wraps the text in `FittedBox(fit: BoxFit.scaleDown)`, so long times (negative, with hours) and larger user text scales shrink to fit the fixed-width cell instead of wrapping onto a second line, mirroring the approach already used by the post-video timer in `meeting_guide_card_item_video.dart`
- add regression tests covering a long negative time at normal text scale and a short negative time at 2x text scale

## Testing

- `flutter test test/lib/features/events/features/live_meeting/features/meeting_guide/agenda_timer_wrap_test.dart` — 2 tests pass (both fail against the previous inline implementation)
- `flutter analyze` on the touched directory: no new issues (10 pre-existing on staging)